### PR TITLE
docs(#15): document four missing env-var toggles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,13 @@ All optional. Per-target state files live under `.claude/state/` (gitignored); e
 | Co-Authored-By trailer | `coauthor` | `CLAUDE_ENG_COAUTHOR` | `on` | Include the trailer in `/work-on` commits (§10.2) |
 | Status cache TTL | — | `STATUS_CACHE_TTL` | `5` | Seconds before re-querying `gh` from `_status_collect` (§5.5) |
 | Session-start fetch TTL | — | `SESSION_START_FETCH_TTL` | `21600` | Seconds before the shell-behind `git fetch` runs again (§6.5) |
+| Session-start fetch timeout | — | `SESSION_START_FETCH_TIMEOUT` | `5` | Per-fetch `timeout(1)` bound when the TTL elapses (§6.5) |
 | Commit-time lint timeout | — | `CLAUDE_ENG_LINT_TIMEOUT` | `30` | Bound on the commit gate's lint (§6.1) |
+| Stop-hook throttle | — | `CLAUDE_ENG_STOP_THROTTLE` | `5` | Suggest `/review` every Nth response from the Stop hook (§6.3) |
+| Unattended park log | — | `SHIP_PARK_LOG_PATH` | `.claude/state/unattended-park.log` | Where `/ship` appends park entries in `unattended` mode (§5.7.1) |
+| PR cache repo override | — | `PR_CACHE_REPO` | — | Override the `owner/repo` `pr_cache` queries; falls back to `gh repo view` of the cwd (§5.4) |
+
+*`STATUS_CACHE_DIR_OVERRIDE` is internal-only (smoke-test plumbing for `helpers/status.sh`) and intentionally not listed.*
 
 ## Docs
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -695,7 +695,7 @@ Explicit entry point for updating the PR body. The main assistant does this auto
 
 Refetch the remote body once before updating. The shell stores the SHA-256 of the last body it saw at `.claude/state/pr-cache/<owner>%2F<repo>__pr-<n>.json` (the `/` between owner and repo is URL-encoded as `%2F` so `<owner>/<repo>` slug boundaries survive the filename); the file holds at least `last_seen_body_sha256`, `last_synced_head`, and `last_synced_at`. If the remote body's SHA differs from `last_seen_body_sha256`, an external edit happened (reviewer, parallel session, GitHub UI) — the automatic update aborts with a stderr message naming the conflict, and merging is the human's call. After a successful sync the cache is rewritten. A corrupt cache file (unparseable / missing key) also aborts the sync rather than silently treating as "first sync."
 
-The cache lives under `.claude/state/`, which is gitignored — it's per-clone state, not part of the repo's history. The helper `.claude/hooks/helpers/pr_cache.sh` exports `pr_cache_read`, `pr_cache_write`, and `pr_cache_check`. `/ship` reuses the cache transitively by routing its body curation through `/sync-pr` (§5.7 step 5). `/work-on` doesn't update the body after PR creation, so it doesn't touch the cache directly; later edits go through `/sync-pr`.
+The cache lives under `.claude/state/`, which is gitignored — it's per-clone state, not part of the repo's history. The helper `.claude/hooks/helpers/pr_cache.sh` exports `pr_cache_read`, `pr_cache_write`, and `pr_cache_check`. The repo slug is derived from `gh repo view` of the cwd, overridable via `$PR_CACHE_REPO` (used by the smoke test suite). `/ship` reuses the cache transitively by routing its body curation through `/sync-pr` (§5.7 step 5). `/work-on` doesn't update the body after PR creation, so it doesn't touch the cache directly; later edits go through `/sync-pr`.
 
 ### 5.5 `/status`
 
@@ -762,7 +762,7 @@ Unknown values fail closed to `attended` and emit a stderr warning naming the of
 
 1. Post a `gh pr comment` with a deterministic state summary (blocker reason + current SHA + CI snapshot).
 2. Apply label `unattended-parked` (create the label on demand if missing). If the label is already present from a previous park on the same PR, `ship_park_pr` writes a single `park-suppressed: <reason>` line to the log instead of reposting the comment, and emits no comment to stdout. The original park comment remains canonical; the label remains applied.
-3. Append one line to `$CLAUDE_ENG_SHELL_ROOT/.claude/state/unattended-park.log` (shell-side, gitignored — not the target's MEMORY.md, not `audit.jsonl`). On suppressed repeat, only the `park-suppressed: <reason>` line is appended.
+3. Append one line to `${SHIP_PARK_LOG_PATH:-$CLAUDE_ENG_SHELL_ROOT/.claude/state/unattended-park.log}` (shell-side, gitignored — not the target's MEMORY.md, not `audit.jsonl`). The override exists for smoke-test isolation. On suppressed repeat, only the `park-suppressed: <reason>` line is appended.
 4. Stop. Do not toggle draft or self-assign.
 
 **Classifier robustness**: `ship_classify_blocker` fails closed to `hard` in two failure modes and emits a one-line stderr warning naming the cause:
@@ -872,7 +872,7 @@ Claude Code's `Stop` hook fires **after every model response**, not at session e
 - uncommitted changes + no recent review → suggest `/review`
 - recent commit + PR body checklist out of sync → suggest `/sync-pr`
 
-Suggestions print one line to stderr (no blocking). Throttling is a simple modulo — no per-category state file.
+Suggestions print one line to stderr (no blocking). Throttling is a simple modulo of N (default 5, overridable via `$CLAUDE_ENG_STOP_THROTTLE`) — no per-category state file.
 
 Session-level cleanup (branch tidy, temp files) belongs to a separate `SessionEnd` hook (where supported) or a user-invoked `/wrap`.
 

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -1883,6 +1883,28 @@ else
   ng "lint: run_bounded_lint helper missing (#29)"
 fi
 
+# ---------- 35. README env-var catalog SSOT (#15) ----------
+# The README "Configuration toggles" table is the user-facing SSOT for env
+# vars per SPEC §1.3. Every env var documented elsewhere in the shell must
+# also appear in the table. A missing row is the same drift class as a
+# missing SPEC TOC entry (§28). Mirrors the §27 multi-target loop idiom.
+README_MD="$SHELL_ROOT/README.md"
+if [ -f "$README_MD" ]; then
+  missing=""
+  for v in SESSION_START_FETCH_TIMEOUT CLAUDE_ENG_STOP_THROTTLE SHIP_PARK_LOG_PATH PR_CACHE_REPO; do
+    if ! grep -q "$v" "$README_MD"; then
+      missing="$missing $v"
+    fi
+  done
+  if [ -z "$missing" ]; then
+    ok "readme-toggles: all four env vars documented in README (#15)"
+  else
+    ng "readme-toggles: env vars missing from README Configuration toggles:$missing (#15)"
+  fi
+else
+  ng "readme-toggles: README.md not found at $README_MD (#15)"
+fi
+
 # ---------- restore registry ----------
 if [ -n "$ORIG_REG_BAK" ]; then
   mv "$ORIG_REG_BAK" "$ORIG_REG"


### PR DESCRIPTION
Closes #15

## Goal
Restore doc/code parity for the README "Configuration toggles" table by adding the four env-var knobs the codebase ships but never documented, plus a smoke grep-lock to prevent future drift. Also backfill three SPEC.md sections to name the env vars they previously described only by behavior.

## How this serves the mission
Direct service to **SPEC §1.3 Active SSOT maintenance**: the README presents itself as the exhaustive user-facing knob catalog ("All optional. … env vars take priority when set."), but four shipped env vars (`SESSION_START_FETCH_TIMEOUT`, `CLAUDE_ENG_STOP_THROTTLE`, `SHIP_PARK_LOG_PATH`, `PR_CACHE_REPO`) were missing. The smoke grep-lock added in §28-style enforces parity going forward (SPEC §11 CI awareness). The SPEC.md sync (surfaced by the `doc-writer` SSOT-sync gate) keeps the contract honest at the spec layer too.

## Plan
Strict-lane `docs` change collapsed to Doc → Test (no Code), three commits:

1. **Doc — README** — Extend the toggles table with four rows preserving the existing 5-column shape (`File: —` for env-only knobs). Each row carries the SPEC section anchor: §6.5, §6.3, §5.7.1, §5.4. Italicized footnote under the table records the decision to keep `STATUS_CACHE_DIR_OVERRIDE` internal-only.
2. **Test — smoke** — New `§35` block in `scripts/test/smoke.sh` mirroring the §27 multi-target loop and the §28 SSOT-string-lock idiom. Asserts each of the four env-var names appears literally in `README.md`.
3. **Doc — SPEC backfill** (added during `/ship` SSOT-sync check) — Three sections in SPEC.md previously described behavior the README now names by env var, but SPEC itself didn't. Inline one-line additions to §5.4 (`PR_CACHE_REPO`), §5.7.1 (`SHIP_PARK_LOG_PATH`), §6.3 (`CLAUDE_ENG_STOP_THROTTLE`). `§6.5`/`SESSION_START_FETCH_TIMEOUT` was already named in SPEC. No heading shifts → TOC unchanged.

## Alternatives considered
- **One combined Doc+Test commit**: faster, but breaks SPEC §1.2 "each phase its own commit when possible." Rejected — the 2-commit cost is trivial and the audit value is real.
- **Separate "Internal / test-only" sub-table** for `STATUS_CACHE_DIR_OVERRIDE`: cleanest taxonomically, but issue explicitly says "Out of scope: Reordering or restructuring the existing table." Rejected — italicized footnote records the decision without restructuring.
- **Per-knob grep-lock vs. single loop**: per-knob would balloon to four near-identical blocks. §27's loop-over-targets is the closest in-file precedent. Loop form chosen.
- **Defer SPEC.md backfill to a follow-up issue** (vs. closing the loop in this PR): rejected per Option B in the `doc-writer` report — the edits are tiny, mechanical, and naming env vars in SPEC gives future grep-locks something to anchor on.

## Key context
- `README.md:65-77` — existing Configuration toggles table; column shape and `—`/`(§X.Y)` precedents.
- `scripts/test/smoke.sh:1886-1906` — new §35 grep-lock block (next slot after §34).
- `scripts/test/smoke.sh:1580-1594` — §28 SSOT-string-lock pattern; §27 (line 1596+) multi-target loop idiom.
- `.claude/hooks/helpers/status.sh:14-19` — `STATUS_CACHE_DIR_OVERRIDE` comment confirms it's smoke-test plumbing, not a user knob.
- `SPEC.md` §5.4 / §5.7.1 / §6.3 — three sections now name their env-var overrides inline.

## Checklist
- [x] **Doc**: Add four env-var rows to README Configuration toggles table.
- [x] **Doc**: Italicized footnote noting `STATUS_CACHE_DIR_OVERRIDE` is internal-only.
- [x] **Test**: New §35 smoke section grep-locks the four env-var names against `README.md`.
- [x] **Doc**: Backfill SPEC.md §5.4, §5.7.1, §6.3 to name `PR_CACHE_REPO`, `SHIP_PARK_LOG_PATH`, `CLAUDE_ENG_STOP_THROTTLE` (post-SSOT-sync gate).

## Out of scope
- Adding new configuration knobs.
- Reordering or restructuring the existing toggles table.
- Exposing `STATUS_CACHE_DIR_OVERRIDE` as a user-facing knob.

## Risks
- **Smoke grep-lock too loose**: each env-var name is matched anywhere in `README.md`, not specifically in the Configuration toggles section. Symmetric to §27's accepted approach against SPEC.md. Scoping to the section block is a fine follow-up.
- **SPEC anchors stale if SPEC.md renumbers**: §6.5, §6.3, §5.7.1, §5.4 all verified to exist. No automated lock between README anchor text and SPEC headings; a follow-up could leverage `scripts/build_toc.sh` output for that.

## Test plan
- [x] `scripts/test/smoke.sh` runs and reports `pass=200 fail=0` (new §35 assertion is the +1).
- [x] `scripts/build_toc.sh --check` passes (SPEC inline edits did not shift headings).
- [~] CI green — enforced by `gh pr merge --auto` gate; will not fire if smoke or bash -n fail.

## Docs touched
- [x] README.md (the table + footnote)
- [x] SPEC.md (§5.4 / §5.7.1 / §6.3 inline env-var names)
- [x] scripts/test/smoke.sh (new §35 grep-lock; counts as Test, not docs, but listed for completeness)

## Ship gate
- [x] All tests pass (smoke 200/200 local; CI pending on commit 3)
- [x] code-reviewer passed (LGTM with non-blocking nits already acknowledged in Risks)
- [~] security-reviewer — N/A (docs + smoke only, no auth/input/deps/crypto)
- [x] Docs in sync (after the SPEC backfill commit; doc-writer SSOT-sync gate cleared)
- [x] PR body curated
- [~] CI green — enforced by `gh pr merge --auto` gate; merge will not fire until CI is green.
