### PR TITLE
feat(#3): hook system (settings, 5 hooks, 14 helpers)

### DIFF
--- a/.claude/hooks/helpers/branch_guard.sh
+++ b/.claude/hooks/helpers/branch_guard.sh
@@ -1,0 +1,76 @@
+# helpers/branch_guard.sh — protected-branch checks. Source from hooks.
+
+# Returns the current branch name, or the empty string if HEAD is detached.
+# Callers that need a human-readable label (including detached-HEAD context)
+# should use branch_label instead.
+current_branch() {
+  git symbolic-ref --short HEAD 2>/dev/null || echo ""
+}
+
+# Resolve the SHA of a protected ref, or empty if it doesn't exist.
+_resolve_protected_ref() {
+  git rev-parse --verify --quiet "refs/heads/$1" 2>/dev/null
+}
+
+# Human-readable branch label suitable for hook error messages.
+# - Attached: the branch name.
+# - Detached on a protected tip: `HEAD@<short> (detached, == <ref>)`.
+# - Detached elsewhere: `HEAD@<short> (detached)`.
+# - No HEAD (empty repo): empty string.
+branch_label() {
+  local b
+  b=$(current_branch)
+  if [ -n "$b" ]; then
+    printf '%s' "$b"
+    return
+  fi
+  local head_sha short tip
+  head_sha=$(git rev-parse --verify --quiet HEAD 2>/dev/null) || { printf ''; return; }
+  short=$(git rev-parse --short HEAD 2>/dev/null) || short="${head_sha:0:7}"
+  local ref
+  for ref in main master; do
+    tip=$(_resolve_protected_ref "$ref") || continue
+    if [ -n "$tip" ] && [ "$tip" = "$head_sha" ]; then
+      printf 'HEAD@%s (detached, == %s)' "$short" "$ref"
+      return
+    fi
+  done
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    tip="${line%% *}"
+    ref="${line#* }"
+    if [ "$tip" = "$head_sha" ]; then
+      printf 'HEAD@%s (detached, == %s)' "$short" "$ref"
+      return
+    fi
+  done < <(git for-each-ref --format='%(objectname) %(refname:short)' 'refs/heads/release/*' 2>/dev/null)
+  printf 'HEAD@%s (detached)' "$short"
+}
+
+# Returns 0 (true) when:
+# - the named branch is in the protected set, OR
+# - HEAD is detached and its SHA equals the tip of any protected branch.
+# The detached-tip check covers `git checkout <main-sha>` mistakes that
+# the symbolic-ref-only matcher silently allowed.
+is_protected_branch() {
+  local b="${1:-$(current_branch)}"
+  case "$b" in
+    main|master|release/*) return 0 ;;
+  esac
+  # Detached HEAD (no symbolic ref): compare HEAD's SHA against the tip
+  # SHA of each protected branch. main/master are constant names; release/*
+  # is enumerated via for-each-ref so any branch under that prefix counts.
+  if [ -z "$b" ]; then
+    local head_sha tip
+    head_sha=$(git rev-parse --verify --quiet HEAD 2>/dev/null) || return 1
+    for ref in main master; do
+      tip=$(_resolve_protected_ref "$ref") || continue
+      [ -n "$tip" ] && [ "$tip" = "$head_sha" ] && return 0
+    done
+    # Enumerate release/* tips.
+    while IFS= read -r tip; do
+      [ -n "$tip" ] && [ "$tip" = "$head_sha" ] && return 0
+    done < <(git for-each-ref --format='%(objectname)' 'refs/heads/release/*' 2>/dev/null)
+  fi
+  return 1
+}

--- a/.claude/hooks/helpers/coauthor.sh
+++ b/.claude/hooks/helpers/coauthor.sh
@@ -1,0 +1,41 @@
+# helpers/coauthor.sh — Co-Authored-By trailer toggle. Source from
+# /work-on (or any commit-flow consumer).
+#
+# Public:
+#   coauthor_trailer — prints the trailer line + newline when enabled,
+#                      empty when disabled. Honors (high → low):
+#                        1. $CLAUDE_ENG_COAUTHOR env (`on` / `off`)
+#                        2. .claude/state/coauthor per-target file
+#                        3. default `on`
+#
+# Unknown values fail-safe to `on` with a one-line stderr warning that
+# names the source — mirrors SPEC §5.7.1's resolve_mode pattern. See
+# SPEC §10.2 "Co-Authored-By trailer toggle".
+
+_coauthor_resolve() {
+  local source value
+  if [ -n "${CLAUDE_ENG_COAUTHOR:-}" ]; then
+    source="\$CLAUDE_ENG_COAUTHOR"
+    value="$CLAUDE_ENG_COAUTHOR"
+  elif [ -f "${CLAUDE_ENG_SHELL_ROOT:-}/.claude/state/coauthor" ]; then
+    source=".claude/state/coauthor"
+    value=$(tr -d '[:space:]' < "$CLAUDE_ENG_SHELL_ROOT/.claude/state/coauthor")
+  else
+    printf '%s' "on"
+    return
+  fi
+  case "$value" in
+    on|off) printf '%s' "$value" ;;
+    *)
+      printf 'coauthor: unknown value %q in %s — falling back to "on"\n' "$value" "$source" >&2
+      printf '%s' "on"
+      ;;
+  esac
+}
+
+coauthor_trailer() {
+  case "$(_coauthor_resolve)" in
+    off) return 0 ;;
+    *)   printf 'Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>\n' ;;
+  esac
+}

--- a/.claude/hooks/helpers/conventional_commit.sh
+++ b/.claude/hooks/helpers/conventional_commit.sh
@@ -1,0 +1,86 @@
+# helpers/conventional_commit.sh — commit subject check. Source from hooks.
+# check_commit_subject <subject> → 0 ok, 1 bad (reason on stderr).
+# extract_commit_subject <raw_cmd> <normalized_cmd> → echoes subject (or empty).
+
+# Extract the commit subject from a `git commit` command. Supports two -m forms:
+#   1. plain quoted:        -m "subj"  /  -m 'subj'
+#   2. heredoc body:        -m "$(cat <<TAG ... TAG)"   (TAG may be 'EOF' / EOF / -EOF)
+# Heredoc handling walks the RAW (pre-whitespace-normalization) command to find
+# the first non-blank, non-closing-tag line of the heredoc body. Plain form
+# falls back to the existing single-line sed against the normalized command.
+extract_commit_subject() {
+  local raw="$1" norm="$2"
+  local subj=""
+  # Heredoc form: detect `<<TAG` or `<<'TAG'` or `<<-TAG`. Extract the tag
+  # name, then return the first body line that is neither blank nor the
+  # closing tag. Strip leading whitespace from the returned line (so `<<-`
+  # indent-stripped heredocs work too).
+  if printf '%s' "$raw" | grep -qE "<<-?[[:space:]]*'?[A-Za-z_][A-Za-z_0-9]*'?"; then
+    subj=$(printf '%s\n' "$raw" | awk '
+      BEGIN { seen = 0; tag = "" }
+      !seen {
+        # Look for the heredoc opener on this line; extract the tag name.
+        if (match($0, /<<-?[[:space:]]*'\''?[A-Za-z_][A-Za-z_0-9]*'\''?/)) {
+          opener = substr($0, RSTART, RLENGTH)
+          # strip `<<` and optional `-`
+          sub(/^<<-?[[:space:]]*/, "", opener)
+          # strip surrounding single quotes if present
+          gsub(/'\''/, "", opener)
+          tag = opener
+          seen = 1
+        }
+        next
+      }
+      seen {
+        # Closing tag line: tag possibly preceded/followed by whitespace.
+        if (tag != "" && $0 ~ "^[[:space:]]*" tag "[[:space:]]*$") { exit }
+        # Skip blank lines.
+        if ($0 ~ /^[[:space:]]*$/) next
+        # Strip leading whitespace and emit the first non-blank body line.
+        sub(/^[[:space:]]+/, "", $0)
+        print
+        exit
+      }
+    ')
+  fi
+  if [ -n "$subj" ]; then
+    printf '%s\n' "$subj"
+    return 0
+  fi
+  # Plain quoted form. Run the existing single-line sed against the
+  # normalized command. Double-quoted `-m "..."` first, then single-quoted.
+  subj=$(printf '%s' "$norm" | sed -nE 's/.*-m[[:space:]]+"([^"]*)".*/\1/p; s/.*-m[[:space:]]+'\''([^'\'']*)'\''.*/\1/p' | head -n1)
+  if [ -n "$subj" ]; then
+    printf '%s\n' "$subj"
+    return 0
+  fi
+  return 0
+}
+
+_codepoint_len() {
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$1" | python3 -c 'import sys; print(len(sys.stdin.read()))'
+  else
+    # wc -m counts characters under a UTF-8 locale on BSD and GNU.
+    printf '%s' "$1" | LC_ALL=en_US.UTF-8 wc -m | tr -d ' '
+  fi
+}
+
+check_commit_subject() {
+  local subj="$1"
+  local re_required='^(feat|fix|docs|refactor|perf)\(#[0-9]+\)!?: .+$'
+  local re_optional='^(test|style|build|ci|chore|revert)(\(#[0-9]+\))?!?: .+$'
+  if [[ ! "$subj" =~ $re_required ]] && [[ ! "$subj" =~ $re_optional ]]; then
+    echo "Not a valid Conventional Commit. feat/fix/docs/refactor/perf require (#N); others are optional." >&2
+    echo "  format: <type>(#<N>)[!]: <subject>" >&2
+    return 1
+  fi
+  local rest="${subj#*: }"
+  local len
+  len=$(_codepoint_len "$rest")
+  if [ "$len" -lt 1 ] || [ "$len" -gt 72 ]; then
+    echo "Subject length out of codepoint range 1..72 (got $len)" >&2
+    return 1
+  fi
+  return 0
+}

