### PR TITLE
feat(#1): shell scaffolding (entry, bootstrap, inject, registry)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+workspace/*
+!workspace/.gitkeep
+!workspace/README.md
+.claude/audit/
+.claude/state/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# claude-eng-shell
+
+An operating shell for [Claude Code](https://docs.claude.com/claude-code) that runs on top of the standard GitHub workflow. See [SPEC.md](SPEC.md) for the full specification — start from the **Table of contents** at the top of that file and `Read --offset --limit` into the section you care about rather than loading all ~1,300 lines.
+
+## Core ideas
+
+- **GitHub-standard backbone** — every change rides issue → branch → draft PR → checklist commits → ready PR → merge. Default base is `main`; topic-branch / experimental work picks an alternate via `/work-on --base <branch>` (SPEC §10.5).
+- **Doc → Test → Code work order** — strict for `feat`/`docs`/contract changes; relaxed for `fix`/`refactor`/`perf` per SPEC §1.2.
+- **Active SSOT maintenance** — docs change alongside code; merged PR bodies are durable cross-session memory via SessionStart.
+- **Eight subagents** — `explorer`, `planner`, `doc-writer`, `test-writer`, `code-reviewer`, `security-reviewer`, `issue-reviewer`, `plan-reviewer`. The four reviewers (`code-`, `security-`, `issue-`, `plan-`) substitute for human-confirm checkpoints in `unattended` mode.
+- **Hooks enforce discipline** — protected branches, force push, backmerges (`git merge main` on a feature branch), secret exposure, malformed commits, sensitive files, paths outside the registry. Every block is escapable via `SKIP_HOOKS=<category> SKIP_REASON='<why>'` and audit-logged at `.claude/audit/audit.jsonl`.
+
+## Install
+
+```bash
+git clone <this-repo-url> claude-eng-shell
+cd claude-eng-shell
+./scripts/bootstrap.sh
+```
+
+`bootstrap.sh` only checks dependencies — `git`, `gh`, `jq` are required; `python3` is recommended (used by several helpers; missing python falls back to less-precise behavior). It never modifies `~/.zshrc` or any other user-global file. Add the binary to PATH or alias it yourself:
+
+```bash
+export PATH="$PWD/bin:$PATH"
+# or
+alias claude-eng="$PWD/bin/claude-eng"
+```
+
+## Quick start
+
+```bash
+# Clone a target repo into the shell's workspace/.
+./scripts/clone-into.sh https://github.com/<owner>/<repo>.git
+cd workspace/<repo>
+claude-eng
+
+# Inside the session:
+> /onboard
+> /file-issue <description>
+> /work-on <issue#>                          # default: branches from main
+> /work-on <issue#> --base experiment/foo    # topic-branch flow (SPEC §10.5)
+> /ship
+```
+
+External paths register too:
+
+```bash
+./scripts/register.sh ~/code/<repo>
+# or: claude-eng ~/code/<repo>   ← unregistered path prompts to register
+```
+
+## Operating modes
+
+| Mode | `/ship` terminal behavior | Use |
+|---|---|---|
+| `attended` (default) | stops at PR-ready | human reviews + merges |
+| `unattended` | continues to merge (clean) or park (hard blocker) | overnight runs, batched fixes |
+
+Set per-target with `echo unattended > .claude/state/mode`. Override per-invocation with `/ship --mode=unattended`. See SPEC §5.7.1 for the full resolution priority and blocker classification.
+
+## Configuration toggles
+
+All optional. Per-target state files live under `.claude/state/` (gitignored); env vars take priority when set.
+
+| Knob | File | Env | Default | Purpose |
+|---|---|---|---|---|
+| Operating mode | `mode` | `CLAUDE_ENG_SHELL_MODE` | `attended` | `/ship` terminal behavior (§5.7.1) |
+| Co-Authored-By trailer | `coauthor` | `CLAUDE_ENG_COAUTHOR` | `on` | Include the trailer in `/work-on` commits (§10.2) |
+| Status cache TTL | — | `STATUS_CACHE_TTL` | `5` | Seconds before re-querying `gh` from `_status_collect` (§5.5) |
+| Session-start fetch TTL | — | `SESSION_START_FETCH_TTL` | `21600` | Seconds before the shell-behind `git fetch` runs again (§6.5) |
+| Commit-time lint timeout | — | `CLAUDE_ENG_LINT_TIMEOUT` | `30` | Bound on the commit gate's lint (§6.1) |
+
+## Docs
+
+- [SPEC.md](SPEC.md) — the single self-contained specification (SSOT). Start from the TOC at the top.
+- [docs/ENGINEERING_FLOW.md](docs/ENGINEERING_FLOW.md) — step-by-step engineering flow.
+- [docs/SUBAGENTS.md](docs/SUBAGENTS.md) — subagent usage guide.
+- [docs/ESCAPE_HATCH.md](docs/ESCAPE_HATCH.md) — bypassing hooks safely.
+- [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) — common blocks and fixes.
+
+## Verify
+
+```bash
+./scripts/test/smoke.sh           # ~190 assertions across hooks, helpers, slash commands
+./scripts/build_toc.sh --check    # SPEC.md TOC freshness
+```

--- a/bin/claude-eng
+++ b/bin/claude-eng
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CLAUDE_ENG_SHELL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+# If the first arg is a directory, check if it's registered; offer to register if not.
+if [ $# -gt 0 ] && [ -d "$1" ]; then
+  target_path=$(cd "$1" && pwd -P)
+  registry="$CLAUDE_ENG_SHELL_ROOT/.claude/state/registry.txt"
+  registered=0
+  if [ -f "$registry" ]; then
+    while IFS= read -r entry; do
+      [ -z "$entry" ] && continue
+      case "$target_path/" in
+        "$entry"/*) registered=1; break ;;
+      esac
+      [ "$target_path" = "$entry" ] && { registered=1; break; }
+    done < "$registry"
+  fi
+  if [ "$registered" = 0 ]; then
+    printf "? '%s' is not registered. Register as workspace/%s and enter? [Y/n] " \
+      "$target_path" "$(basename "$target_path")"
+    read -r resp || resp="Y"
+    case "${resp:-Y}" in
+      [Yy]|"")
+        "$CLAUDE_ENG_SHELL_ROOT/scripts/register.sh" "$target_path"
+        ;;
+      *)
+        echo "Cancelled."
+        exit 0
+        ;;
+    esac
+  fi
+  cd "$target_path"
+  shift
+fi
+
+exec claude "$@"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks the shell environment only — never modifies user-global files (~/.zshrc, ~/.claude, etc.).
+
+SHELL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+export CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT"
+
+ok() { printf '✓ %s\n' "$1"; }
+warn() { printf '⚠ %s\n' "$1" >&2; }
+info() { printf 'ℹ %s\n' "$1"; }
+fail() { printf '✗ %s\n' "$1" >&2; FAILED=1; }
+
+FAILED=0
+
+# Required dependencies
+for tool in git gh jq; do
+  if command -v "$tool" >/dev/null 2>&1; then ok "$tool installed"; else fail "$tool missing"; fi
+done
+
+# Recommended dependencies
+for tool in python3; do
+  if command -v "$tool" >/dev/null 2>&1; then ok "$tool installed"; else warn "$tool missing (recommended for commit subject codepoint measurement)"; fi
+done
+
+# gh auth
+if command -v gh >/dev/null 2>&1; then
+  if gh auth status >/dev/null 2>&1; then ok "gh authenticated"; else fail "gh auth required. Run \`gh auth login\`."; fi
+fi
+
+# Shell directory structure
+for d in .claude/agents .claude/commands .claude/hooks .claude/templates bin scripts workspace; do
+  [ -d "$SHELL_ROOT/$d" ] && ok "$d/ exists" || fail "$d/ missing"
+done
+
+# Create runtime dirs (.claude/audit, .claude/state)
+mkdir -p "$SHELL_ROOT/.claude/audit" "$SHELL_ROOT/.claude/state"
+ok ".claude/audit/, .claude/state/ ready"
+
+# Self-register: ensure the shell repo is in its own registry so its hooks
+# fire when working on the shell itself (SPEC §3.6). Idempotent.
+. "$SHELL_ROOT/scripts/lib/self_register.sh"
+if msg=$(ensure_self_registered "$SHELL_ROOT" 2>&1); then
+  ok "$msg"
+else
+  fail "self-register failed: $msg"
+fi
+
+# Install guidance (no auto-install).
+# Shell aliases live in the user's interactive rc and are invisible to this
+# subprocess, so we don't try to detect "is claude-eng accessible" — that check
+# only sees PATH and would false-alarm on the alias path (#4). Always surface
+# both options as info; the user picks one and edits their own rc.
+ok "claude-eng wrapper: $SHELL_ROOT/bin/claude-eng"
+info "to invoke as 'claude-eng', pick one (your rc, not ours):"
+info "    - add $SHELL_ROOT/bin to PATH (visible to subprocesses)"
+info "    - or: alias claude-eng=$SHELL_ROOT/bin/claude-eng (per-shell; bootstrap can't see it)"
+
+if [ "${FAILED:-0}" = 1 ]; then
+  echo
+  echo "bootstrap: one or more checks failed." >&2
+  exit 1
+fi
+echo "bootstrap complete."

--- a/scripts/clone-into.sh
+++ b/scripts/clone-into.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() { echo "usage: clone-into.sh <upstream-repo-url>" >&2; exit 2; }
+[ $# -ge 1 ] || usage
+
+URL="$1"
+SHELL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+export CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT"
+
+. "$SHELL_ROOT/scripts/lib/inject.sh"
+
+NAME=$(basename "$URL" .git)
+TARGET="$SHELL_ROOT/workspace/$NAME"
+
+if [ -e "$TARGET" ]; then
+  echo "already exists: $TARGET" >&2
+  exit 1
+fi
+
+git clone "$URL" "$TARGET"
+inject_into "$TARGET"
+
+# Fork detection
+if command -v gh >/dev/null 2>&1; then
+  if (cd "$TARGET" && gh repo view --json isFork --jq .isFork 2>/dev/null | grep -q true); then
+    echo "WARN: this repo is a fork. claude-eng-shell is upstream-only." >&2
+  fi
+fi
+
+echo "next: cd $TARGET && claude-eng"

--- a/scripts/lib/inject.sh
+++ b/scripts/lib/inject.sh
@@ -1,0 +1,54 @@
+# scripts/lib/inject.sh — shared inject logic for clone-into / register.
+# Source and call inject_into "$TARGET".
+
+inject_into() {
+  local target="$1"
+  : "${CLAUDE_ENG_SHELL_ROOT:?CLAUDE_ENG_SHELL_ROOT must be set}"
+  [ -d "$target" ] || { echo "target directory not found: $target" >&2; return 1; }
+  target=$(cd "$target" && pwd -P)
+
+  mkdir -p "$target/.claude/agents" "$target/.claude/commands"
+
+  # settings.local.json — Claude Code's this-clone-only slot
+  if [ -e "$target/.claude/settings.local.json" ] && [ ! -L "$target/.claude/settings.local.json" ]; then
+    echo "WARN: $target/.claude/settings.local.json exists (real file). Shell settings not injected." >&2
+  else
+    ln -sfn "$CLAUDE_ENG_SHELL_ROOT/.claude/settings.json" "$target/.claude/settings.local.json"
+  fi
+
+  # agents / commands — skip with warning if a same-named asset already exists
+  local kind src dest
+  for kind in agents commands; do
+    if [ -d "$CLAUDE_ENG_SHELL_ROOT/.claude/$kind" ]; then
+      for src in "$CLAUDE_ENG_SHELL_ROOT/.claude/$kind"/*.md; do
+        [ -e "$src" ] || continue
+        dest="$target/.claude/$kind/$(basename "$src")"
+        if [ -e "$dest" ] && [ ! -L "$dest" ]; then
+          echo "WARN: $dest exists. Shell asset injection skipped." >&2
+        else
+          ln -sfn "$src" "$dest"
+        fi
+      done
+    fi
+  done
+
+  # Hide the shell injection from the target's git via .git/info/exclude
+  if [ -d "$target/.git" ]; then
+    local excl="$target/.git/info/exclude"
+    mkdir -p "$(dirname "$excl")"
+    touch "$excl"
+    if ! grep -qxF '.claude/settings.local.json' "$excl"; then
+      printf '\n# claude-eng-shell injection\n.claude/settings.local.json\n' >> "$excl"
+    fi
+  fi
+
+  # Record in registry
+  local registry="$CLAUDE_ENG_SHELL_ROOT/.claude/state/registry.txt"
+  mkdir -p "$(dirname "$registry")"
+  touch "$registry"
+  if ! grep -qxF "$target" "$registry"; then
+    printf '%s\n' "$target" >> "$registry"
+  fi
+
+  echo "OK: shell assets injected into $target"
+}

--- a/scripts/lib/self_register.sh
+++ b/scripts/lib/self_register.sh
@@ -1,0 +1,20 @@
+# scripts/lib/self_register.sh — ensure the shell repo itself is in the registry.
+# Source and call ensure_self_registered "$SHELL_ROOT". Idempotent.
+# See SPEC.md §3.6 for the rationale.
+
+ensure_self_registered() {
+  local shell_root="$1"
+  [ -n "$shell_root" ] || { echo "ensure_self_registered: shell_root argument required" >&2; return 1; }
+  [ -d "$shell_root" ] || { echo "ensure_self_registered: not a directory: $shell_root" >&2; return 1; }
+  shell_root=$(cd "$shell_root" && pwd -P)
+
+  local registry="$shell_root/.claude/state/registry.txt"
+  mkdir -p "$(dirname "$registry")"
+  touch "$registry"
+  if ! grep -qxF "$shell_root" "$registry"; then
+    printf '%s\n' "$shell_root" >> "$registry"
+    echo "self-register: added $shell_root"
+  else
+    echo "self-register: already present ($shell_root)"
+  fi
+}

--- a/scripts/register.sh
+++ b/scripts/register.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() { echo "usage: register.sh <abs-path>" >&2; exit 2; }
+[ $# -ge 1 ] || usage
+
+TARGET="$1"
+[ -d "$TARGET" ] || { echo "directory not found: $TARGET" >&2; exit 1; }
+TARGET=$(cd "$TARGET" && pwd -P)
+
+SHELL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+export CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT"
+
+. "$SHELL_ROOT/scripts/lib/inject.sh"
+
+# Shell self-registration: target == SHELL_ROOT is a no-op for workspace symlinks
+# and inject_into (the shell IS the inject source; a workspace/<basename> symlink
+# would loop into workspace/ contained within SHELL_ROOT). See SPEC §3.6.
+if [ "$TARGET" = "$SHELL_ROOT" ]; then
+  . "$SHELL_ROOT/scripts/lib/self_register.sh"
+  ensure_self_registered "$SHELL_ROOT"
+  exit 0
+fi
+
+# If not already inside workspace/, also create a symlink for convenience.
+if [[ "$TARGET" != "$SHELL_ROOT/workspace/"* ]]; then
+  LINK="$SHELL_ROOT/workspace/$(basename "$TARGET")"
+  if [ -e "$LINK" ] && [ ! -L "$LINK" ]; then
+    echo "WARN: $LINK exists (real file). Symlink not created." >&2
+  else
+    ln -sfn "$TARGET" "$LINK"
+  fi
+fi
+
+inject_into "$TARGET"

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,0 +1,8 @@
+# workspace/
+
+Where target repos live — either as direct clones or symlinks to external paths.
+
+- `scripts/clone-into.sh <upstream-url>` — clone directly into `workspace/<repo>/`.
+- `scripts/register.sh <abs-path>` — register an external path and create a `workspace/<basename>` symlink.
+
+Contents of this directory are not git-tracked (the `.gitignore` whitelist only keeps `.gitkeep` and this README).


### PR DESCRIPTION
Closes #1

## Goal
Add the shell's foundational layer: entry-point wrapper, bootstrap dependency check + self-register, target-injection mechanism, registry tracking, workspace layout, and project README.

## How this serves the mission
Implements SPEC §16 build steps 1–2 and 10–11 (`.gitignore`, entry point, scripts). Establishes `CLAUDE_ENG_SHELL_ROOT` and the registry that every downstream PR depends on.

## Plan
Bootstrap PR per SPEC §16.15. Doc → Test → Code is relaxed: SPEC.md (already merged at 91bd47e) is the doc; smoke ships in PR #6. This PR adds the implementation files exactly as specified in SPEC §3.2 / §3.4 / §3.5 / §3.6.

## Alternatives considered
- **Single mega-PR with all files**: rejected — reviewability and commit-graph clarity. SPEC §16 itself prescribes an incremental build order.
- **Splitting scaffolding into entry-point vs scripts vs README**: rejected — those files form one boot-time unit; no meaningful review gain.

## Key context
- `bin/claude-eng` — SPEC §3.5
- `scripts/lib/inject.sh` — SPEC §3.2
- `scripts/lib/self_register.sh` — SPEC §3.6
- `.gitignore` — SPEC §16 step 1

## Checklist
- [x] Add scaffolding files
- [x] Push branch + open draft PR
- [x] Ready for merge
- [x] Merge

## Out of scope
Hook system (#2), templates (#3), agents (#4), commands + docs (#5), CI + smoke (#6).

## Risks
None — bootstrap exception per SPEC §16.15. Files are already verified against SPEC by the smoke test landing in #6.

## Test plan
- [~] N/A — smoke test ships in #6.

## Docs touched
- [~] N/A — SPEC.md (the SSOT) merged at 91bd47e; README.md ships in this PR.

## Ship gate
- [x] PR body curated
- [~] tests / code-review / security / docs / CI — N/A under SPEC §16.15 bootstrap exception
