### PR TITLE
feat(#9): nine slash commands (onboard, file-issue, work-on, ship, etc.)

### DIFF
--- a/.claude/commands/adr.md
+++ b/.claude/commands/adr.md
@@ -1,0 +1,17 @@
+---
+description: Write an Architecture Decision Record in the target repo. For irreversible decisions only.
+argument-hint: <title>
+---
+
+`$ARGUMENTS` is the ADR title.
+
+**ADR vs PR body Decisions**:
+- ADR — irreversible, system-level. DB engine change, API spec, auth scheme, etc. Once merged, costly to reverse.
+- PR body Decisions — reversible, PR-scoped. Default option choice, library preference, etc. Explained within this PR.
+
+Confirm with the user that this decision warrants an ADR. If yes:
+
+1. Check `docs/ADRs/` exists (else confirm creation permission).
+2. Determine the next number: `ls docs/ADRs/ 2>/dev/null | grep -oE '^[0-9]+' | sort -n | tail -1`, then +1, zero-padded to 4 digits.
+3. Create `docs/ADRs/NNNN-<kebab-title>.md` from `$CLAUDE_ENG_SHELL_ROOT/.claude/templates/adr.md`.
+4. Add a link `→ ADR-NNNN: <title>` to the current PR body's Decisions section.

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,15 @@
+---
+description: Query the audit log. Recent blocks, escapes, warns.
+argument-hint: [<filter>]
+---
+
+Query `$CLAUDE_ENG_SHELL_ROOT/.claude/audit/audit.jsonl`.
+
+If `$ARGUMENTS` is empty, show the last 50 lines.
+With an argument, grep by substring (e.g. `force-push`, `escape`, `2026-05-19`).
+
+Aggregate:
+- Escape count per category.
+- Most-escaped category — signal for hook tuning.
+
+Format for human readability, one line each: `<ts> <event>/<decision> [<category>] <reason>`.

--- a/.claude/commands/file-issue.md
+++ b/.claude/commands/file-issue.md
@@ -1,0 +1,24 @@
+---
+description: Create a GitHub issue. Enforces MISSION reference and acceptance criteria.
+argument-hint: [--quick] <description>
+---
+
+Create an issue.
+
+1. Parse `$ARGUMENTS`:
+   - With `--quick`: one-line issue (label `chore`), ask only for one acceptance criterion.
+   - Otherwise: confirm title, body, label with the user.
+2. The body follows the structure of `$CLAUDE_ENG_SHELL_ROOT/.claude/templates/issue.md`. MISSION reference and acceptance criteria must be filled.
+3. **Rationale check** (mandatory; not skipped in Auto / unattended mode). Before `gh issue create`, surface to the user:
+   - **(a) MISSION fit**: which MISSION item does this serve?
+   - **(b) Why now**: what changes if this waits a week / a quarter?
+   - **(c) Existing-issue / open-PR coverage**: would a comment on an existing issue, or a follow-up note in an open PR, suffice instead?
+   "Weak" means any of (a)–(c) cannot be answered in a sentence, or the answer reduces to "to be tidy" / "someday" / "while I'm in the area." If any of (a)–(c) is weak, refine the issue or drop the request instead of filing. This is a moment of reflection, not a form to fill.
+4. **Reviewer gate** — invoke the `issue-reviewer` subagent (see SPEC §4.7) on the proposed body. Pass the body, the target MISSION.md, and the `gh issue list --state open --limit 100 --json number,title,body` snapshot. Parse the verdict line (`^VERDICT: (ship|refine|block)`).
+   - **`ship`**: proceed to step 5.
+   - **`refine: <feedback>`**: revise the body per the one-line feedback. Re-invoke `issue-reviewer` on the revised body. After two consecutive `refine` verdicts on the latest body, escalate to the user (or, in unattended mode, treat as `block`).
+   - **`block: <reason>`**: do NOT call `gh issue create`. In attended mode: report the reason to the user and stop. In unattended mode: append one line to `$CLAUDE_ENG_SHELL_ROOT/.claude/state/issue-block.log` naming the rejected title and reason, then stop.
+5. Call `gh issue create --title "..." --body "..." --label "..."`.
+6. Output the created issue number and URL.
+
+**Forbidden**: creating an issue with empty or ambiguous acceptance criteria, with a weak rationale that didn't pass the §3 check, OR with a non-`ship` verdict from `issue-reviewer`. If unclear, re-ask the user and stop.

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,0 +1,23 @@
+---
+description: One-time check right after cloning a target repo. Reports on upstream, permissions, SSOT, .github/, branch protection, CI.
+---
+
+Perform an initial check of the target repo. **No automatic changes.** All recommendations are for the user to review and execute.
+
+Report in order:
+
+1. **Upstream check**: `gh repo view --json isFork,parent`. If it's a fork, block with a message and stop.
+2. **Permission check**: `gh repo view --json viewerPermission`. If push permission (`ADMIN`/`MAINTAIN`/`WRITE`) is missing, advise and stop.
+3. **Target SSOT check**: one line per file:
+   - `MISSION.md` (absent → strong warning + draft proposal based on `$CLAUDE_ENG_SHELL_ROOT/.claude/templates/mission.md`)
+   - `README.md`
+   - `CLAUDE.md`
+   - `docs/ARCHITECTURE.md`
+4. **`.github/` check**:
+   - `.github/ISSUE_TEMPLATE/` present? If absent → propose installing `$CLAUDE_ENG_SHELL_ROOT/.claude/templates/issue_template_for_target.md`.
+   - `.github/PULL_REQUEST_TEMPLATE.md` present? If absent → propose installing `$CLAUDE_ENG_SHELL_ROOT/.claude/templates/pr_template_for_target.md`.
+   - `.github/CODEOWNERS` present? If absent → recommend.
+5. **Branch protection**: `gh api repos/{owner}/{repo}/branches/main/protection`. Report missing items (PR required, review required, status checks required, force push blocked). Setup requires admin so print commands only.
+6. **CI presence**: check `.github/workflows/`. If absent → recommend appropriate workflows.
+
+Each item gets ✓ or ✗ and a one-line summary. End with a "Recommended next actions" block.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,14 @@
+---
+description: Invoke code-reviewer (+ security-reviewer if relevant).
+argument-hint: [--staged | <base>]
+---
+
+Parse `$ARGUMENTS`:
+- `--staged`: review staged diff only.
+- `<base>` as commit-ish: review from base to HEAD.
+- No argument: default base (origin/main or PR base) to HEAD.
+
+Steps:
+1. Invoke `code-reviewer` subagent with diff + changed-file context + target `MISSION.md` + referenced issue body + PR body as input.
+2. If the diff touches a security surface (auth/session/input/deps/crypto/IO boundary), invoke `security-reviewer` as well.
+3. Combine the results and report. Don't auto-apply fixes unless the user asks.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,24 @@
+---
+description: Gate the PR for ready transition — review, tests, doc sync, PR body curation, CI, then gh pr ready.
+---
+
+Execute ship steps in order. If any step fails, stop immediately and report.
+
+0. **Resolve mode** via `resolve_mode` from `$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/helpers/ship_mode.sh`. Priority: `--mode=` flag → `$CLAUDE_ENG_SHELL_MODE` → `.claude/state/mode` → default `attended`. Unknown values fail closed to `attended` with a stderr warning. See SPEC §5.7.1.
+1. Invoke `code-reviewer`. Blocker → stop.
+2. If the diff touches a security surface, invoke `security-reviewer`. High/Medium findings → stop.
+3. Final SSOT sync check via `doc-writer`. Missing doc updates → stop and ask user.
+4. **Run the full test suite** (`$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/helpers/tests.sh` → `run_tests`, or `detect_test_cmd` result). Failure → stop.
+5. Curate the PR body (tidy stale items, check ship gate). Use `/sync-pr`.
+6. Verify `Closes #N` — single/final PR uses `Closes`, intermediate uses `Refs`. Check the first line of the PR body.
+7. CI snapshot: `gh pr checks --json state`. `failure`/`cancelled` → stop.
+7.5. **Checklist audit** — re-fetch the PR body and scan for any `- [ ]` line. Per SPEC §1.4, a merged PR body must reflect truth: each unchecked item is in one of three terminal states — ticked (`- [x]`) because it was done, marked `- [~] N/A — <one-line reason>` because it intentionally won't be done, or removed from the body. Apply to every checklist (Plan, Test plan, Docs touched, Ship gate). If any `- [ ]` remains after the pass, stop and ask the user — do NOT proceed to `gh pr ready`. Same rule on auto-close for issues: post a closing comment confirming each acceptance-criterion item, ticked or N/A'd.
+8. `gh pr ready` — draft → ready. Then `gh pr checks --watch` in background; return immediately.
+9. If mode is `attended`: stop here and report (existing behavior — human picks up review and merge).
+10. If mode is `unattended`: classify the PR state via `ship_classify_blocker` (also in `ship_mode.sh`). Branch per SPEC §5.7.1:
+    - `clean` → `gh pr merge --auto --merge --delete-branch`. No-fast-forward merge commit; PR branch commits stay on `main` (preserves the Doc → Test → Code arc per SPEC §1.2). If auto-merge is disabled at the repo level, fall back to the park path with reason `auto-merge-disabled`.
+    - `soft` → one self-fix-and-push attempt (commit `fix(#N): ...`), then return to CI-wait. A second `soft` outcome escalates to `hard`.
+    - `hard` → park: `gh pr comment` (deterministic state summary) + apply label `unattended-parked` (create on demand; idempotent — edit-last or skip if already labeled) + append one line to `$CLAUDE_ENG_SHELL_ROOT/.claude/state/unattended-park.log` + stop.
+11. Emit a single summary line to stdout naming the terminal action taken: `stopped at ready`, `merged`, or `parked: <reason>`.
+
+At the end, print the PR URL and follow-up notes (reviewer mentions, etc.).

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,16 @@
+---
+description: One-shot summary of current work state.
+---
+
+Source `$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/helpers/status.sh` and call `status_compact`. That helper is the canonical implementation — the `UserPromptSubmit` hook delegates to the same function, so the per-turn summary and the on-demand `/status` block never drift. See SPEC §5.5.
+
+Compact-mode output (one line each, `-` for missing):
+
+- `branch:` current branch + dirty flag
+- `issue:` # and title — extracted from `Closes #N` / `Refs #N` in the PR body
+- `pr:` # and draft/ready state, plus `[x/y tasks]` checklist progress, plus CI status
+- `phase:` inferred from the next unchecked checklist item (Doc / Test / Code / Review / Ship)
+- `next:` first unchecked checklist item
+- `mode:` attended / unattended via `ship_mode.sh::resolve_mode`
+
+For diff-friendly machine output: `status_json` instead.

--- a/.claude/commands/sync-pr.md
+++ b/.claude/commands/sync-pr.md
@@ -1,0 +1,15 @@
+---
+description: Update the current PR body to match commit history and local intent. Aborts on external-edit conflict.
+---
+
+Update the PR body. External-edit detection is real and persistent — see SPEC §5.4.
+
+1. Get current PR number: `gh pr view --json number --jq .number`. None → stop.
+2. Refetch remote body: `gh pr view --json body --jq .body`.
+3. Source `$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/helpers/pr_cache.sh` and call `pr_cache_check <pr_number> <remote_body_sha256>`. If it exits non-zero (external edit detected), report the conflict to the user and abort.
+4. If the cache matches (or no cache exists yet), apply intended changes (checklist updates, Decisions additions, etc.) via `gh pr edit --body "..."`.
+5. After a successful edit, call `pr_cache_write <pr_number> <new_body_sha256> <current_head_sha>` so the next sync starts from a known-good baseline.
+6. Curation principles:
+   - Tidy stale items.
+   - If history is needed, keep one line per entry in a separate "Changelog" section.
+   - Editorial, not append-only.

--- a/.claude/commands/work-on.md
+++ b/.claude/commands/work-on.md
@@ -1,0 +1,47 @@
+---
+description: Take an issue, create branch + draft PR, invoke planner — all in one. Supports --base for topic-branch / experimental work (SPEC §10.5).
+argument-hint: <issue#> [--base <branch>]
+---
+
+Parse `$ARGUMENTS`: the issue number plus optional `--base <branch>` (default `main`). Do the following in order:
+
+1. `gh issue view <#> --json title,body,labels` — read the issue. Print it and give the user a brief summary.
+2. **Acceptance criteria check** — if the issue body has no criteria or is vague, ask the user to fix it and stop. **Don't start work with an ambiguous goal.**
+3. **Resolve target base** — let `BASE` = `--base` arg (default `main`). Then `git fetch origin && git checkout "$BASE" && git pull --ff-only`. If `BASE != main` and the named branch isn't reachable locally or remotely, fail loudly — `/work-on` does NOT auto-create alternate bases. See SPEC §10.5 for the topic-branch pattern.
+4. Create branch:
+   - `USER=$(gh api user --jq .login)`
+   - `TYPE` = from issue label or user confirmation (one of feat/fix/docs/refactor/perf/test/style/build/ci/chore/revert)
+   - `SLUG` = kebab-case abbreviation of issue title
+   - `git checkout -b "${USER}/${TYPE}/<#>-${SLUG}"`
+   - If the branch already exists on remote: `git pull --ff-only origin <branch>`.
+5. **Invoke planner agent** — pass issue body, target `MISSION.md`, target `CLAUDE.md`, **and the resolved `BASE`** as input. Receive the plan markdown. The planner output must include non-empty `## Alternatives considered` AND `## Target base` sections (mandatory per SPEC §4.1); the `Target base` value must equal `BASE`. Reject and re-invoke if either is missing or empty.
+6. **Reviewer gate** — invoke the `plan-reviewer` subagent (see SPEC §4.8) on the planner output. Pass the planner output, the issue body, and the target MISSION.md. Parse the verdict line (`^VERDICT: (ship|refine|block)`).
+   - **`ship`**: proceed to step 7.
+   - **`refine: <feedback>`**: re-invoke `planner` with the one-line feedback. Re-invoke `plan-reviewer` on the new output. After two consecutive `refine` verdicts on the latest plan, escalate to the user (or, in unattended mode, treat as `block`).
+   - **`block: <reason>`**: stop and post a `gh issue comment` on the linked issue naming the structural problem. In unattended mode, also append one line to `$CLAUDE_ENG_SHELL_ROOT/.claude/state/plan-block.log`.
+7. **Wait for user approval of the plan.** Approval requires an **approach check**: confirm with the user that the chosen approach beats the alternatives the planner surfaced, not just that the plan exists. If the alternatives are weak (single option without an explicit forced-choice justification), refine before approval. The approach check is not skipped in Auto / unattended mode. **In `unattended` mode, a clean `plan-reviewer` verdict from step 6 counts as approval** — no human is present, and the reviewer is the substitute.
+8. Once approved, **write Phase A (Doc) and make it the first commit on the branch.** Never open the PR with an empty seed commit.
+   ```
+   # …edit the SSOTs identified by the plan (MISSION, README, CLAUDE.md, ARCHITECTURE, ADR)…
+   git add <changed SSOTs>
+   # First-line trailer is `Closes #<#>` when BASE == main; otherwise `Refs #<#>`.
+   # The issue should auto-close only when work reaches main (SPEC §10.4 / §10.5).
+   TRAILER="Closes #<#>"; [ "$BASE" != "main" ] && TRAILER="Refs #<#>"
+   # Co-Authored-By trailer is toggleable (SPEC §10.2). Source the helper
+   # and conditionally include the line — the `${COAUTHOR:+…}` expansion
+   # injects the leading blank line ONLY when the trailer is enabled, so
+   # `off` users don't get a trailing blank in the commit message.
+   . "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/helpers/coauthor.sh"
+   COAUTHOR=$(coauthor_trailer)
+   git commit -m "<type>(#<#>): <subject>
+
+   ${TRAILER}${COAUTHOR:+
+
+   ${COAUTHOR}}"
+   git push -u origin HEAD
+   gh pr create --draft --base "$BASE" --title "<type>(#<#>): <subject>" --body "<filled pr_body.md>"
+   ```
+   `Closes` vs `Refs` — the rule above is the default; the user may override on split (intermediate PR → `Refs`, final consolidator → `Closes`).
+
+   If Phase A isn't ready to commit (e.g. planner output needs more clarification), **defer the PR** — keep the issue + plan in conversation. Don't fall back to an empty seed commit just to open the draft PR; see SPEC §5.3.
+9. Print "ready to start" message. Continue with the next phase (Test).


### PR DESCRIPTION
Closes #9

## Goal
Add the nine user-facing slash commands that drive the work-item lifecycle: `/onboard`, `/file-issue`, `/work-on`, `/sync-pr`, `/status`, `/review`, `/ship`, `/adr`, `/audit`.

## How this serves the mission
SPEC §5 (every slash command) + §5.7.1 (mode-gated /ship) + §10.5 (topic-branch /work-on --base) + §5.4 (sync-pr external-edit check).

## Plan
Bootstrap PR per SPEC §16.15 (build step 9). Commands are markdown skill definitions invoked via Claude Code's Skill tool. They reference helpers/ via `$CLAUDE_ENG_SHELL_ROOT` path (the same convention the hooks use, SPEC §3.2.1).

## Alternatives considered
- **Add commands incrementally as features land**: rejected — commands cite each other (`/ship` calls `/sync-pr`, `/work-on` invokes plan-reviewer, etc.); shipping piecemeal leaves dangling references in the merged tree.
- **Combine with process docs in one PR**: rejected — commit-type semantics differ (feat vs docs). Split into #9 (this PR) and #10 (docs).

## Key context
- `work-on.md` — SPEC §5.3 + §10.5 (--base topic-branch flow)
- `ship.md` — SPEC §5.7 (8-step ship sequence + step 7.5 checklist audit)
- `file-issue.md` — SPEC §5.2 (rationale triad + issue-reviewer gate)

## Checklist
- [x] Add command files
- [x] Push branch + open draft PR
- [x] Ready for merge
- [x] Merge

## Out of scope
Process docs + CLAUDE.md (#10 next), CI + smoke.

## Risks
None — bootstrap exception per SPEC §16.15.

## Test plan
- [~] N/A — smoke (#7) grep-asserts the load-bearing invariants.

## Docs touched
- [~] N/A — SPEC.md is the SSOT (merged at 91bd47e).

## Ship gate
- [x] PR body curated
- [~] tests / code-review / security / docs / CI — N/A (SPEC §16.15 bootstrap)