--- a/.claude/hooks/helpers/cwd_guard.sh
+++ b/.claude/hooks/helpers/cwd_guard.sh
@@ -1,0 +1,61 @@
+# helpers/cwd_guard.sh — registry-based scope checks. Source from hooks.
+
+# in_scope: returns 0 if PWD is inside any registry entry, 1 otherwise.
+in_scope() {
+  local registry="$CLAUDE_ENG_SHELL_ROOT/.claude/state/registry.txt"
+  [ -f "$registry" ] || return 1
+  local pwd_real
+  pwd_real=$(cd "$PWD" 2>/dev/null && pwd -P) || return 1
+  local entry
+  while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    case "$pwd_real/" in
+      "$entry"/*) return 0 ;;
+    esac
+    [ "$pwd_real" = "$entry" ] && return 0
+  done < "$registry"
+  return 1
+}
+
+# path_in_scope <path>: returns 0 if the path lies inside registry (or the shell itself).
+path_in_scope() {
+  local p="$1"
+  [ -z "$p" ] && return 1
+  # Substitute common env-var literals (as they may appear in Bash command args)
+  case "$p" in
+    '$HOME'|'$HOME'/*) p="${HOME}${p#'$HOME'}" ;;
+    \~|\~/*) p="${HOME}${p#\~}" ;;
+  esac
+  # Make absolute
+  case "$p" in
+    /*) ;;
+    *) p="$(pwd -P)/$p" ;;
+  esac
+  # Walk up to the first existing directory ancestor, then physical-resolve.
+  # Covers files, missing paths, and existing dirs uniformly.
+  local ancestor="$p" suffix=""
+  while [ ! -d "$ancestor" ] && [ "$ancestor" != "/" ] && [ -n "$ancestor" ]; do
+    suffix="/$(basename "$ancestor")$suffix"
+    local next; next=$(dirname "$ancestor")
+    [ "$next" = "$ancestor" ] && break
+    ancestor="$next"
+  done
+  if [ -d "$ancestor" ]; then
+    p="$(cd "$ancestor" 2>/dev/null && pwd -P)$suffix"
+  fi
+  # Allow shell self-modification
+  case "$p/" in
+    "$CLAUDE_ENG_SHELL_ROOT"/*) return 0 ;;
+  esac
+  local registry="$CLAUDE_ENG_SHELL_ROOT/.claude/state/registry.txt"
+  [ -f "$registry" ] || return 1
+  local entry
+  while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    case "$p/" in
+      "$entry"/*) return 0 ;;
+    esac
+    [ "$p" = "$entry" ] && return 0
+  done < "$registry"
+  return 1
+}

--- a/.claude/hooks/helpers/detect_stack.sh
+++ b/.claude/hooks/helpers/detect_stack.sh
@@ -1,0 +1,90 @@
+# helpers/detect_stack.sh — language / test / formatter detection. Source from hooks.
+# Supported stacks: node, python, go, rust, ruby, godot. See SPEC.md §6.6 for the
+# sentinel files, test/lint/format commands, and stack-specific notes.
+
+detect_stack() {
+  if [ -f package.json ]; then echo node; return; fi
+  if [ -f pyproject.toml ] || [ -f setup.py ] || [ -f requirements.txt ]; then echo python; return; fi
+  if [ -f go.mod ]; then echo go; return; fi
+  if [ -f Cargo.toml ]; then echo rust; return; fi
+  if [ -f Gemfile ]; then echo ruby; return; fi
+  if [ -f project.godot ]; then echo godot; return; fi
+  echo unknown
+}
+
+detect_test_cmd() {
+  case "$(detect_stack)" in
+    node)
+      if [ -f package.json ] && grep -q '"test"' package.json 2>/dev/null; then echo "npm test"; fi ;;
+    python)
+      command -v pytest >/dev/null 2>&1 && echo "pytest" ;;
+    go) echo "go test ./..." ;;
+    rust) echo "cargo test" ;;
+    ruby) command -v bundle >/dev/null && echo "bundle exec rspec" ;;
+    godot)
+      # GUT (Godot Unit Test) addon present → run its CLI; otherwise parse-only boot.
+      if [ -f addons/gut/gut_cmdln.gd ]; then
+        echo "godot --headless --path . -s res://addons/gut/gut_cmdln.gd -gexit"
+      else
+        echo "godot --headless --path . --quit-after 1"
+      fi
+      ;;
+  esac
+}
+
+detect_lint_cmd() {
+  case "$(detect_stack)" in
+    node) command -v npx >/dev/null && [ -f package.json ] && grep -q '"lint"' package.json 2>/dev/null && echo "npm run lint" ;;
+    python) command -v ruff >/dev/null && echo "ruff check ." ;;
+    go) echo "go vet ./..." ;;
+    rust) echo "cargo check" ;;
+    godot) command -v gdlint >/dev/null 2>&1 && echo "gdlint ." ;;
+  esac
+}
+
+_lint_timeout_warned=0
+
+# run_bounded_lint <cmd>
+#   Runs <cmd> via timeout(1) (or gtimeout(1) on macOS) bounded by
+#   CLAUDE_ENG_LINT_TIMEOUT seconds (default 30). Returns the command's
+#   exit code, or the timeout exit (typically 124) when the bound fires.
+#   If neither timeout binary is on PATH, emits an audit_log warn once
+#   per process and falls back to unbounded execution — better to surface
+#   the missing dep than to silently disable enforcement or hang.
+run_bounded_lint() {
+  local cmd="$1"
+  local secs="${CLAUDE_ENG_LINT_TIMEOUT:-30}"
+  local timeout_bin=""
+  if command -v timeout >/dev/null 2>&1; then
+    timeout_bin=timeout
+  elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_bin=gtimeout
+  fi
+  if [ -z "$timeout_bin" ]; then
+    if [ "${_lint_timeout_warned:-0}" = "0" ] && command -v audit_log >/dev/null 2>&1; then
+      audit_log warn lint-timeout-absent notice "timeout(1)/gtimeout(1) not on PATH; lint runs unbounded"
+      _lint_timeout_warned=1
+    fi
+    eval "$cmd"
+    return $?
+  fi
+  "$timeout_bin" "$secs" sh -c "$cmd"
+}
+
+detect_format_cmd() {
+  local file="$1"
+  # Shell-quote the file path so the caller's `eval` cannot execute injected
+  # metacharacters from the filename. printf '%q' is a bash builtin and is
+  # safe to use here because all hook helpers run under #!/usr/bin/env bash.
+  local qfile
+  qfile=$(printf '%q' "$file")
+  case "$file" in
+    *.py) command -v ruff >/dev/null && { echo "ruff format $qfile"; return; }
+          command -v black >/dev/null && echo "black $qfile" ;;
+    *.js|*.jsx|*.ts|*.tsx|*.json|*.md|*.yml|*.yaml)
+          command -v prettier >/dev/null && echo "prettier --write $qfile" ;;
+    *.go) command -v gofmt >/dev/null && echo "gofmt -w $qfile" ;;
+    *.rs) command -v rustfmt >/dev/null && echo "rustfmt $qfile" ;;
+    *.gd) command -v gdformat >/dev/null 2>&1 && echo "gdformat $qfile" ;;
+  esac
+}

--- a/.claude/hooks/helpers/escape.sh
+++ b/.claude/hooks/helpers/escape.sh
@@ -1,0 +1,87 @@
+# helpers/escape.sh — SKIP_HOOKS handling. Source from hooks.
+# Usage: should_skip <category>  → returns 0 if skipping (audit-logged), 1 otherwise.
+
+should_skip() {
+  local cat="$1"
+  [ -z "${SKIP_HOOKS:-}" ] && return 1
+  case ",${SKIP_HOOKS}," in
+    *",all,"*|*",${cat},"*)
+      local reason="${SKIP_REASON:-unspecified}"
+      audit_log escape "$cat" skip "$reason"
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# parse_env_prefix <cmd> <outvar>
+#   Parses the SPEC §7 escape-hatch env-prefix (`SKIP_HOOKS=…` and
+#   `SKIP_REASON=…`) from the leading edge of <cmd>, exports those pairs
+#   into the calling shell, and writes the stripped cmd into the variable
+#   named by <outvar> (via `printf -v`, so no subshell loses the exports).
+#
+# Only `SKIP_HOOKS` and `SKIP_REASON` are recognized — any other ALLCAPS
+# `K=V` leading token is treated as an ordinary cmd argument and left in
+# place. This is deliberate: a permissive allow-list would let a crafted
+# `PATH=/evil git commit …` redirect downstream `command -v` lookups in
+# the hook (which then `eval` the resolved binary), exfiltrating the
+# guardrail. Restricting to the SPEC-documented variables closes that
+# vector while keeping the documented syntax intact.
+#
+# Why a nameref-style outvar instead of stdout: `outvar=$(parse_env_prefix
+# …)` would put the function body in a subshell, and any exports inside
+# would be discarded when that subshell exited. The <outvar> argument must
+# be a valid bash identifier; callers pass it as a literal.
+#
+# Falls back to a no-op (outvar set to cmd unchanged, no env exports) when
+# python3 or jq is absent. The escape hatch then behaves as it did before
+# this PR (broken on minimal hosts), which is no worse than the prior state.
+parse_env_prefix() {
+  # All internals are `_pep_`-prefixed so they cannot shadow a caller-
+  # supplied outvar name through bash's dynamic scope. In particular,
+  # naming the parameter local `cmd` and the caller passing `cmd` as
+  # outvar would route `printf -v "$outvar"` to the function-local,
+  # silently dropping the stripped result.
+  local _pep_cmd="$1"
+  local _pep_outvar="$2"
+  if ! command -v python3 >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    printf -v "$_pep_outvar" '%s' "$_pep_cmd"
+    return
+  fi
+  local _pep_out
+  _pep_out=$(printf '%s' "$_pep_cmd" | python3 -c '
+import json, re, shlex, sys
+ALLOW = {"SKIP_HOOKS", "SKIP_REASON"}
+data = sys.stdin.read()
+try:
+    toks = shlex.split(data)
+except ValueError:
+    print(json.dumps({"env": [], "cmd": data}))
+    sys.exit(0)
+pat = re.compile(r"^([A-Z_][A-Z0-9_]*)=(.*)$", re.DOTALL)
+env = []
+i = 0
+while i < len(toks):
+    m = pat.match(toks[i])
+    if not m or m.group(1) not in ALLOW:
+        break
+    env.append([m.group(1), m.group(2)])
+    i += 1
+try:
+    rest = shlex.join(toks[i:])  # Python 3.8+
+except AttributeError:
+    rest = " ".join(toks[i:])
+print(json.dumps({"env": env, "cmd": rest}))
+' 2>/dev/null) || {
+    printf -v "$_pep_outvar" '%s' "$_pep_cmd"
+    return
+  }
+  local _pep_env_lines _pep_stripped _pep_kv
+  _pep_env_lines=$(printf '%s' "$_pep_out" | jq -r '.env[]? | "\(.[0])=\(.[1])"' 2>/dev/null) || _pep_env_lines=""
+  _pep_stripped=$(printf '%s' "$_pep_out" | jq -r '.cmd // ""' 2>/dev/null) || _pep_stripped="$_pep_cmd"
+  while IFS= read -r _pep_kv; do
+    [ -z "$_pep_kv" ] && continue
+    export "$_pep_kv"
+  done <<< "$_pep_env_lines"
+  printf -v "$_pep_outvar" '%s' "$_pep_stripped"
+}

--- a/.claude/hooks/helpers/gh_state.sh
+++ b/.claude/hooks/helpers/gh_state.sh
@@ -1,0 +1,30 @@
+# helpers/gh_state.sh — gh CLI wrappers. Source from hooks.
+
+current_pr_number() {
+  gh pr view --json number --jq .number 2>/dev/null
+}
+
+current_pr_field() {
+  local n="$1" field="$2"
+  gh pr view "$n" --json "$field" --jq ".$field" 2>/dev/null
+}
+
+current_pr_state_line() {
+  local n="${1:-$(current_pr_number)}"
+  [ -n "$n" ] || return 1
+  gh pr view "$n" --json isDraft,headRefName,title \
+    --jq '"\(.isDraft)|\(.headRefName)|\(.title)"' 2>/dev/null
+}
+
+pr_is_draft() {
+  local n="${1:-$(current_pr_number)}"
+  [ -n "$n" ] || return 1
+  local d
+  d=$(gh pr view "$n" --json isDraft --jq .isDraft 2>/dev/null) || return 1
+  [ "$d" = "true" ]
+}
+
+issue_body() {
+  local n="$1"
+  gh issue view "$n" --json body --jq .body 2>/dev/null
+}

--- a/.claude/hooks/helpers/git_matcher.sh
+++ b/.claude/hooks/helpers/git_matcher.sh
@@ -1,0 +1,26 @@
+# helpers/git_matcher.sh — shared regex fragment for `git <subcommand>` matchers.
+# Source from any hook that needs to match git subcommands tolerantly.
+
+# GIT_PREFIX is an ERE fragment that matches `git` followed by zero or more
+# standard git-level options between `git` and the subcommand. Used as a
+# prefix in every `git <subcommand>` matcher so the downstream gates fire
+# even when the user supplies common option prefixes. See SPEC §6.1
+# "Git option-prefix tolerance" for the contract.
+#
+# Tolerated options (single source of truth):
+#   -c <key>=<value>             — per-invocation config
+#   -C <path>                    — change directory
+#   -p, --paginate               — page output
+#   --no-pager                   — suppress pager
+#   --git-dir=<path>             — custom .git
+#   --work-tree=<path>           — custom work tree
+#   --bare                       — bare repo flag
+#   --namespace=<ref>            — ref namespace
+#   --literal-pathspecs          — literal pathspec matching
+#   --icase-pathspecs            — case-insensitive pathspec
+#   --no-optional-locks          — skip refresh/index locks
+#   --no-replace-objects         — disregard replace refs
+#   --no-advice                  — suppress advice hints
+#   --exec-path[=<path>]         — git exec path
+#   --config-env=<name>=<envvar> — config from env
+GIT_PREFIX='\bgit(\s+(-c\s+\S+|-C\s+\S+|-p|--paginate|--no-pager|--git-dir=\S+|--work-tree=\S+|--bare|--namespace=\S+|--literal-pathspecs|--icase-pathspecs|--no-optional-locks|--no-replace-objects|--no-advice|--exec-path(=\S+)?|--config-env=\S+))*\s+'

--- a/.claude/hooks/helpers/log.sh
+++ b/.claude/hooks/helpers/log.sh
@@ -1,0 +1,37 @@
+# helpers/log.sh — audit log writer. Source from hooks.
+
+# Encode an arbitrary string as a JSON string literal (with surrounding
+# quotes). Prefers jq for fidelity; falls back to inline escapes for the
+# control characters most likely to appear in `reason` / `cwd`.
+_audit_json_string() {
+  local s="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$s" | jq -Rs .
+    return
+  fi
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '"%s"' "$s"
+}
+
+audit_log() {
+  local event="$1" category="$2" decision="$3" reason="$4"
+  local ts cwd log
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  cwd=$(pwd -P 2>/dev/null || pwd)
+  log="$CLAUDE_ENG_SHELL_ROOT/.claude/audit/audit.jsonl"
+  mkdir -p "$(dirname "$log")"
+  # `reason` is user-controllable (SKIP_REASON, normalized cmd strings,
+  # park reasons) and `cwd` is filesystem-derived (POSIX paths legally
+  # contain `"` and `\`). Both must be JSON-encoded to preserve the
+  # "one record per line" invariant of audit.jsonl. Other fields are
+  # hardcoded constants at every call site.
+  local r_reason r_cwd
+  r_reason=$(_audit_json_string "$reason")
+  r_cwd=$(_audit_json_string "$cwd")
+  printf '{"ts":"%s","event":"%s","category":"%s","decision":"%s","reason":%s,"cwd":%s}\n' \
+    "$ts" "$event" "$category" "$decision" "$r_reason" "$r_cwd" >> "$log"
+}

--- a/.claude/hooks/helpers/pr_cache.sh
+++ b/.claude/hooks/helpers/pr_cache.sh
@@ -1,0 +1,118 @@
+# helpers/pr_cache.sh — persistent "last seen PR body" cache. Source from
+# /sync-pr, /ship, /work-on. SPEC §5.4.
+#
+# Cache location: $PR_CACHE_DIR (override; defaults to
+# $CLAUDE_ENG_SHELL_ROOT/.claude/state/pr-cache).
+#
+# Filename: <owner>%2F<repo>__pr-<n>.json — '/' URL-encoded as '%2F' so
+# `<owner>/<repo>` slug boundaries survive the filename. Per-PR file holds:
+#   { "last_seen_body_sha256": "...", "last_synced_head": "...",
+#     "last_synced_at": "..." }
+#
+# Public:
+#   pr_cache_read <pr_number>                          — print cached SHA;
+#                                                        exit 0 if absent/valid,
+#                                                        exit 2 + stderr if corrupt
+#   pr_cache_write <pr_number> <body_sha256> <head>    — atomic write
+#   pr_cache_check <pr_number> <remote_body_sha256>    — exit 0 if absent/match, !=0 + stderr if mismatch
+
+_pr_cache_dir() {
+  printf '%s' "${PR_CACHE_DIR:-${CLAUDE_ENG_SHELL_ROOT:-.}/.claude/state/pr-cache}"
+}
+
+_pr_cache_key() {
+  # Derive <owner-url-encoded>__<repo-url-encoded>__pr-<n>. PR_CACHE_REPO
+  # override for tests. URL-encode '/' as '%2F' so the `/` boundary survives
+  # the filename — `tr '/' '_'` previously collapsed `acme/my_repo` and
+  # `acme_my/repo` to the same key. GitHub repo names are restricted to
+  # [A-Za-z0-9._-], so '/' is the only character ever encoded.
+  local n="$1" repo=""
+  if [ -n "${PR_CACHE_REPO:-}" ]; then
+    repo="$PR_CACHE_REPO"
+  elif command -v gh >/dev/null 2>&1; then
+    repo=$(gh repo view --json owner,name --jq '.owner.login + "/" + .name' 2>/dev/null)
+  fi
+  [ -z "$repo" ] && repo="unknown/unknown"
+  printf '%s__pr-%s' "$(printf '%s' "$repo" | sed 's|/|%2F|g')" "$n"
+}
+
+_pr_cache_path() {
+  printf '%s/%s.json' "$(_pr_cache_dir)" "$(_pr_cache_key "$1")"
+}
+
+pr_cache_read() {
+  # Distinguishes three cases:
+  #   - file absent           → exit 0, stdout empty (caller treats as first sync)
+  #   - file present + valid  → exit 0, stdout = SHA
+  #   - file present + corrupt→ exit 2, stderr warning (caller must abort)
+  local path
+  path=$(_pr_cache_path "$1")
+  [ -f "$path" ] || return 0
+
+  local sha=""
+  if command -v jq >/dev/null 2>&1; then
+    sha=$(jq -er '.last_seen_body_sha256 // ""' "$path" 2>/dev/null)
+    if [ $? -ne 0 ]; then
+      printf 'pr_cache: corrupt cache file at %s (jq parse failed)\n' "$path" >&2
+      return 2
+    fi
+  else
+    # Fallback parse — match the simple flat JSON we write.
+    sha=$(grep -oE '"last_seen_body_sha256"[[:space:]]*:[[:space:]]*"[^"]*"' "$path" 2>/dev/null \
+      | head -1 | sed -E 's/.*"([^"]*)"$/\1/')
+    # Heuristic for corruption when jq is missing: file is non-empty but no
+    # key was found.
+    if [ -z "$sha" ] && [ -s "$path" ]; then
+      printf 'pr_cache: corrupt cache file at %s (key not found in fallback parse)\n' "$path" >&2
+      return 2
+    fi
+  fi
+  printf '%s' "$sha"
+}
+
+pr_cache_write() {
+  local n="$1" body_sha="$2" head="${3:-}"
+  local dir path tmp ts
+  dir=$(_pr_cache_dir)
+  path=$(_pr_cache_path "$n")
+  tmp="$path.tmp.$$"
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  mkdir -p "$dir" 2>/dev/null || return 1
+
+  if command -v jq >/dev/null 2>&1; then
+    jq -n \
+      --arg sha "$body_sha" \
+      --arg head "$head" \
+      --arg ts "$ts" \
+      '{last_seen_body_sha256: $sha, last_synced_head: $head, last_synced_at: $ts}' \
+      > "$tmp" || return 1
+  else
+    # Minimal hand-formatted JSON if jq is missing.
+    printf '{"last_seen_body_sha256":"%s","last_synced_head":"%s","last_synced_at":"%s"}\n' \
+      "$body_sha" "$head" "$ts" > "$tmp" || return 1
+  fi
+
+  mv -f "$tmp" "$path"
+}
+
+pr_cache_check() {
+  local n="$1" remote_sha="$2"
+  local cached rc
+  cached=$(pr_cache_read "$n")
+  rc=$?
+  # Corrupt cache → forward the abort; pr_cache_read already wrote to stderr.
+  if [ "$rc" -ne 0 ]; then
+    return "$rc"
+  fi
+  if [ -z "$cached" ]; then
+    # No cache yet — first sync; treat as match.
+    return 0
+  fi
+  if [ "$cached" = "$remote_sha" ]; then
+    return 0
+  fi
+  printf 'pr_cache: external edit detected for PR #%s (cached=%s remote=%s)\n' \
+    "$n" "$cached" "$remote_sha" >&2
+  return 1
+}

--- a/.claude/hooks/helpers/secret_scan.sh
+++ b/.claude/hooks/helpers/secret_scan.sh
@@ -1,0 +1,27 @@
+# helpers/secret_scan.sh — pattern scan over the staged diff. Source from hooks.
+
+scan_staged_secrets() {
+  local added
+  added=$(git diff --cached 2>/dev/null | grep -E '^\+[^+]' | sed 's/^\+//')
+  [ -z "$added" ] && return 0
+  local p
+  for p in \
+    'AKIA[0-9A-Z]{16}' \
+    'aws(_| )secret(_| )access(_| )key.*[A-Za-z0-9/+=]{40}' \
+    'ghp_[A-Za-z0-9]{36}' \
+    'gho_[A-Za-z0-9]{36}' \
+    'github_pat_[A-Za-z0-9_]{20,}' \
+    'glpat-[A-Za-z0-9_-]{20}' \
+    'sk-ant-[A-Za-z0-9_-]+' \
+    'sk-[A-Za-z0-9]{40,}' \
+    'xox[bpoa]-[A-Za-z0-9-]+' \
+    '-----BEGIN [A-Z ]+PRIVATE KEY-----' \
+    'password[[:space:]]*[:=][[:space:]]*["'\''][^"'\'' ]{8,}["'\'']' \
+  ; do
+    if echo "$added" | grep -qE "$p"; then
+      echo "Possible secret pattern detected (only paths/lines audited; body never logged): $p" >&2
+      return 1
+    fi
+  done
+  return 0
+}

--- a/.claude/hooks/helpers/ship_mode.sh
+++ b/.claude/hooks/helpers/ship_mode.sh
@@ -1,0 +1,152 @@
+# helpers/ship_mode.sh — operating-mode resolution + post-ready dispatch.
+# Source from /ship and /status. SPEC §5.7.1.
+
+# resolve_mode [--mode=VALUE]
+# Stdout: `attended` or `unattended`.
+# Unknown values fail closed to `attended` with a stderr warning naming
+# the offending surface (flag/env/file). The surface is internal to the
+# warning; not exposed as a return value — callers that need the bare
+# mode use `mode=$(resolve_mode)` and don't have to think about scoping.
+resolve_mode() {
+  local flag_val="" arg raw="" surface=""
+  for arg in "$@"; do
+    case "$arg" in
+      --mode=*) flag_val="${arg#--mode=}";;
+    esac
+  done
+
+  if [ -n "$flag_val" ]; then
+    raw="$flag_val"; surface="flag"
+  elif [ -n "${CLAUDE_ENG_SHELL_MODE:-}" ]; then
+    raw="$CLAUDE_ENG_SHELL_MODE"; surface="env"
+  elif [ -f .claude/state/mode ]; then
+    raw=$(head -c 64 .claude/state/mode 2>/dev/null | tr -d '[:space:]')
+    surface="file"
+  fi
+
+  case "$raw" in
+    attended|unattended) printf '%s\n' "$raw";;
+    "")                  printf '%s\n' "attended";;
+    *)
+      printf 'ship_mode: unknown mode %q from %s — using attended\n' \
+        "$raw" "$surface" >&2
+      printf '%s\n' "attended"
+      ;;
+  esac
+}
+
+# ship_classify_blocker — JSON on stdin → `clean` | `soft` | `hard` on stdout.
+# Input shape: subset of `gh pr view --json mergeable,mergeStateStatus,statusCheckRollup,reviewDecision,reviewRequests`.
+ship_classify_blocker() {
+  local json
+  json=$(cat)
+  if [ -z "$json" ]; then
+    printf 'ship_classify_blocker: no input on stdin — defaulting to hard\n' >&2
+    printf 'hard\n'
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'ship_classify_blocker: jq not found — defaulting to hard\n' >&2
+    printf 'hard\n'
+    return 0
+  fi
+
+  if printf '%s' "$json" | jq -e \
+       '(.statusCheckRollup // []) | map(.status // .conclusion // "") |
+        any(. == "PENDING" or . == "IN_PROGRESS" or . == "QUEUED")' \
+       >/dev/null 2>&1; then
+    printf 'soft\n'; return 0
+  fi
+
+  local review_decision review_requests_len merge_state
+  review_decision=$(printf '%s' "$json" | jq -r '.reviewDecision // ""' 2>/dev/null)
+  review_requests_len=$(printf '%s' "$json" | jq -r '(.reviewRequests // []) | length' 2>/dev/null)
+  merge_state=$(printf '%s' "$json" | jq -r '.mergeStateStatus // ""' 2>/dev/null)
+
+  if [ "$review_decision" = "REVIEW_REQUIRED" ] && [ "${review_requests_len:-0}" = "0" ]; then
+    printf 'hard\n'; return 0
+  fi
+
+  if printf '%s' "$json" | jq -e \
+       '(.statusCheckRollup // []) | map(.conclusion // "") |
+        any(. == "FAILURE" or . == "CANCELLED" or . == "TIMED_OUT")' \
+       >/dev/null 2>&1; then
+    printf 'hard\n'; return 0
+  fi
+
+  if [ "$merge_state" = "BLOCKED" ]; then
+    printf 'hard\n'; return 0
+  fi
+
+  case "$review_decision" in
+    ""|APPROVED) printf 'clean\n';;
+    *)           printf 'hard\n';;
+  esac
+}
+
+# ship_decide_post_ready <mode> [<classification>]
+# Stdout: `stop` | `merge` | `fix-and-wait` | `park`.
+# Attended always returns `stop` and ignores the second arg.
+ship_decide_post_ready() {
+  local mode="${1:-attended}"
+  local class="${2:-}"
+  case "$mode" in
+    attended)
+      printf 'stop\n'
+      ;;
+    unattended)
+      case "$class" in
+        clean) printf 'merge\n';;
+        soft)  printf 'fix-and-wait\n';;
+        hard)  printf 'park\n';;
+        *)     printf 'park\n';;
+      esac
+      ;;
+    *)
+      printf 'stop\n'
+      ;;
+  esac
+}
+
+# ship_park_pr <reason-token>
+# Idempotent. On a fresh park (label `unattended-parked` not yet present):
+#   Stdout: deterministic comment string (reason token verbatim).
+#   Side effect: appends one timestamped park line to $SHIP_PARK_LOG_PATH.
+# On a repeat park (label already present from a previous park):
+#   Stdout: empty.
+#   Side effect: appends one `park-suppressed: <reason>` line to the log.
+# Default log path: $CLAUDE_ENG_SHELL_ROOT/.claude/state/unattended-park.log.
+#
+# Cwd requirement: the label check uses `gh pr view --json labels` with no
+# explicit PR identifier, so `gh`'s branch→PR detection picks the current
+# branch's PR. The caller's cwd must be inside the target repo's worktree on
+# the PR's branch. `/ship` callers satisfy this; cron/CI callers may need to
+# `cd` first or extend this helper to accept an explicit PR number.
+ship_park_pr() {
+  local reason="${1:-unspecified}"
+  local log_path="${SHIP_PARK_LOG_PATH:-$CLAUDE_ENG_SHELL_ROOT/.claude/state/unattended-park.log}"
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  mkdir -p "$(dirname "$log_path")" 2>/dev/null || true
+
+  local labels=""
+  if command -v gh >/dev/null 2>&1; then
+    labels=$(gh pr view --json labels --jq '.labels[].name' 2>/dev/null)
+  fi
+
+  # Whitespace-tolerant exact-line match: tolerate leading/trailing spaces
+  # on either side of the label name (clean gh output has neither, but a
+  # future shim or formatter mustn't slip past silently).
+  if printf '%s\n' "$labels" | grep -qE '^[[:space:]]*unattended-parked[[:space:]]*$'; then
+    printf '%s park-suppressed: %s\n' "$ts" "$reason" >> "$log_path"
+    return 0
+  fi
+
+  printf '%s parked reason=%s\n' "$ts" "$reason" >> "$log_path"
+
+  printf 'unattended-parked\n'
+  printf 'reason: %s\n' "$reason"
+  printf 'time: %s\n' "$ts"
+  printf 'See SPEC §5.7.1 for the operating-mode contract.\n'
+}

--- a/.claude/hooks/helpers/status.sh
+++ b/.claude/hooks/helpers/status.sh
@@ -1,0 +1,272 @@
+# helpers/status.sh — canonical work-state summary used by /status and
+# UserPromptSubmit. Single source of truth so the two surfaces never drift.
+# SPEC §5.5.
+#
+# Public:
+#   status_compact — multi-line plaintext block (turn-context surface).
+#   status_json    — same fields as stable JSON.
+#
+# Both modes resolve the same fields. Callers may invoke independently;
+# `gh` calls are made at most once per invocation. Results are cached
+# per-branch under .claude/state/status-cache/ with STATUS_CACHE_TTL
+# seconds (default 5). See SPEC §5.5 "Cache".
+
+# Compute the per-branch cache file path. STATUS_CACHE_DIR_OVERRIDE is
+# honored by the smoke tests; production uses the default under
+# .claude/state/.
+_status_cache_path() {
+  local branch="$1"
+  local dir="${STATUS_CACHE_DIR_OVERRIDE:-${CLAUDE_ENG_SHELL_ROOT:-.}/.claude/state/status-cache}"
+  local safe
+  safe=$(printf '%s' "$branch" | tr '/' '_')
+  printf '%s/%s.json' "$dir" "$safe"
+}
+
+# Returns 0 iff <file> exists and is younger than STATUS_CACHE_TTL seconds.
+_status_cache_fresh() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  local ttl="${STATUS_CACHE_TTL:-5}"
+  local mtime now
+  # GNU stat (-c %Y), BSD stat (-f %m).
+  if mtime=$(stat -c %Y "$f" 2>/dev/null); then
+    :
+  elif mtime=$(stat -f %m "$f" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  now=$(date +%s)
+  [ "$((now - mtime))" -le "$ttl" ]
+}
+
+# Load a cached JSON file into STATUS_* vars via a single jq @sh pass.
+_status_cache_load() {
+  local f="$1"
+  command -v jq >/dev/null 2>&1 || return 1
+  local script
+  script=$(jq -r '
+    to_entries[] | "STATUS_" + (.key | ascii_upcase) + "=" + (.value // "" | @sh)
+  ' "$f" 2>/dev/null) || return 1
+  [ -n "$script" ] || return 1
+  eval "$script"
+}
+
+# Write the current STATUS_* set to <file> atomically. Failures (disk
+# full, EACCES, jq missing) are intentionally silent: a missed cache
+# write is a perf regression, not a correctness one — the next call
+# simply misses again and refetches via gh.
+_status_cache_write() {
+  local f="$1"
+  command -v jq >/dev/null 2>&1 || return 0
+  mkdir -p "$(dirname "$f")" 2>/dev/null
+  local tmp="$f.tmp.$$"
+  jq -n \
+    --arg branch "$STATUS_BRANCH" \
+    --arg dirty "$STATUS_DIRTY" \
+    --arg pr_num "$STATUS_PR_NUM" \
+    --arg pr_state "$STATUS_PR_STATE" \
+    --arg pr_title "$STATUS_PR_TITLE" \
+    --arg pr_base "$STATUS_PR_BASE" \
+    --arg issue_num "$STATUS_ISSUE_NUM" \
+    --arg issue_title "$STATUS_ISSUE_TITLE" \
+    --arg tasks_done "$STATUS_TASKS_DONE" \
+    --arg tasks_total "$STATUS_TASKS_TOTAL" \
+    --arg next "$STATUS_NEXT" \
+    --arg phase "$STATUS_PHASE" \
+    --arg ci "$STATUS_CI" \
+    --arg mode "$STATUS_MODE" \
+    '{branch:$branch,dirty:$dirty,pr_num:$pr_num,pr_state:$pr_state,pr_title:$pr_title,pr_base:$pr_base,issue_num:$issue_num,issue_title:$issue_title,tasks_done:$tasks_done,tasks_total:$tasks_total,next:$next,phase:$phase,ci:$ci,mode:$mode}' \
+    > "$tmp" 2>/dev/null && mv -f "$tmp" "$f" 2>/dev/null
+  rm -f "$tmp" 2>/dev/null
+}
+
+# Internal: populate STATUS_* vars by querying git + gh + the PR body.
+_status_collect() {
+  STATUS_BRANCH=""
+  STATUS_DIRTY=""
+  STATUS_PR_NUM=""
+  STATUS_PR_STATE=""
+  STATUS_PR_TITLE=""
+  STATUS_ISSUE_NUM=""
+  STATUS_ISSUE_TITLE=""
+  STATUS_PR_BASE=""
+  STATUS_TASKS_DONE=""
+  STATUS_TASKS_TOTAL=""
+  STATUS_NEXT=""
+  STATUS_PHASE=""
+  STATUS_CI=""
+  STATUS_MODE=""
+
+  command -v git >/dev/null 2>&1 || return 0
+  STATUS_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+  # Cache short-circuit (SPEC §5.5 Cache). After computing the branch
+  # we know the cache key; if the cache is fresh, load + return.
+  if [ -n "$STATUS_BRANCH" ]; then
+    local _cache_file
+    _cache_file=$(_status_cache_path "$STATUS_BRANCH")
+    if _status_cache_fresh "$_cache_file" && _status_cache_load "$_cache_file"; then
+      return 0
+    fi
+  fi
+
+  if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+    STATUS_DIRTY="dirty"
+  fi
+
+  if command -v gh >/dev/null 2>&1; then
+    local pr_json
+    pr_json=$(gh pr view --json number,isDraft,title,body,baseRefName 2>/dev/null)
+    if [ -n "$pr_json" ] && command -v jq >/dev/null 2>&1; then
+      STATUS_PR_NUM=$(printf '%s' "$pr_json" | jq -r '.number // ""' 2>/dev/null)
+      local is_draft
+      is_draft=$(printf '%s' "$pr_json" | jq -r '.isDraft // false' 2>/dev/null)
+      [ "$is_draft" = "true" ] && STATUS_PR_STATE="draft" || STATUS_PR_STATE="ready"
+      STATUS_PR_TITLE=$(printf '%s' "$pr_json" | jq -r '.title // ""' 2>/dev/null)
+      STATUS_PR_BASE=$(printf '%s' "$pr_json" | jq -r '.baseRefName // ""' 2>/dev/null)
+      local body
+      body=$(printf '%s' "$pr_json" | jq -r '.body // ""' 2>/dev/null)
+
+      # Issue from `Closes #N` / `Refs #N` on the first non-empty line.
+      local closes_line
+      closes_line=$(printf '%s\n' "$body" | grep -m1 -E '^(Closes|Refs) #[0-9]+')
+      if [ -n "$closes_line" ]; then
+        STATUS_ISSUE_NUM=$(printf '%s' "$closes_line" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+        if [ -n "$STATUS_ISSUE_NUM" ]; then
+          STATUS_ISSUE_TITLE=$(gh issue view "$STATUS_ISSUE_NUM" --json title --jq .title 2>/dev/null)
+        fi
+      fi
+
+      # Checklist progress from "- [x]" / "- [ ]" lines. awk over grep -c
+      # because the latter exits 1 on zero matches AND prints "0", which
+      # combined with `|| printf '0'` produced "0\n0" and broke the
+      # subsequent arithmetic. awk always prints exactly one integer.
+      STATUS_TASKS_DONE=$(printf '%s\n' "$body" | awk '/^- \[x\]/ {c++} END {print c+0}')
+      local tasks_open
+      tasks_open=$(printf '%s\n' "$body" | awk '/^- \[ \]/ {c++} END {print c+0}')
+      STATUS_TASKS_TOTAL=$((STATUS_TASKS_DONE + tasks_open))
+
+      # Next unchecked item + the phase it sits under. Walks line-by-line;
+      # tracks the most recent phase heading while scanning toward the first
+      # unchecked checklist item, then stops. Phase is one of Doc/Test/Code/
+      # Review/Ship — whichever section the next-to-do lives in.
+      local current_phase=""
+      local next_item=""
+      while IFS= read -r line; do
+        [ -n "$next_item" ] && continue
+        case "$line" in
+          *"**Phase A"*|*"**Doc**"*|*"Phase A — Doc"*) current_phase="Doc";;
+          *"**Phase B"*|*"**Test**"*|*"Phase B — Test"*) current_phase="Test";;
+          *"**Phase C"*|*"**Code**"*|*"Phase C — Code"*) current_phase="Code";;
+          *"## Ship gate"*) current_phase="Ship";;
+        esac
+        case "$line" in
+          "- [ ] "*)
+            next_item=${line#- \[ \] }
+            ;;
+        esac
+      done <<EOF
+$body
+EOF
+      STATUS_NEXT="$next_item"
+      STATUS_PHASE="$current_phase"
+    fi
+
+    # CI status — single token or `-`.
+    local ci_state
+    ci_state=$(gh pr checks --json state --jq '[.[].state] | unique | join(",")' 2>/dev/null)
+    [ -n "$ci_state" ] && STATUS_CI="$ci_state"
+  fi
+
+  if [ -f "${CLAUDE_ENG_SHELL_ROOT:-}/.claude/hooks/helpers/ship_mode.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/helpers/ship_mode.sh"
+    STATUS_MODE=$(resolve_mode 2>/dev/null)
+  fi
+
+  # Persist the freshly-collected state for the next invocation within
+  # the TTL window. Skips silently if we couldn't get a branch (no git
+  # repo / empty rev-parse) — no key, no cache.
+  if [ -n "$STATUS_BRANCH" ]; then
+    _status_cache_write "$(_status_cache_path "$STATUS_BRANCH")"
+  fi
+}
+
+# Print "-" if the argument is empty; otherwise the argument itself.
+_status_or_dash() { [ -n "$1" ] && printf '%s' "$1" || printf '%s' "-"; }
+
+status_compact() {
+  _status_collect
+  printf '[claude-eng-shell]\n'
+  local branch_line="$STATUS_BRANCH"
+  [ -n "$STATUS_DIRTY" ] && branch_line="$branch_line ($STATUS_DIRTY)"
+  printf 'branch: %s\n' "$(_status_or_dash "$branch_line")"
+
+  local issue_line="-"
+  if [ -n "$STATUS_ISSUE_NUM" ]; then
+    issue_line="#$STATUS_ISSUE_NUM"
+    [ -n "$STATUS_ISSUE_TITLE" ] && issue_line="$issue_line $STATUS_ISSUE_TITLE"
+  fi
+  printf 'issue: %s\n' "$issue_line"
+
+  local pr_line="-"
+  if [ -n "$STATUS_PR_NUM" ]; then
+    pr_line="#$STATUS_PR_NUM $STATUS_PR_STATE"
+    # Surface a non-`main` base so the user sees which work-stack the
+    # PR belongs to (topic-branch / experimental flows, SPEC §10.5).
+    if [ -n "$STATUS_PR_BASE" ] && [ "$STATUS_PR_BASE" != "main" ]; then
+      pr_line="$pr_line → $STATUS_PR_BASE"
+    fi
+    pr_line="$pr_line [$STATUS_TASKS_DONE/$STATUS_TASKS_TOTAL tasks] ci: $(_status_or_dash "$STATUS_CI")"
+  fi
+  printf 'pr: %s\n' "$pr_line"
+
+  printf 'phase: %s\n' "$(_status_or_dash "$STATUS_PHASE")"
+  printf 'next: %s\n' "$(_status_or_dash "$STATUS_NEXT")"
+  printf 'mode: %s\n' "$(_status_or_dash "$STATUS_MODE")"
+}
+
+status_json() {
+  _status_collect
+  # jq is required for status_json. If absent, emit a minimal {} so callers
+  # that parse get a valid JSON object rather than empty stdin.
+  if ! command -v jq >/dev/null 2>&1; then
+    printf '{}\n'
+    return 0
+  fi
+  jq -n \
+    --arg branch "$STATUS_BRANCH" \
+    --arg dirty "$STATUS_DIRTY" \
+    --arg pr_num "$STATUS_PR_NUM" \
+    --arg pr_state "$STATUS_PR_STATE" \
+    --arg pr_title "$STATUS_PR_TITLE" \
+    --arg pr_base "$STATUS_PR_BASE" \
+    --arg issue_num "$STATUS_ISSUE_NUM" \
+    --arg issue_title "$STATUS_ISSUE_TITLE" \
+    --arg tasks_done "$STATUS_TASKS_DONE" \
+    --arg tasks_total "$STATUS_TASKS_TOTAL" \
+    --arg next_item "$STATUS_NEXT" \
+    --arg phase "$STATUS_PHASE" \
+    --arg ci "$STATUS_CI" \
+    --arg mode "$STATUS_MODE" \
+    '{
+      branch: ($branch | select(. != "") // null),
+      dirty: ($dirty == "dirty"),
+      pr: (if $pr_num != "" then {
+            number: ($pr_num | tonumber),
+            state: $pr_state,
+            title: $pr_title,
+            base: ($pr_base | select(. != "") // null),
+            tasks: {done: ($tasks_done | tonumber), total: ($tasks_total | tonumber)}
+          } else null end),
+      issue: (if $issue_num != "" then {
+            number: ($issue_num | tonumber),
+            title: $issue_title
+          } else null end),
+      next: ($next_item | select(. != "") // null),
+      phase: ($phase | select(. != "") // null),
+      ci: ($ci | select(. != "") // null),
+      mode: ($mode | select(. != "") // null)
+    }'
+}

--- a/.claude/hooks/helpers/tests.sh
+++ b/.claude/hooks/helpers/tests.sh
@@ -1,0 +1,12 @@
+# helpers/tests.sh — test runner used by /ship. Source then call run_tests.
+
+run_tests() {
+  local cmd
+  cmd=$(detect_test_cmd)
+  if [ -z "$cmd" ]; then
+    echo "No test runner detected (supported: node/python/go/rust/ruby/godot)" >&2
+    return 2
+  fi
+  echo ">> $cmd"
+  eval "$cmd"
+}

--- a/.claude/hooks/post_tool_use.sh
+++ b/.claude/hooks/post_tool_use.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SHELL_ROOT="${CLAUDE_ENG_SHELL_ROOT:-}"
+[ -n "$SHELL_ROOT" ] && [ -d "$SHELL_ROOT/.claude/hooks/helpers" ] || exit 0
+
+. "$SHELL_ROOT/.claude/hooks/helpers/log.sh"
+. "$SHELL_ROOT/.claude/hooks/helpers/cwd_guard.sh"
+. "$SHELL_ROOT/.claude/hooks/helpers/detect_stack.sh"
+. "$SHELL_ROOT/.claude/hooks/helpers/git_matcher.sh"
+
+in_scope || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty')
+
+case "$tool" in
+  Edit|Write|MultiEdit)
+    target=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+    [ -z "$target" ] && exit 0
+    fmt=$(detect_format_cmd "$target")
+    [ -n "$fmt" ] && eval "$fmt" >/dev/null 2>&1 || true
+    ;;
+  Bash)
+    cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+    # Match `git commit` / `git push` tolerantly so that option-prefix
+    # forms (git -c <opt> commit, git -C <path> push, …) still fire the
+    # reminders. Single source of truth lives in helpers/git_matcher.sh.
+    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}commit\b"; then
+      printf '[claude-eng-shell] reminder: update the matching PR body checklist item.\n' >&2
+    fi
+    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}push\b"; then
+      if command -v gh >/dev/null 2>&1; then
+        n=$(gh pr view --json number --jq .number 2>/dev/null)
+        if [ -n "$n" ]; then
+          state=$(gh pr checks "$n" --json state 2>/dev/null | jq -r '[.[].state] | unique | join(",")' 2>/dev/null)
+          [ -n "$state" ] && printf '[claude-eng-shell] PR #%s checks: %s\n' "$n" "$state" >&2
+        fi
+      fi
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/pre_tool_use.sh
+++ b/.claude/hooks/pre_tool_use.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SHELL_ROOT="${CLAUDE_ENG_SHELL_ROOT:-}"
+[ -n "$SHELL_ROOT" ] && [ -d "$SHELL_ROOT/.claude/hooks/helpers" ] || exit 0
+
+. "$SHELL_ROOT/.claude/hooks/helpers/log.sh"
+. "$SHELL_ROOT/.claude/hooks/helpers/escape.sh"
+. "$SHELL_ROOT/.claude/hooks/helpers/cwd_guard.sh"
+. "$SHELL_ROOT/.claude/hooks/helpers/detect_stack.sh"
+. "$SHELL_ROOT/.claude/hooks/helpers/branch_guard.sh"
+. "$SHELL_ROOT/.claude/hooks/helpers/conventional_commit.sh"
+. "$SHELL_ROOT/.claude/hooks/helpers/secret_scan.sh"
+
+in_scope || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty')
+[ -z "$tool" ] && exit 0
+
+block() {
+  local cat="$1" msg="$2"
+  audit_log block "$cat" deny "$msg"
+  printf '%s\n' "$msg" >&2
+  exit 2
+}
+
+# Scan args of a Bash command for paths outside the registry.
+# Shell-aware: tokenizes via python3 `shlex.split` so quoted paths with spaces
+# stay intact and literal globs (`*`) are not pathname-expanded. Falls back to
+# `set -f` + `read -ra` when python3 is absent — quoting is lost in that
+# fallback, but globbing is still disabled and out-of-scope paths still block
+# (the corrupted token does not prefix-match any registry entry).
+check_destructive_args() {
+  local cmd="$1"
+  local arg
+  local -a args=()
+  if command -v python3 >/dev/null 2>&1; then
+    local tok_out
+    if ! tok_out=$(printf '%s' "$cmd" | python3 -c '
+import shlex, sys
+try:
+    for t in shlex.split(sys.stdin.read()):
+        print(t)
+except ValueError:
+    sys.exit(2)
+' 2>/dev/null); then
+      # shlex parse failed (unclosed quote, dangling backslash). Fail closed —
+      # we cannot reason about which paths the command would have touched.
+      return 1
+    fi
+    local tok
+    while IFS= read -r tok; do
+      [ -n "$tok" ] && args+=("$tok")
+    done <<< "$tok_out"
+  else
+    local _opts=$-
+    set -f
+    read -ra args <<< "$cmd"
+    case "$_opts" in *f*) ;; *) set +f ;; esac
+  fi
+
+  for arg in "${args[@]}"; do
+    case "$arg" in
+      -*) continue ;;
+      rm|mv|cp|sudo|doas|time|env) continue ;;
+    esac
+    case "$arg" in
+      '$HOME'|'$HOME'/*) arg="${HOME}${arg#'$HOME'}" ;;
+      '${HOME}'|'${HOME}'/*) arg="${HOME}${arg#'${HOME}'}" ;;
+      \~|\~/*) arg="${HOME}${arg#\~}" ;;
+    esac
+    path_in_scope "$arg" || return 1
+  done
+  return 0
+}
+
+. "$SHELL_ROOT/.claude/hooks/helpers/git_matcher.sh"
+
+case "$tool" in
+  Bash)
+    cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+    [ -z "$cmd" ] && exit 0
+
+    # Keep the raw command (with newlines) for matchers that need multi-line
+    # context — currently extract_commit_subject for the heredoc -m form.
+    raw_cmd="$cmd"
+
+    # Normalize multiline backslash-continuation and stray newlines so the
+    # matchers see a single logical command. Collapse `\\\n` first, then
+    # remaining newlines, then runs of whitespace. See SPEC §6.1
+    # "Implementation note" for the framing.
+    cmd=$(printf '%s' "$cmd" | tr '\n' ' ' | sed -E 's/\\[[:space:]]+/ /g; s/[[:space:]]+/ /g')
+
+    # Parse the SPEC §7 escape-hatch env-prefix (SKIP_HOOKS=, SKIP_REASON=,
+    # etc.) out of the cmd string, export it into this shell, and strip the
+    # prefix tokens before downstream matchers run. Claude Code's hook
+    # subprocess does not inherit env-prefixes from the user's cmd, so
+    # without this parse the documented escape hatch silently no-ops.
+    parse_env_prefix "$cmd" cmd
+
+    # Bypass-suspect patterns — eval / bash -c / sh -c / python -c /
+    # heredoc-spawned shells. Don't block (hooks aren't a sandbox; see
+    # §6.1 framing) and **don't short-circuit** the downstream matchers —
+    # emit a warn entry so the trail exists, then continue. This means
+    # `eval "git push --force"` still gets blocked by the force-push
+    # matcher on the literal substring, while plain `eval "ls"` warns
+    # and proceeds.
+    # Heredoc pattern excludes `<<<` here-strings (preceding-char check).
+    if printf '%s' "$cmd" | grep -qE '(^|[^[:alnum:]_])(eval|bash[[:space:]]+-c|sh[[:space:]]+-c|python[[:space:]]*[0-9.]*[[:space:]]+-c)([^[:alnum:]_]|$)' \
+       || printf '%s' "$cmd" | grep -qE '(^|[^<])<<-?[[:space:]]*[A-Za-z_]'; then
+      audit_log warn bypass-suspect notice "$cmd"
+    fi
+
+    # Destructive command with out-of-scope path arg
+    if printf '%s' "$cmd" | grep -qE '\b(rm|mv|cp)\s+(-[A-Za-z]*[fF][A-Za-z]*\s+)+'; then
+      if ! check_destructive_args "$cmd"; then
+        should_skip out-of-scope || block out-of-scope "destructive command points outside registry: $cmd"
+      fi
+    fi
+    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}reset\s+--hard\b"; then
+      should_skip destructive || block destructive "git reset --hard blocked"
+    fi
+    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}clean\s+-[A-Za-z]*f"; then
+      should_skip destructive || block destructive "git clean -f blocked"
+    fi
+
+    # Backmerge: `git merge <protected>` (optionally prefixed with
+    # `origin/` or `upstream/`) while NOT currently on a protected
+    # branch. The recommended motion when the base advances is the
+    # rebase pull form (SPEC §13). See §6.1 row.
+    #
+    # The matcher tolerates intermediate option tokens (e.g.
+    # `--no-ff`, `--no-edit`, `-m "msg"`, `--strategy=ours`) between
+    # `merge` and the ref. `(\s+\S+)*` consumes them; backtracking
+    # then aligns to the final protected-ref token. `(\s|$)` anchors
+    # the ref end so substring-like names (`mainframe`, `master-key`)
+    # don't false-positive. The remote-prefix is pinned to `origin/`
+    # / `upstream/` so a feature branch named `feature/main` doesn't
+    # match (the loose `\S+/` form would have swallowed `feature/`).
+    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}merge(\s+\S+)*\s+((origin|upstream)/)?(main|master|release/\S+)(\s|$)"; then
+      if ! is_protected_branch; then
+        should_skip backmerge \
+          || block backmerge "backmerge blocked — use 'git pull --rebase origin <base>' instead (or SKIP_HOOKS=backmerge for exceptional cases)"
+      fi
+    fi
+
+    # Force push
+    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}push\b.*(\-f\b|\-\-force\b|\-\-force-with-lease\b)"; then
+      should_skip force-push || block force-push "force push blocked"
+    fi
+
+    # Direct push to protected branch
+    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}push\b.*\b(main|master|release/\S+)\b"; then
+      should_skip branch || block branch "direct push to protected branch blocked"
+    fi
+
+    # --no-verify
+    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}commit\b.*\-\-no-verify\b"; then
+      should_skip no-verify || block no-verify "--no-verify blocked"
+    fi
+
+    # --amend (only when the commit is already pushed)
+    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}commit\b.*\-\-amend\b"; then
+      if git rev-parse '@{upstream}' >/dev/null 2>&1; then
+        if git merge-base --is-ancestor HEAD '@{upstream}' 2>/dev/null; then
+          should_skip amend || block amend "--amend of an already-pushed commit blocked"
+        fi
+      fi
+    fi
+
+    # git commit body: protected branch / commit format / secrets / lint
+    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}commit\b" \
+       && ! printf '%s' "$cmd" | grep -qE '\-\-allow-empty\b' ; then
+      if is_protected_branch; then
+        should_skip branch || block branch "commit on protected branch ($(branch_label)) blocked"
+      fi
+      subj=$(extract_commit_subject "$raw_cmd" "$cmd")
+      if [ -n "$subj" ]; then
+        err=$(check_commit_subject "$subj" 2>&1) || {
+          should_skip commit-format || block commit-format "$err"
+        }
+      fi
+      if ! err=$(scan_staged_secrets 2>&1); then
+        should_skip secret || block secret "$err"
+      fi
+      lint=$(detect_lint_cmd)
+      if [ -n "$lint" ]; then
+        if ! run_bounded_lint "$lint" >/dev/null 2>&1; then
+          should_skip format || block format "lint failed or timed out (CLAUDE_ENG_LINT_TIMEOUT=${CLAUDE_ENG_LINT_TIMEOUT:-30}s): $lint"
+        fi
+      fi
+    fi
+    ;;
+
+  Edit|Write|MultiEdit)
+    target=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+    [ -z "$target" ] && exit 0
+
+    # Shell self-modification: skip all checks.
+    case "$target/" in "$SHELL_ROOT"/*) exit 0 ;; esac
+
+    # Edit on protected branch
+    if is_protected_branch; then
+      should_skip branch || block branch "edit on protected branch blocked: $target"
+    fi
+
+    # Outside registry
+    if ! path_in_scope "$target"; then
+      should_skip out-of-scope || block out-of-scope "edit outside registry blocked: $target"
+    fi
+
+    # Sensitive files
+    base=$(basename "$target")
+    case "$base" in
+      .env|.env.*|*.pem|credentials|credentials.*|id_rsa|id_rsa.*|id_ed25519|id_ed25519.*)
+        should_skip sensitive || block sensitive "sensitive file edit blocked: $target"
+        ;;
+    esac
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/session_start.sh
+++ b/.claude/hooks/session_start.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SHELL_ROOT="${CLAUDE_ENG_SHELL_ROOT:-}"
+[ -n "$SHELL_ROOT" ] && [ -d "$SHELL_ROOT/.claude/hooks/helpers" ] || exit 0
+
+. "$SHELL_ROOT/.claude/hooks/helpers/cwd_guard.sh"
+. "$SHELL_ROOT/.claude/hooks/helpers/branch_guard.sh"
+
+# 1) Shell self-sync check — always runs regardless of target cwd.
+# Gated by .claude/state/last-shell-fetched stamp (SESSION_START_FETCH_TTL
+# seconds, default 21600 = 6 h). Fetch is bounded by
+# SESSION_START_FETCH_TIMEOUT (default 5 s) via timeout(1)/gtimeout(1).
+# See SPEC §6.5(a).
+_session_should_fetch() {
+  local stamp="$SHELL_ROOT/.claude/state/last-shell-fetched"
+  [ -f "$stamp" ] || return 0
+  local ttl="${SESSION_START_FETCH_TTL:-21600}"
+  local mtime now
+  if mtime=$(stat -c %Y "$stamp" 2>/dev/null); then
+    :
+  elif mtime=$(stat -f %m "$stamp" 2>/dev/null); then
+    :
+  else
+    return 0
+  fi
+  now=$(date +%s)
+  [ "$((now - mtime))" -ge "$ttl" ]
+}
+
+_session_run_fetch() {
+  local stamp="$SHELL_ROOT/.claude/state/last-shell-fetched"
+  local secs="${SESSION_START_FETCH_TIMEOUT:-5}"
+  local timeout_bin=""
+  if command -v timeout >/dev/null 2>&1; then
+    timeout_bin=timeout
+  elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_bin=gtimeout
+  fi
+  mkdir -p "$(dirname "$stamp")" 2>/dev/null
+  if [ -n "$timeout_bin" ]; then
+    (cd "$SHELL_ROOT" && "$timeout_bin" "$secs" git fetch --quiet 2>/dev/null) \
+      && touch "$stamp"
+  else
+    (cd "$SHELL_ROOT" && git fetch --quiet 2>/dev/null) \
+      && touch "$stamp"
+  fi
+}
+
+if command -v git >/dev/null 2>&1; then
+  if (cd "$SHELL_ROOT" && git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+    _session_should_fetch && _session_run_fetch
+    # `behind` reads local refs (possibly up to TTL stale by design).
+    behind=$(cd "$SHELL_ROOT" && git rev-list --count HEAD..@{u} 2>/dev/null || echo 0)
+    if [ "${behind:-0}" -gt 0 ]; then
+      printf '[claude-eng-shell] shell repo is %s commit(s) behind origin. consider pulling.\n' "$behind"
+    fi
+  fi
+fi
+
+# 2) Session restore — only when target cwd is in the registry.
+in_scope || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+
+branch=$(current_branch)
+[ -z "$branch" ] && exit 0
+printf '[claude-eng-shell] branch: %s\n' "$branch"
+
+if [ -f MISSION.md ]; then
+  printf '[MISSION summary]\n'
+  head -n 20 MISSION.md
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  body=$(gh pr view --json body --jq .body 2>/dev/null || true)
+  if [ -n "$body" ]; then
+    printf '[current PR body]\n%s\n' "$body" | head -c 8192
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SHELL_ROOT="${CLAUDE_ENG_SHELL_ROOT:-}"
+[ -n "$SHELL_ROOT" ] && [ -d "$SHELL_ROOT/.claude/hooks/helpers" ] || exit 0
+
+. "$SHELL_ROOT/.claude/hooks/helpers/cwd_guard.sh"
+
+in_scope || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+
+# Simple modulo throttle: suggest only when response_count is a multiple of N.
+count_file="$SHELL_ROOT/.claude/state/stop_count"
+count=$(cat "$count_file" 2>/dev/null || echo 0)
+count=$((count + 1))
+printf '%s\n' "$count" > "$count_file"
+
+throttle_n=${CLAUDE_ENG_STOP_THROTTLE:-5}
+[ $((count % throttle_n)) -ne 0 ] && exit 0
+
+# Suggest /review when uncommitted changes are present.
+if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+  printf '[claude-eng-shell] uncommitted changes present. consider /review.\n' >&2
+fi
+
+exit 0

--- a/.claude/hooks/user_prompt_submit.sh
+++ b/.claude/hooks/user_prompt_submit.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SHELL_ROOT="${CLAUDE_ENG_SHELL_ROOT:-}"
+[ -n "$SHELL_ROOT" ] && [ -d "$SHELL_ROOT/.claude/hooks/helpers" ] || exit 0
+
+. "$SHELL_ROOT/.claude/hooks/helpers/cwd_guard.sh"
+in_scope || exit 0
+
+# Delegate to the canonical work-state helper (SPEC §5.5). Same source as
+# /status — so the per-turn injection and the on-demand command never drift.
+# shellcheck disable=SC1090,SC1091
+. "$SHELL_ROOT/.claude/hooks/helpers/status.sh"
+status_compact
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,56 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/pre_tool_use.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/post_tool_use.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/stop.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/user_prompt_submit.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/session_start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #3

## Goal
Wire the five Claude Code hooks and their 14 helper modules, registered via `.claude/settings.json`. This PR makes the discipline enforcement layer actually fire.

## How this serves the mission
SPEC §3.2.1 (hook command path resolution), §6.1–§6.5 (every PreToolUse / PostToolUse / SessionStart / UserPromptSubmit / Stop behavior), and §5.5 (status helper canonical implementation).

## Plan
Bootstrap PR per SPEC §16.15 (build steps 6–8). All hook scripts source helpers via `$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/helpers/`, the single mechanism that survives both the workspace clone and external-path registration.

Key design choices already locked in SPEC:
- Hooks are guardrails, not sandboxes (SPEC §6.1 framing) — bypass-suspect commands warn, downstream matchers still fire.
- All `git <subcommand>` matchers use the shared `GIT_PREFIX` ERE fragment so `-c`/`-C`/`--no-pager` prefixes never silently skip the gate.
- `status.sh` is the single source of truth — `/status` and `UserPromptSubmit` both delegate to it.

## Alternatives considered
- **Inline helper logic in each hook**: rejected — duplicated regex/branch logic was the bug source SPEC §6.1 Git option-prefix tolerance was added to fix.
- **Per-helper PRs**: rejected — helpers and hooks are mutually-coupled (helpers are sourced by hooks); per-file PRs create incoherent intermediate states.

## Key context
- pre_tool_use.sh — SPEC §6.1
- helpers/git_matcher.sh::GIT_PREFIX — SPEC §6.1
- helpers/status.sh — SPEC §5.5
- helpers/ship_mode.sh — SPEC §5.7.1
- helpers/pr_cache.sh — SPEC §5.4

## Checklist
- [x] Add hook system files
- [x] Push branch + open draft PR
- [x] Ready for merge
- [x] Merge

## Out of scope
Templates (#4), subagents (#5), commands + docs (#6), CI + smoke (#7).

## Risks
None — bootstrap exception per SPEC §16.15. Behavior is covered by the smoke test landing in #6.

## Test plan
- [~] N/A — smoke ships in #6.

## Docs touched
- [~] N/A — SPEC.md is the SSOT (merged at 91bd47e).

## Ship gate
- [x] PR body curated
- [~] tests / code-review / security / docs / CI — N/A (SPEC §16.15 bootstrap)
