### PR TITLE
refactor(#27): drop _protected_static_refs and PROTECTED_BRANCH_CASE_GLOB

### DIFF
--- a/.claude/hooks/helpers/branch_guard.sh
+++ b/.claude/hooks/helpers/branch_guard.sh
@@ -8,14 +8,6 @@
 # shellcheck disable=SC1090,SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/git_matcher.sh"
 
-# Static-name subset of the protected branches — the names that exist
-# without a glob (i.e. `main`, `master`). Used by detached-HEAD tip-equality
-# enumeration where for-each-ref is overkill. If you add a new static name
-# here, also add it to PROTECTED_BRANCH_* in helpers/git_matcher.sh.
-_protected_static_refs() {
-  printf '%s\n' main master
-}
-
 # Returns the current branch name, or the empty string if HEAD is detached.
 # Callers that need a human-readable label (including detached-HEAD context)
 # should use branch_label instead.
@@ -44,16 +36,19 @@ branch_label() {
   head_sha=$(git rev-parse --verify --quiet HEAD 2>/dev/null) || { printf ''; return; }
   short=$(git rev-parse --short HEAD 2>/dev/null) || short="${head_sha:0:7}"
   local ref
-  for ref in $(_protected_static_refs); do
+  # Static-name subset: `main`/`master` are constant; release/* is enumerated
+  # by the for-each-ref below. If you add a new static protected name, also
+  # extend PROTECTED_BRANCH_PATTERN in helpers/git_matcher.sh.
+  for ref in main master; do
     tip=$(_resolve_protected_ref "$ref") || continue
     if [ -n "$tip" ] && [ "$tip" = "$head_sha" ]; then
       printf 'HEAD@%s (detached, == %s)' "$short" "$ref"
       return
     fi
   done
-  # `refs/heads/release/*` mirrors the `release/*` segment of
-  # PROTECTED_BRANCH_CASE_GLOB in helpers/git_matcher.sh. If you change the
-  # glob there, update this refspec too.
+  # `refs/heads/release/*` mirrors the release/* segment of
+  # PROTECTED_BRANCH_PATTERN in helpers/git_matcher.sh. If you change the
+  # ERE there, update this refspec too.
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     tip="${line%% *}"
@@ -87,11 +82,12 @@ is_protected_branch() {
   if [ -z "$b" ]; then
     local head_sha tip
     head_sha=$(git rev-parse --verify --quiet HEAD 2>/dev/null) || return 1
-    for ref in $(_protected_static_refs); do
+    for ref in main master; do
       tip=$(_resolve_protected_ref "$ref") || continue
       [ -n "$tip" ] && [ "$tip" = "$head_sha" ] && return 0
     done
-    # Enumerate release/* tips. Glob mirrors PROTECTED_BRANCH_CASE_GLOB.
+    # Enumerate release/* tips. Glob mirrors the release/* segment of
+    # PROTECTED_BRANCH_PATTERN in helpers/git_matcher.sh.
     while IFS= read -r tip; do
       [ -n "$tip" ] && [ "$tip" = "$head_sha" ] && return 0
     done < <(git for-each-ref --format='%(objectname)' 'refs/heads/release/*' 2>/dev/null)

--- a/.claude/hooks/helpers/git_matcher.sh
+++ b/.claude/hooks/helpers/git_matcher.sh
@@ -4,39 +4,26 @@
 # subcommands tolerantly OR gate on protected branches.
 
 # PROTECTED_BRANCH_PATTERN is the ERE fragment naming branches the shell
-# treats as protected. Used by enforcement matchers (direct push, backmerge)
-# inside pre_tool_use.sh. PROTECTED_BRANCH_CASE_GLOB is the case-statement
-# form of the same policy. The two forms exist because bash globs and EREs
-# are different metacharacter languages — keeping both centralized closes
-# the drift surface between push/merge regex matchers and `is_protected_branch`'s
-# symbolic-ref check.
-#
-# Single source of truth for SPEC §6.1 "direct commit/push to protected
-# branch" and §6.1 "backmerge blocked". Adding a new protected pattern
-# (e.g. `hotfix/*`) is a one-edit change here. The `main master` static
-# subset is enumerated by `branch_guard.sh::_protected_static_refs` for
-# the detached-HEAD tip-equality check.
+# treats as protected. Single source of truth for SPEC §6.1 "direct
+# commit/push to protected branch" and "backmerge blocked"; adding a new
+# protected pattern (e.g. `hotfix/*`) is a one-edit change here.
 #
 # Behavior preserved byte-exact against the prior `release/\S+` ERE
 # matchers in pre_tool_use.sh: `release/foo` matches, `release/foo bar`
 # (whitespace) does not. The legacy `case "$b" in main|master|release/*)`
 # in branch_guard.sh was looser — its `*` glob would have matched
-# `release/foo bar` too — but git's own check-ref-format rejects branch
-# names with whitespace, so that codepath was unreachable in practice
-# and the refactor tightens an already-dead case rather than weakening
-# enforcement.
+# `release/foo bar` — but git's own check-ref-format rejects branch
+# names with whitespace, so that codepath was unreachable in practice.
 # Tightening further (e.g. `release/[^[:space:]/]+`) is a separate concern.
 #
-# Consumers: pre_tool_use.sh matchers use the ERE form via grep -qE
-# interpolation. branch_guard.sh::is_protected_branch uses the ERE
-# form via `grep -qE` (subprocess fork, but only 1–3 calls per hook —
-# tolerated for SSOT). The case-glob form is currently unused at
-# runtime; kept for callers that want a glob-context pattern without
-# spawning grep. See alternatives in PR #16.
+# Consumers: pre_tool_use.sh matchers interpolate the ERE form via
+# `grep -qE`; branch_guard.sh::is_protected_branch likewise uses
+# `grep -qE` (subprocess fork, 1–3 calls per hook — tolerated for SSOT).
+# branch_guard.sh enumerates the `main master` static-name subset
+# inline for the detached-HEAD tip-equality check; release/* is matched
+# via `git for-each-ref refs/heads/release/*`.
 # shellcheck disable=SC2034  # sourced by every hook that gates on branches
 PROTECTED_BRANCH_PATTERN='main|master|release/\S+'
-# shellcheck disable=SC2034  # kept for callers wanting a glob-context pattern
-PROTECTED_BRANCH_CASE_GLOB='main|master|release/*'
 
 # GIT_PREFIX is an ERE fragment that matches `git` followed by zero or more
 # standard git-level options between `git` and the subcommand. Used as a

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -2032,7 +2032,6 @@ fi
 ( . "$SHELL_ROOT/.claude/hooks/helpers/git_matcher.sh"
   fail36a=0
   [ -n "${PROTECTED_BRANCH_PATTERN:-}" ] || fail36a=1
-  [ -n "${PROTECTED_BRANCH_CASE_GLOB:-}" ] || fail36a=1
   # ERE form must match the expected positives.
   for b in main master release/foo release/2026-q2; do
     printf '%s' "$b" | grep -qE "^(${PROTECTED_BRANCH_PATTERN})$" || fail36a=1


### PR DESCRIPTION
Closes #27

## Goal
Remove two pieces of speculative code from #16 that the codebase has since disproved. `PROTECTED_BRANCH_PATTERN` stays as the single load-bearing constant; everything else folds inline.

## How this serves the mission
SPEC §1.3 (Active SSOT maintenance) — fewer unused symbols, smaller surface, less docstring-justified cruft. The helper and constant existed for problems the rest of the codebase later proved nonexistent (#21 showed shellcheck doesn't fire SC2046; #16 itself proved bash `case` won't accept the glob via variable expansion). External behavior is byte-identical.

## Plan
Single Code commit (relaxed-lane `refactor` per SPEC §1.2 — `Docs: n/a — refactor, no external behavior change`):

- **`git_matcher.sh`** — delete `PROTECTED_BRANCH_CASE_GLOB` + its `# shellcheck disable=SC2034` directive; trim the case-glob clauses from the header docstring so only `PROTECTED_BRANCH_PATTERN`'s rationale survives.
- **`branch_guard.sh`** — delete `_protected_static_refs`; inline `for ref in main master` at both call sites (`branch_label`, `is_protected_branch`); update the two cross-ref comments that pointed at `CASE_GLOB` to point at `PATTERN` instead.
- **`smoke.sh`** — drop the `[ -n "${PROTECTED_BRANCH_CASE_GLOB:-}" ]` non-emptiness sub-check from §36a. §36b drift-lock unaffected (the `main|master|release` literal still lives in `git_matcher.sh` via `PROTECTED_BRANCH_PATTERN`).

## Alternatives considered
- **Keep `_protected_static_refs` as a documentation anchor**: rejected — the helper wrapped a 2-token literal called from 2 sites in one file. A comment block above the loops carries the "static-name subset" rationale just as well.
- **Defer deleting `PROTECTED_BRANCH_CASE_GLOB` until a concrete glob-context caller appears**: rejected — YAGNI. Unused since #16 with an SC2034 disable + docstring justification. Reintroducing a one-line constant later is trivial.
- **Split into two Code commits**: rejected — cohesive cleanup with one motivation.
- **Leave the `CASE_GLOB` cross-ref comments dangling**: rejected — dangling refs are worse than no ref. Updated mid-commit.

## Key context
- `helpers/git_matcher.sh:36-39` — deleted constant + disable directive.
- `helpers/branch_guard.sh:11-17` — deleted helper.
- `helpers/branch_guard.sh:47, 90` — call sites converted to `for ref in main master`.
- `helpers/branch_guard.sh:54-56, 94` — cross-ref comments updated.
- `scripts/test/smoke.sh:2035` — `CASE_GLOB` non-emptiness sub-check removed.

## Checklist
- [x] **Code**: `PROTECTED_BRANCH_CASE_GLOB` + SC2034 directive deleted; docstring trimmed.
- [x] **Code**: `_protected_static_refs` deleted; both call sites inlined.
- [x] **Code**: Two `CASE_GLOB` cross-ref comments updated to reference `PATTERN`.
- [x] **Code**: smoke §36a non-emptiness assertion for `CASE_GLOB` removed.
- [x] `PROTECTED_BRANCH_PATTERN` retained (load-bearing).
- [x] No SPEC / CLAUDE.md edit needed — protected-branch contract unchanged.
- [x] No stale references anywhere (`grep -r 'PROTECTED_BRANCH_CASE_GLOB\|_protected_static_refs'` → 0 hits).
- [x] All 211 smoke assertions pass; shellcheck 0 findings.

## Out of scope
- User-configurable override for the protected pattern.
- Tightening `release/\S+` to `release/[^[:space:]/]+`.
- Touching `pre_tool_use.sh`'s matchers (consume `PROTECTED_BRANCH_PATTERN`, preserved).
- Renaming `PROTECTED_BRANCH_PATTERN`.

## Risks
- **Behavioral regression: very low.** `PROTECTED_BRANCH_CASE_GLOB` had zero runtime consumers (grep confirms — only smoke's non-emptiness check and its own docstring). `_protected_static_refs` returned static `main\nmaster` consumed by two `for ref in $(...)` loops — inlining is mechanically equivalent (no IFS-sensitive characters in those two tokens).
- **Detached-HEAD codepath**: the inlining touches the rarely-exercised detached-HEAD branch in `branch_label` and `is_protected_branch`. smoke §32a-c cover the detached-HEAD-on-protected-tip case (verified green post-change).
- **No tally drift**: removing one *sub-check* from §36a doesn't change the overall pass count (§36a is one `ok`/`ng` assertion regardless of how many internal predicates it tests). Smoke remains 211/211.

## Test plan
- [x] `./scripts/test/smoke.sh` — 211/211.
- [x] `shellcheck --severity=warning --shell=bash` — 0 findings.
- [x] `grep -rE 'PROTECTED_BRANCH_CASE_GLOB|_protected_static_refs'` over the tree — 0 hits.
- [~] CI green on both matrix legs — enforced by `gh pr merge` gate.

## Docs touched
- [~] N/A — refactor, no external behavior change (Docs: n/a per SPEC §1.2). Inline docstring edits in `git_matcher.sh` / `branch_guard.sh` are code-adjacent comments, not SSOT contract changes.

## Ship gate
- [x] All tests pass (local 211/211, shellcheck 0)
- [x] code-reviewer passed (pending /ship)
- [~] security-reviewer — N/A (deletion of unused symbols; no auth/input/deps/crypto surface; `PROTECTED_BRANCH_PATTERN` enforcement contract unchanged)
- [x] Docs in sync (no SSOT edit required; inline comments updated)
- [x] PR body curated
- [~] CI green — enforced by merge gate.