### PR TITLE
feat(#5): PR/issue/mission/ADR templates

### DIFF
--- a/.claude/templates/adr.md
+++ b/.claude/templates/adr.md
@@ -1,0 +1,21 @@
+# ADR {{ number }}: {{ title }}
+
+- Date: {{ today }}
+- Status: Proposed
+- Context PR: #{{ pr }}
+
+## Context
+<Why is this decision needed?>
+
+## Decision
+<What was decided?>
+
+## Alternatives considered
+- <Alternative 1>: <Why rejected>
+- <Alternative 2>: <Why rejected>
+
+## Consequences
+<Outcomes — positive, negative, neutral>
+
+## Notes
+<Reference docs, experiments, measurements>

--- a/.claude/templates/issue.md
+++ b/.claude/templates/issue.md
@@ -1,0 +1,15 @@
+## What
+<What's broken / what do we need?>
+
+## Why
+<Which MISSION.md item or metric does this serve?>
+
+## Acceptance criteria
+- [ ] <Verifiable condition 1>
+- [ ] <Verifiable condition 2>
+
+## Out of scope
+<What this issue does NOT cover>
+
+## Notes
+<Links, prior discussion, related issues/PRs>

--- a/.claude/templates/issue_template_for_target.md
+++ b/.claude/templates/issue_template_for_target.md
@@ -1,0 +1,14 @@
+<!-- Install as .github/ISSUE_TEMPLATE/default.md in the target repo. claude-eng-shell's /onboard suggests this when absent. -->
+
+## What
+
+## Why
+<Which MISSION item or metric does this serve?>
+
+## Acceptance criteria
+- [ ] ...
+- [ ] ...
+
+## Out of scope
+
+## Notes

--- a/.claude/templates/mission.md
+++ b/.claude/templates/mission.md
@@ -1,0 +1,15 @@
+# Mission
+
+## What this exists for
+<One paragraph — what would break if this project didn't exist?>
+
+## Success looks like
+<3-5 observable metrics or scenarios>
+
+## Explicitly NOT goals
+<Tempting directions we intentionally don't take>
+
+## Stakeholders
+<Primary users, decision makers>
+
+## Last reviewed: {{ today }}

--- a/.claude/templates/pr_body.md
+++ b/.claude/templates/pr_body.md
@@ -1,0 +1,50 @@
+{{ closes_or_refs }} #{{ issue }}
+
+## Goal
+<Work item in one sentence>
+
+## How this serves the mission
+<Which MISSION.md item does this contribute to?>
+
+## Plan
+<From planner output>
+
+## Alternatives considered
+- <Alternative 1>: <one-line why-not>
+- <Alternative 2>: <one-line why-not>
+(If forced choice — single viable approach — say so explicitly with a one-line justification.)
+
+## Key context
+<file:line — only things currently shaping decisions, curated>
+
+## Checklist
+- [ ] **Doc**: ...
+- [ ] **Doc**: ...
+- [ ] **Test**: ...
+- [ ] **Code**: ...
+
+## Out of scope
+<What this PR does NOT do>
+
+## Risks
+<Compatibility, performance, data, security concerns>
+
+## Open questions
+<Must be resolved before ship>
+
+## Decisions
+<Important trade-offs and choices, dated. Irreversible decisions go to ADRs with links here.>
+
+## Test plan
+- [ ] <Test item>
+
+## Docs touched
+- [ ] MISSION.md / CLAUDE.md / ARCHITECTURE.md / ADR / README
+
+## Ship gate
+- [ ] All tests pass
+- [ ] code-reviewer passed
+- [ ] (conditional) security-reviewer passed
+- [ ] Docs in sync
+- [ ] PR body curated
+- [ ] CI green

--- a/.claude/templates/pr_template_for_target.md
+++ b/.claude/templates/pr_template_for_target.md
@@ -1,0 +1,23 @@
+<!-- Install as .github/PULL_REQUEST_TEMPLATE.md in the target repo. claude-eng-shell's /onboard suggests this when absent. -->
+
+Closes #
+
+## Goal
+
+## Plan
+
+## Checklist
+- [ ] **Doc**: ...
+- [ ] **Test**: ...
+- [ ] **Code**: ...
+
+## Risks
+
+## Test plan
+- [ ] ...
+
+## Ship gate
+- [ ] tests pass
+- [ ] review pass
+- [ ] docs in sync
+- [ ] CI green


### PR DESCRIPTION
Closes #5

## Goal
Add the six `.claude/templates/` files — the single source of truth that every slash command substitutes into PRs, issues, mission stubs, and ADRs.

## How this serves the mission
SPEC §9 (template specifications) + §9.3.1 (section owners). The planner's mandatory `Alternatives considered` section needs a slot in `pr_body.md` for SPEC §4.1 to be implementable.

## Plan
Bootstrap PR per SPEC §16.15 (build step 3). Templates are loaded by name from `$CLAUDE_ENG_SHELL_ROOT/.claude/templates/`; commands reference them by relative path within the shell, never copied into the target.

## Alternatives considered
- **Inline the template text in each command**: rejected — turns six small files into thirty duplicated copies; first edit drifts. The §9 single-source pattern exists for this reason.
- **Per-template PRs**: rejected — six files totaling 138 lines; one PR is the right unit.

## Key context
- `.claude/templates/pr_body.md` — SPEC §9.3 (Alternatives slot is load-bearing for planner contract)
- `.claude/templates/issue.md` — SPEC §9.2 (Acceptance criteria + Why)
- `.claude/templates/mission.md` — SPEC §9.1 (used by /onboard when MISSION absent)

## Checklist
- [x] Add templates
- [x] Push branch + open draft PR
- [x] Ready for merge
- [x] Merge

## Out of scope
Subagents (#4 → next PR), commands + docs, CI + smoke.

## Risks
None — bootstrap exception per SPEC §16.15.

## Test plan
- [~] N/A — smoke test (#6) grep-asserts the `Alternatives considered` slot.

## Docs touched
- [~] N/A — SPEC.md is the SSOT (merged at 91bd47e).

## Ship gate
- [x] PR body curated
- [~] tests / code-review / security / docs / CI — N/A (SPEC §16.15 bootstrap)
