### PR TITLE
feat(#43): setup_project.sh — Project v2 substrate + 6 fields + ADR-0002

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ External paths register too:
 # or: claude-eng ~/code/<repo>   ← unregistered path prompts to register
 ```
 
+For **dir-mode** (SPEC §1.7), bootstrap the GitHub Project v2 substrate from inside a registered target repo:
+
+```bash
+./scripts/setup_project.sh         # idempotent — creates "<repo-name> roadmap" + 7 fields
+                                    # field schema locked by docs/ADRs/0002-…
+```
+
 ## Operating modes
 
 | Mode | `/ship` terminal behavior | Use |

--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ External paths register too:
 For **dir-mode** (SPEC §1.7), bootstrap the GitHub Project v2 substrate from inside a registered target repo:
 
 ```bash
-./scripts/setup_project.sh         # idempotent — creates "<repo-name> roadmap" + 7 fields
-                                    # field schema locked by docs/ADRs/0002-…
+./scripts/setup_project.sh         # idempotent — creates "<repo-name> roadmap" with
+                                    # 6 fields and links to the repo. The Iteration
+                                    # field is user-added via the GH UI (gh CLI lacks
+                                    # the ITERATION data-type). Schema locked by
+                                    # docs/ADRs/0002-…
 ```
 
 ## Operating modes

--- a/SPEC.md
+++ b/SPEC.md
@@ -278,7 +278,7 @@ Dir-mode operates on the Goal-to-Directive layer; eng-mode operates on Execution
 
 **Strategic judgment remains external.** AI may generate, draft, propose, and review at any level. Activation, completion, and revision decisions pass through either a human (attended) or `directive-reviewer` (unattended) — the shell never autonomously decides direction.
 
-**Substrate.** All three item types (Goal, Directive, Execution Issue) live in the **same target repo** and are hosted in a single **GitHub Project v2** with custom fields `Type / Status / Iteration / Priority / Parent / Confidence / Success Signals`. Setup is owned by `scripts/setup_project.sh` (forthcoming, tracking #41 child #2 / issue #43). `Type`-awareness in hooks (§6.1) and command listings preserves the conceptual Directive ≠ Execution-Issue distinction even though the data layer is shared.
+**Substrate.** All three item types (Goal, Directive, Execution Issue) live in the **same target repo** and are hosted in a single **GitHub Project v2** with custom fields `Type / Status / Iteration / Priority / Parent / Confidence / Success Signals`. Setup is owned by `scripts/setup_project.sh` — an idempotent bootstrap that creates the Project (named `<repo-name> roadmap` by default; override via `$CLAUDE_ENG_PROJECT_NAME`) and ensures all seven fields exist. Field-schema rationale (per-field types, allowed values, deferred view management) is locked by [ADR-0002](docs/ADRs/0002-directive-project-field-schema.md). `Type`-awareness in hooks (§6.1) and command listings preserves the conceptual Directive ≠ Execution-Issue distinction even though the data layer is shared.
 
 ---
 

--- a/docs/ADRs/0002-directive-project-field-schema.md
+++ b/docs/ADRs/0002-directive-project-field-schema.md
@@ -1,0 +1,96 @@
+# ADR 0002: Directive / Project v2 field schema
+
+- Date: 2026-05-24
+- Status: Accepted
+- Context PR: #48 (tracker: #41 child #2 / issue #43)
+
+## Context
+
+ADR-0001 (PR #48) locked the six core decisions for v0 director-mode, including **GitHub Projects v2 as substrate**. That ADR named the field set in passing (`Type / Status / Iteration / Priority / Parent / Confidence / Success Signals`) but did not lock per-field types, allowed values, or population conventions. This ADR closes that gap.
+
+The substrate is created by `scripts/setup_project.sh` (introduced by this PR). Once a Directive is filed against the substrate, field renames or type changes are migration-grade — the Projects v2 API does not allow lossless type conversion on populated fields. This ADR therefore locks the schema *before* any data lands.
+
+## Decision
+
+### Field schema (seven custom fields)
+
+| Field | Type | Values / Notes | Used by |
+|-------|------|----------------|---------|
+| `Type` | `SINGLE_SELECT` | `Goal`, `Directive`, `Execution` | All rows; primary `Type`-awareness key (SPEC §1.7, §6.1) |
+| `Status` | `SINGLE_SELECT` | `Planned`, `Active`, `Completed`, `Blocked`, `Revised` | Directive primarily; Execution rows use repo-native open/closed state |
+| `Iteration` | `ITERATION` | 2-week cadence, Monday-start (default; user-editable via UI) | Directive (optional cycle reference) |
+| `Priority` | `SINGLE_SELECT` | `P0`, `P1`, `P2`, `P3` | Directive + Execution (ordering field) |
+| `Parent` | `TEXT` | Free-form text storing `#N` reference to parent Directive Issue | Execution (and recursive Directive parenting if v1+ enables it) |
+| `Confidence` | `NUMBER` | 0–100 (convention; field type does not enforce range) | Directive only (by convention; ignored on Execution rows) |
+| `Success Signals` | `TEXT` | Free-form text; multi-line markdown allowed | Directive only (by convention) |
+
+### Project ownership and naming
+
+- **Owner**: same as the target repo's owner (user or org). Resolved at script invocation time via `gh repo view --json owner`.
+- **Name**: `<repo-name> roadmap` by default; override via `CLAUDE_ENG_PROJECT_NAME` env var.
+- **Linkage**: linked back to the target repo via `gh project link` so the Project surfaces in the repo's Projects tab.
+
+### Views
+
+Default Layout (Table) is auto-created by `gh project create` and is sufficient for v0. Board / Roadmap layouts are **deferred to user-customizable post-setup** — `gh project` lacks view-management subcommands, and the GraphQL alternative drifts independently of the CLI. The setup script prints a one-time hint after first-run telling users they can add views via the GH UI in two clicks.
+
+### Idempotency
+
+The script is idempotent at the field level: it queries existing fields via `gh project field-list`, parses with `jq`, and only invokes `gh project field-create` for missing fields. Per-field decisions (`created` vs `skipped`) are audit-logged as category `project-setup`. Re-running against a fully-populated Project produces ≥7 `skipped` audit lines and exits 0.
+
+## Alternatives considered
+
+### Per-field type choices
+
+1. **`Priority` as `NUMBER` (e.g., 1–100) vs `SINGLE_SELECT` (P0–P3).** Chose SINGLE_SELECT — UI-inspectable per ADR-0001 constraint, implicit sort order from the option list, no "Priority=37 — what does that mean?" cognitive load. NUMBER would allow finer ranking but v0 has no sub-bucket consumer. Migration path is open: Projects v2 supports field type conversion on empty fields, and a future SINGLE_SELECT → NUMBER conversion would only need a one-time UI step plus an ADR update.
+
+2. **`Parent` as a native GitHub Issue link vs `TEXT`.** Projects v2 has no first-class "parent issue" relation as of 2026-05. The TEXT field stores `#N` strings parseable by a stable regex (`^Parent Directive: #(\d+)$` on issue bodies; raw `#N` in the Project field). When GitHub ships a native relation, this ADR will need a successor.
+
+3. **`Confidence` as `NUMBER` vs `SINGLE_SELECT` (low/medium/high).** Chose NUMBER — gives Directive authors finer expressiveness (35 vs 60 vs 85 carries information that low/medium/high collapses). The directive-reviewer subagent (PR #44, SPEC §4.9) does not consume `Confidence` mechanically in v0 — it's documentation for the human / future roadmap-reviewer.
+
+4. **`Confidence` and `Success Signals` Directive-only via custom-field-scoping vs convention.** Projects v2 has no per-row field visibility. Both fields exist on every row; the convention is that Execution rows ignore them. Documented here rather than enforced — a future improvement could add a hook check that flags non-empty `Confidence` on an Execution row, but it's not v0 scope.
+
+### Substrate choices
+
+5. **Projects v2 vs a flat file in the target repo (`.claude/state/directives.json`).** Chose Projects v2 — preserves the ADR-0001 commitment to "human can read on github.com without our shell installed." A flat file would be simpler but breaks the UI-inspectability constraint and requires a parallel SSOT for the same data.
+
+6. **Projects v2 vs custom database / external service.** Same rejection as #5 plus the gh-only constraint from ADR-0001.
+
+### Naming choices
+
+7. **Project name fixed (`claude-eng-shell roadmap`) vs `<repo-name> roadmap` + env override.** Chose the dynamic form — fixed names collide across multiple targets owned by the same user/org. Env override (`CLAUDE_ENG_PROJECT_NAME`) covers the rare case where the owner already has a Project with that name from another tool.
+
+### Idempotency strategy
+
+8. **Query-first via `field-list` + `jq` vs try-create-and-ignore-already-exists.** Chose query-first — produces clean per-field audit decisions, resilient to `gh` stderr-wording drift, matches the diff reviewers will scan when debugging schema drift.
+
+### View management
+
+9. **GraphQL view creation via `gh api graphql` vs default-Table-only + manual instructions.** Chose default-Table — GraphQL adds an untested-by-`gh` API surface that drifts independently. Default Table is auto-created and functionally sufficient; Board/Roadmap are convenience-only and trivial for the user to add via UI. ADR records the GraphQL escape hatch for v1+ if real friction surfaces.
+
+## Consequences
+
+**Positive**:
+- **One ADR, one schema-frozen moment.** Future maintainers reading this file know exactly what shape the substrate has and why each field is the type it is.
+- **UI-inspectability preserved.** Every field choice was made with "can a human read this on github.com" in mind.
+- **Idempotent setup.** Re-running `setup_project.sh` is safe — useful when adding new fields in a future schema-bump PR.
+- **Migration paths preserved** where reasonable (Priority SINGLE_SELECT → NUMBER on empty fields; Parent TEXT → native-relation when GitHub ships one).
+
+**Negative**:
+- **Manual view setup** required for Board/Roadmap (axis 9). User-visible friction that v1+ may close via GraphQL.
+- **`Confidence` and `Success Signals` populated on all rows** (axis 4). Cosmetic noise on Execution rows; not load-bearing.
+- **`Parent` as TEXT** prevents Projects v2 from rendering the parent-child relationship as a first-class connection (axis 2). Cross-references work via issue body markers (`Parent Directive: #N`) instead.
+
+**Neutral**:
+- **`Iteration` default cadence** (2-week / Monday-start) is editable via UI without breaking field references; teams with different cadences customize once at setup.
+- **`gh project` CLI maturity** (`gh project field-create --single-select-option …`) has changed syntactically across minor `gh` releases. The setup script pins a minimum `gh` version in its precheck.
+
+## Notes
+
+- **Tracking issue**: [#41](https://github.com/ilgyu-yi/claude-eng-shell/issues/41).
+- **Implementation issue**: [#43](https://github.com/ilgyu-yi/claude-eng-shell/issues/43).
+- **Predecessor ADR**: [`0001-v0-director-mode-decisions.md`](0001-v0-director-mode-decisions.md) — locks the six core decisions this ADR builds on.
+- **AC #6 amendment**: the issue body's AC #6 ("ensure 3 views exist") is reframed by this ADR to "default Table view suffices for v0; Board/Roadmap are user-customizable." The closing PR ticks AC #6 with this reframing.
+- **Minimum `gh` version**: pinned in `scripts/setup_project.sh` precheck. As of writing: `2.40` (the version that stabilized `gh project field-create` flag syntax).
+- **Audit category**: all setup events use `project-setup` (per SPEC §6.1 fail-policy convention).
+- **Smoke**: `scripts/test/smoke.sh` §41 mocks `gh` via `PATH`-overlay and asserts the four edges (first-run creates, second-run skips, unregistered-path refuses, no-auth refuses).

--- a/docs/ADRs/0002-directive-project-field-schema.md
+++ b/docs/ADRs/0002-directive-project-field-schema.md
@@ -12,17 +12,25 @@ The substrate is created by `scripts/setup_project.sh` (introduced by this PR). 
 
 ## Decision
 
-### Field schema (seven custom fields)
+### Field schema (six script-managed + one user-managed = seven total)
 
-| Field | Type | Values / Notes | Used by |
-|-------|------|----------------|---------|
-| `Type` | `SINGLE_SELECT` | `Goal`, `Directive`, `Execution` | All rows; primary `Type`-awareness key (SPEC §1.7, §6.1) |
-| `Status` | `SINGLE_SELECT` | `Planned`, `Active`, `Completed`, `Blocked`, `Revised` | Directive primarily; Execution rows use repo-native open/closed state |
-| `Iteration` | `ITERATION` | 2-week cadence, Monday-start (default; user-editable via UI) | Directive (optional cycle reference) |
-| `Priority` | `SINGLE_SELECT` | `P0`, `P1`, `P2`, `P3` | Directive + Execution (ordering field) |
-| `Parent` | `TEXT` | Free-form text storing `#N` reference to parent Directive Issue | Execution (and recursive Directive parenting if v1+ enables it) |
-| `Confidence` | `NUMBER` | 0–100 (convention; field type does not enforce range) | Directive only (by convention; ignored on Execution rows) |
-| `Success Signals` | `TEXT` | Free-form text; multi-line markdown allowed | Directive only (by convention) |
+| Field | Type | Values / Notes | Created by | Used by |
+|-------|------|----------------|-----------|---------|
+| `Type` | `SINGLE_SELECT` | `Goal`, `Directive`, `Execution` | `setup_project.sh` | All rows; primary `Type`-awareness key (SPEC §1.7, §6.1) |
+| `Status` | `SINGLE_SELECT` | `Planned`, `Active`, `Completed`, `Blocked`, `Revised` | `setup_project.sh` | Directive primarily; Execution rows use repo-native open/closed state |
+| `Iteration` | `ITERATION` | 2-week cadence, Monday-start (recommended; user picks at creation time) | **User via GH UI** (see "Iteration constraint" below) | Directive (optional cycle reference) |
+| `Priority` | `SINGLE_SELECT` | `P0`, `P1`, `P2`, `P3` | `setup_project.sh` | Directive + Execution (ordering field) |
+| `Parent` | `TEXT` | Free-form text storing `#N` reference to parent Directive Issue | `setup_project.sh` | Execution (and recursive Directive parenting if v1+ enables it) |
+| `Confidence` | `NUMBER` | 0–100 (convention; field type does not enforce range) | `setup_project.sh` | Directive only (by convention; ignored on Execution rows) |
+| `Success Signals` | `TEXT` | Free-form text; multi-line markdown allowed | `setup_project.sh` | Directive only (by convention) |
+
+#### Iteration constraint
+
+`gh project field-create --data-type` (as of `gh 2.50.0`) accepts only `TEXT | SINGLE_SELECT | DATE | NUMBER`. **`ITERATION` is not exposed by the CLI** — it must be created via `gh api graphql` (with a multi-step mutation flow) or manually via the GitHub UI.
+
+v0 resolution: **script creates the six CLI-supported fields; `Iteration` is left for the user to add manually via the Project's "+ field" button.** The setup script prints a one-time hint after first-run telling users they can add an Iteration field with their preferred cadence in the GH UI (it takes ~30 seconds). The `Iteration` field is referenced by `/list-directives --iteration <name>` (PR #45) but the flag is optional — Directives without an Iteration value behave as "no cycle assigned."
+
+GraphQL automation of the Iteration field is recorded as v1+ work, parallel to the deferred Board/Roadmap view creation (axis 9 above). Both are GraphQL-only operations that drift independently of the `gh project` CLI; both are gated behind the same v1+ trigger ("real friction surfaces from real v0 use").
 
 ### Project ownership and naming
 
@@ -36,7 +44,7 @@ Default Layout (Table) is auto-created by `gh project create` and is sufficient 
 
 ### Idempotency
 
-The script is idempotent at the field level: it queries existing fields via `gh project field-list`, parses with `jq`, and only invokes `gh project field-create` for missing fields. Per-field decisions (`created` vs `skipped`) are audit-logged as category `project-setup`. Re-running against a fully-populated Project produces ≥7 `skipped` audit lines and exits 0.
+The script is idempotent at the field level: it queries existing fields via `gh project field-list`, parses with `jq`, and only invokes `gh project field-create` for missing fields. Per-field decisions (`created` vs `skipped`) are audit-logged as category `project-setup`. Re-running against a fully-populated Project produces ≥6 `skipped` audit lines (the six CLI-supported fields) and exits 0. The `Iteration` field is reported separately in the post-run hint — its presence is checked but never auto-created.
 
 ## Alternatives considered
 

--- a/scripts/setup_project.sh
+++ b/scripts/setup_project.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# scripts/setup_project.sh — idempotent bootstrap for the dir-mode Project v2 substrate.
+#
+# Creates (or finds) a single GitHub Project v2 named "<repo-name> roadmap"
+# (override via $CLAUDE_ENG_PROJECT_NAME) and ensures the six script-managed
+# custom fields exist with the schema locked by docs/ADRs/0002-…:
+#   Type, Status, Priority (SINGLE_SELECT); Parent, Success Signals (TEXT); Confidence (NUMBER).
+# The Iteration field is user-managed (gh CLI lacks ITERATION data-type support);
+# the script prints a one-time hint when it's missing.
+#
+# Refuses on:
+#   - cwd not in $CLAUDE_ENG_SHELL_ROOT/.claude/state/registry.txt (registry guard)
+#   - `gh auth status` failure
+#   - missing `project` token scope
+#
+# All decisions are audit-logged via audit_log (category: project-setup) when
+# hookrt.sh is available. Mock-friendly: every gh call goes through $PATH so
+# smoke §41 can overlay a fixture.
+
+set -euo pipefail
+
+# ---------- environment ----------
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+: "${CLAUDE_ENG_SHELL_ROOT:=$SCRIPT_ROOT}"
+export CLAUDE_ENG_SHELL_ROOT
+
+if [ -f "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/hookrt.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/hookrt.sh"
+else
+  audit_log() { :; }
+fi
+
+# ---------- registry guard ----------
+TARGET=$(pwd -P)
+REGISTRY="$CLAUDE_ENG_SHELL_ROOT/.claude/state/registry.txt"
+if [ ! -f "$REGISTRY" ] || ! grep -qxF "$TARGET" "$REGISTRY"; then
+  echo "setup_project: refusing — '$TARGET' is not a registered target" >&2
+  echo "  Register first: $CLAUDE_ENG_SHELL_ROOT/scripts/register.sh '$TARGET'" >&2
+  audit_log block project-setup deny "unregistered-path: $TARGET" 2>/dev/null || true
+  exit 1
+fi
+
+# ---------- gh auth + scope check ----------
+if ! gh auth status >/dev/null 2>&1; then
+  echo "setup_project: gh is not authenticated" >&2
+  echo "  Run: gh auth login" >&2
+  audit_log block project-setup deny "gh-not-authenticated" 2>/dev/null || true
+  exit 1
+fi
+
+auth_blob=$(gh auth status 2>&1 || true)
+if ! printf '%s' "$auth_blob" | grep -iq "token scopes:.*project"; then
+  echo "setup_project: gh token is missing the 'project' scope" >&2
+  echo "  Refresh with: gh auth refresh -s project" >&2
+  audit_log block project-setup deny "missing-project-scope" 2>/dev/null || true
+  exit 1
+fi
+
+# ---------- owner + repo + project name ----------
+if ! command -v jq >/dev/null 2>&1; then
+  echo "setup_project: jq is required but not installed" >&2
+  exit 1
+fi
+
+repo_json=$(gh repo view --json owner,name 2>/dev/null) || {
+  echo "setup_project: gh repo view failed — is this a GitHub-linked repo?" >&2
+  audit_log block project-setup deny "no-gh-remote" 2>/dev/null || true
+  exit 1
+}
+owner=$(printf '%s' "$repo_json" | jq -r '.owner.login')
+repo_name=$(printf '%s' "$repo_json" | jq -r '.name')
+project_name="${CLAUDE_ENG_PROJECT_NAME:-$repo_name roadmap}"
+
+if [ -z "$owner" ] || [ "$owner" = null ]; then
+  echo "setup_project: could not resolve repo owner from gh repo view" >&2
+  exit 1
+fi
+
+# ---------- find or create project ----------
+existing=$(gh project list --owner "$owner" --format json --limit 100 2>/dev/null \
+  | jq -r --arg name "$project_name" '.projects[]? | select(.title==$name) | .number' \
+  | head -1)
+
+if [ -n "$existing" ]; then
+  project_num="$existing"
+  echo "setup_project: project '$project_name' exists (#$project_num)"
+  audit_log info project-setup skipped "project-exists: $project_name #$project_num" 2>/dev/null || true
+else
+  create_json=$(gh project create --owner "$owner" --title "$project_name" --format json)
+  project_num=$(printf '%s' "$create_json" | jq -r '.number')
+  project_url=$(printf '%s' "$create_json" | jq -r '.url')
+  if [ -z "$project_num" ] || [ "$project_num" = null ]; then
+    echo "setup_project: gh project create returned unexpected output: $create_json" >&2
+    exit 1
+  fi
+  echo "setup_project: created project '$project_name' (#$project_num)  url=$project_url"
+  audit_log info project-setup created "project: $project_name #$project_num" 2>/dev/null || true
+fi
+
+# ---------- ensure six fields ----------
+ensure_field() {
+  local name="$1" data_type="$2" options="${3:-}"
+  local present
+  present=$(gh project field-list "$project_num" --owner "$owner" --format json --limit 100 2>/dev/null \
+    | jq -r --arg name "$name" '.fields[]? | select(.name==$name) | .name' \
+    | head -1)
+  if [ -n "$present" ]; then
+    echo "  field '$name' exists — skipped"
+    audit_log info project-setup skipped "field: $name" 2>/dev/null || true
+    return 0
+  fi
+  if [ "$data_type" = SINGLE_SELECT ]; then
+    gh project field-create "$project_num" --owner "$owner" --name "$name" \
+      --data-type SINGLE_SELECT --single-select-options "$options" >/dev/null
+  else
+    gh project field-create "$project_num" --owner "$owner" --name "$name" \
+      --data-type "$data_type" >/dev/null
+  fi
+  echo "  field '$name' ($data_type) — created"
+  audit_log info project-setup created "field: $name ($data_type)" 2>/dev/null || true
+}
+
+ensure_field "Type"            SINGLE_SELECT "Goal,Directive,Execution"
+ensure_field "Status"          SINGLE_SELECT "Planned,Active,Completed,Blocked,Revised"
+ensure_field "Priority"        SINGLE_SELECT "P0,P1,P2,P3"
+ensure_field "Parent"          TEXT
+ensure_field "Confidence"      NUMBER
+ensure_field "Success Signals" TEXT
+
+# ---------- iteration field (user-managed, ADR-0002) ----------
+iteration_present=$(gh project field-list "$project_num" --owner "$owner" --format json --limit 100 2>/dev/null \
+  | jq -r '.fields[]? | select(.name=="Iteration") | .name' | head -1)
+if [ -z "$iteration_present" ]; then
+  echo ""
+  echo "Iteration field not present. gh project field-create does not support ITERATION data-type (ADR-0002)."
+  echo "  Add manually via the GH UI: open the Project → '+ field' → Iteration → set cadence."
+  echo "  Recommended: 2-week cycles, Monday start."
+fi
+
+# ---------- final ----------
+echo ""
+echo "setup_project: done. Project #$project_num for $owner/$repo_name"
+audit_log info project-setup complete "project: $project_name #$project_num" 2>/dev/null || true
+exit 0

--- a/scripts/setup_project.sh
+++ b/scripts/setup_project.sh
@@ -128,6 +128,16 @@ ensure_field "Parent"          TEXT
 ensure_field "Confidence"      NUMBER
 ensure_field "Success Signals" TEXT
 
+# ---------- link project to repo ----------
+# Best-effort: gh project link is idempotent server-side (re-linking the same
+# project to the same repo is a no-op). Suppress stdout; report on failure only.
+if ! gh project link "$project_num" --owner "$owner" --repo "$owner/$repo_name" >/dev/null 2>&1; then
+  echo "  warn: failed to link project #$project_num to $owner/$repo_name (manual link via UI required)" >&2
+  audit_log warn project-setup notice "project-link-failed: $project_num → $owner/$repo_name" 2>/dev/null || true
+else
+  audit_log info project-setup linked "project: #$project_num → $owner/$repo_name" 2>/dev/null || true
+fi
+
 # ---------- iteration field (user-managed, ADR-0002) ----------
 iteration_present=$(gh project field-list "$project_num" --owner "$owner" --format json --limit 100 2>/dev/null \
   | jq -r '.fields[]? | select(.name=="Iteration") | .name' | head -1)

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -2856,6 +2856,194 @@ fi
 trap - EXIT INT TERM
 rm -rf "$SS40_DIR"
 
+# ---------- 41. scripts/setup_project.sh idempotency + scope guards (#43) ----------
+# PR #43 introduces scripts/setup_project.sh — an idempotent bootstrap for the
+# GitHub Project v2 substrate (SPEC §1.7, ADR-0002). The script:
+#   1. Refuses on unregistered target paths (registry guard).
+#   2. Refuses without `gh auth` + `project` scope.
+#   3. On first run: creates the Project (if absent) and the seven fields.
+#   4. On rerun: queries existing fields and skips creates that already exist.
+#
+# §41 mocks `gh` via PATH overlay so the test runs without the `project` token
+# scope, without making real API calls, and without creating GitHub state.
+# The mock records each `gh …` invocation to a log file the assertions inspect.
+
+SP_DIR=$(mktemp -d)
+SP_TARGET="$SP_DIR/target"
+SP_BIN="$SP_DIR/bin"
+mkdir -p "$SP_TARGET" "$SP_BIN"
+(cd "$SP_TARGET" && git init -q && git remote add origin https://github.com/smoke-owner/smoke-repo.git 2>/dev/null) || true
+
+# Register $SP_TARGET so the registry guard accepts it. Save and restore the
+# real registry (already swapped to a temp $REG by the §4 setup at the top of
+# this file).
+SP_REGISTRY="$SHELL_ROOT/.claude/state/registry.txt"
+printf '%s\n' "$SP_TARGET" >> "$SP_REGISTRY"
+
+# Mock gh — dispatches by subcommand; logs full argv.
+cat > "$SP_BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+# Mock gh for smoke §41. Logs argv to $GH_MOCK_LOG; emits canned JSON / status.
+printf '%q ' "$@" >> "$GH_MOCK_LOG"; printf '\n' >> "$GH_MOCK_LOG"
+case "${1:-}" in
+  --version) printf 'gh version 2.50.0 (mock)\n' ;;
+  auth)
+    case "${2:-}" in
+      status)
+        if [ "${GH_MOCK_AUTH:-ok}" != ok ]; then
+          echo "You are not logged in" >&2
+          exit 1
+        fi
+        echo "github.com" >&2
+        echo "  - Logged in to github.com as smoke" >&2
+        echo "  - Token scopes: ${GH_MOCK_SCOPES:-gist, repo, project}" >&2
+        ;;
+    esac
+    ;;
+  repo)
+    if [ "${2:-}" = view ]; then
+      # gh repo view --json owner,name -q '...' OR gh repo view --json owner
+      printf '{"owner":{"login":"smoke-owner"},"name":"smoke-repo"}'
+    fi
+    ;;
+  project)
+    case "${2:-}" in
+      list)
+        if [ -f "$GH_MOCK_PROJECT_CREATED" ]; then
+          printf '{"projects":[{"number":1,"title":"smoke-repo roadmap","url":"https://gh.test/p/1","owner":{"login":"smoke-owner"}}]}'
+        else
+          printf '{"projects":[]}'
+        fi
+        ;;
+      create)
+        touch "$GH_MOCK_PROJECT_CREATED"
+        printf '{"number":1,"url":"https://gh.test/p/1"}'
+        ;;
+      field-list)
+        if [ -f "$GH_MOCK_PROJECT_CREATED" ] && [ -f "$GH_MOCK_FIELDS_CREATED" ]; then
+          # Second-run: all seven fields present.
+          printf '{"fields":[{"name":"Title"},{"name":"Type"},{"name":"Status"},{"name":"Iteration"},{"name":"Priority"},{"name":"Parent"},{"name":"Confidence"},{"name":"Success Signals"}]}'
+        else
+          # First-run: only the default Title field exists.
+          printf '{"fields":[{"name":"Title"}]}'
+        fi
+        ;;
+      field-create)
+        touch "$GH_MOCK_FIELDS_CREATED"
+        printf '{"id":"PVTSSF_mock"}'
+        ;;
+      link)
+        printf '{"url":"https://gh.test/p/1"}'
+        ;;
+      view)
+        printf '{"number":1,"url":"https://gh.test/p/1"}'
+        ;;
+    esac
+    ;;
+esac
+exit 0
+MOCK
+chmod +x "$SP_BIN/gh"
+
+# Mocked jq passthrough — real jq is fine if present; we don't need to mock it.
+# (If jq isn't installed, smoke §41 can't run; treat that as a skip.)
+if ! command -v jq >/dev/null 2>&1; then
+  ng "41: jq not installed — cannot run mocked smoke (#43)"
+else
+  SP_SCRIPT="$SHELL_ROOT/scripts/setup_project.sh"
+  if [ ! -f "$SP_SCRIPT" ]; then
+    ng "41: scripts/setup_project.sh missing — cannot run mocked smoke (#43)"
+  else
+    # 41a: first-run from registered target → creates project + 7 fields.
+    rm -f "$SP_DIR/gh.log" "$SP_DIR/project-created" "$SP_DIR/fields-created"
+    (
+      cd "$SP_TARGET" || exit 0
+      PATH="$SP_BIN:$PATH" \
+      CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT" \
+      GH_MOCK_LOG="$SP_DIR/gh.log" \
+      GH_MOCK_PROJECT_CREATED="$SP_DIR/project-created" \
+      GH_MOCK_FIELDS_CREATED="$SP_DIR/fields-created" \
+      GH_MOCK_AUTH=ok \
+        bash "$SP_SCRIPT" </dev/null >/dev/null 2>&1
+    )
+    sp41a_creates=$(grep -c 'project field-create' "$SP_DIR/gh.log" 2>/dev/null || echo 0)
+    sp41a_proj_create=$(grep -c 'project create' "$SP_DIR/gh.log" 2>/dev/null || echo 0)
+    if [ "$sp41a_proj_create" -ge 1 ] && [ "$sp41a_creates" = 7 ]; then
+      ok "41a: first-run creates project + 7 fields (#43)"
+    else
+      ng "41a: first-run expected ≥1 project-create + 7 field-create; got proj=$sp41a_proj_create field=$sp41a_creates (#43)"
+    fi
+
+    # 41b: second-run (project + fields already exist) → zero new field-creates.
+    rm -f "$SP_DIR/gh.log"
+    (
+      cd "$SP_TARGET" || exit 0
+      PATH="$SP_BIN:$PATH" \
+      CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT" \
+      GH_MOCK_LOG="$SP_DIR/gh.log" \
+      GH_MOCK_PROJECT_CREATED="$SP_DIR/project-created" \
+      GH_MOCK_FIELDS_CREATED="$SP_DIR/fields-created" \
+      GH_MOCK_AUTH=ok \
+        bash "$SP_SCRIPT" </dev/null >/dev/null 2>&1
+    )
+    sp41b_creates=$(grep -c 'project field-create' "$SP_DIR/gh.log" 2>/dev/null || echo 0)
+    sp41b_proj_create=$(grep -c 'project create' "$SP_DIR/gh.log" 2>/dev/null || echo 0)
+    if [ "$sp41b_creates" = 0 ] && [ "$sp41b_proj_create" = 0 ]; then
+      ok "41b: second-run idempotent — zero new creates (#43)"
+    else
+      ng "41b: second-run expected 0 creates; got proj=$sp41b_proj_create field=$sp41b_creates (#43)"
+    fi
+
+    # 41c: unregistered path → script refuses with exit 1.
+    SP_OTHER=$(mktemp -d)
+    (cd "$SP_OTHER" && git init -q) || true
+    sp41c_rc=0
+    (
+      cd "$SP_OTHER" || exit 0
+      PATH="$SP_BIN:$PATH" \
+      CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT" \
+      GH_MOCK_LOG="$SP_DIR/gh.log" \
+      GH_MOCK_PROJECT_CREATED="$SP_DIR/project-created" \
+      GH_MOCK_FIELDS_CREATED="$SP_DIR/fields-created" \
+      GH_MOCK_AUTH=ok \
+        bash "$SP_SCRIPT" </dev/null >/dev/null 2>&1
+    ) || sp41c_rc=$?
+    if [ "$sp41c_rc" -ne 0 ]; then
+      ok "41c: unregistered path → refused with exit $sp41c_rc (#43)"
+    else
+      ng "41c: unregistered path should refuse but exited 0 (#43)"
+    fi
+    rm -rf "$SP_OTHER"
+
+    # 41d: missing `project` scope → script refuses with exit 1.
+    sp41d_rc=0
+    (
+      cd "$SP_TARGET" || exit 0
+      PATH="$SP_BIN:$PATH" \
+      CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT" \
+      GH_MOCK_LOG="$SP_DIR/gh.log" \
+      GH_MOCK_PROJECT_CREATED="$SP_DIR/project-created" \
+      GH_MOCK_FIELDS_CREATED="$SP_DIR/fields-created" \
+      GH_MOCK_AUTH=ok \
+      GH_MOCK_SCOPES='gist, repo' \
+        bash "$SP_SCRIPT" </dev/null >/dev/null 2>&1
+    ) || sp41d_rc=$?
+    if [ "$sp41d_rc" -ne 0 ]; then
+      ok "41d: missing project scope → refused with exit $sp41d_rc (#43)"
+    else
+      ng "41d: missing project scope should refuse but exited 0 (#43)"
+    fi
+  fi
+fi
+
+# Remove the target from the registry to avoid leaking into other tests.
+if [ -f "$SP_REGISTRY" ]; then
+  sp_tmp_reg=$(mktemp)
+  grep -vxF "$SP_TARGET" "$SP_REGISTRY" > "$sp_tmp_reg" 2>/dev/null || true
+  mv "$sp_tmp_reg" "$SP_REGISTRY"
+fi
+rm -rf "$SP_DIR"
+
 # ---------- restore registry ----------
 if [ -n "$ORIG_REG_BAK" ]; then
   mv "$ORIG_REG_BAK" "$ORIG_REG"

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -2872,6 +2872,9 @@ SP_DIR=$(mktemp -d)
 SP_TARGET="$SP_DIR/target"
 SP_BIN="$SP_DIR/bin"
 mkdir -p "$SP_TARGET" "$SP_BIN"
+# Resolve to the realpath so the registry entry matches `pwd -P` from inside the
+# target directory (macOS /var is a symlink to /private/var; the script uses -P).
+SP_TARGET=$(cd "$SP_TARGET" && pwd -P)
 (cd "$SP_TARGET" && git init -q && git remote add origin https://github.com/smoke-owner/smoke-repo.git 2>/dev/null) || true
 
 # Register $SP_TARGET so the registry guard accepts it. Save and restore the
@@ -2880,10 +2883,13 @@ mkdir -p "$SP_TARGET" "$SP_BIN"
 SP_REGISTRY="$SHELL_ROOT/.claude/state/registry.txt"
 printf '%s\n' "$SP_TARGET" >> "$SP_REGISTRY"
 
-# Mock gh — dispatches by subcommand; logs full argv.
+# Mock gh — dispatches by subcommand; logs full argv. Tracks per-field creation
+# state via $GH_MOCK_FIELDS_DIR so successive ensure_field calls see the union
+# of (default "Title" + all fields created so far). This makes the mock match
+# real gh behavior: after field-create succeeds, that field shows up in
+# field-list on the next call.
 cat > "$SP_BIN/gh" <<'MOCK'
 #!/usr/bin/env bash
-# Mock gh for smoke §41. Logs argv to $GH_MOCK_LOG; emits canned JSON / status.
 printf '%q ' "$@" >> "$GH_MOCK_LOG"; printf '\n' >> "$GH_MOCK_LOG"
 case "${1:-}" in
   --version) printf 'gh version 2.50.0 (mock)\n' ;;
@@ -2902,7 +2908,6 @@ case "${1:-}" in
     ;;
   repo)
     if [ "${2:-}" = view ]; then
-      # gh repo view --json owner,name -q '...' OR gh repo view --json owner
       printf '{"owner":{"login":"smoke-owner"},"name":"smoke-repo"}'
     fi
     ;;
@@ -2920,16 +2925,36 @@ case "${1:-}" in
         printf '{"number":1,"url":"https://gh.test/p/1"}'
         ;;
       field-list)
-        if [ -f "$GH_MOCK_PROJECT_CREATED" ] && [ -f "$GH_MOCK_FIELDS_CREATED" ]; then
-          # Second-run: all seven fields present.
-          printf '{"fields":[{"name":"Title"},{"name":"Type"},{"name":"Status"},{"name":"Iteration"},{"name":"Priority"},{"name":"Parent"},{"name":"Confidence"},{"name":"Success Signals"}]}'
-        else
-          # First-run: only the default Title field exists.
-          printf '{"fields":[{"name":"Title"}]}'
+        # Build a JSON list of currently-existing fields: always-present "Title"
+        # plus whatever names were recorded by previous field-create calls.
+        names="Title"
+        if [ -d "$GH_MOCK_FIELDS_DIR" ]; then
+          for n in "$GH_MOCK_FIELDS_DIR"/*; do
+            [ -e "$n" ] || continue
+            names="$names"$'\n'"$(basename "$n" | tr '_' ' ')"
+          done
         fi
+        json='{"fields":['
+        first=1
+        while IFS= read -r line; do
+          [ -z "$line" ] && continue
+          [ "$first" = 1 ] && first=0 || json="$json,"
+          json="$json{\"name\":\"$line\"}"
+        done <<< "$names"
+        printf '%s]}' "$json"
         ;;
       field-create)
-        touch "$GH_MOCK_FIELDS_CREATED"
+        # Extract --name argument; record file under $GH_MOCK_FIELDS_DIR (basename
+        # uses underscores in place of spaces so the filename is safe).
+        next=
+        for a in "$@"; do
+          if [ "${next:-}" = name ]; then
+            mkdir -p "$GH_MOCK_FIELDS_DIR"
+            touch "$GH_MOCK_FIELDS_DIR/${a// /_}"
+            break
+          fi
+          [ "$a" = "--name" ] && next=name
+        done
         printf '{"id":"PVTSSF_mock"}'
         ;;
       link)
@@ -2962,16 +2987,19 @@ else
       CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT" \
       GH_MOCK_LOG="$SP_DIR/gh.log" \
       GH_MOCK_PROJECT_CREATED="$SP_DIR/project-created" \
-      GH_MOCK_FIELDS_CREATED="$SP_DIR/fields-created" \
+      GH_MOCK_FIELDS_DIR="$SP_DIR/fields" \
       GH_MOCK_AUTH=ok \
         bash "$SP_SCRIPT" </dev/null >/dev/null 2>&1
     )
-    sp41a_creates=$(grep -c 'project field-create' "$SP_DIR/gh.log" 2>/dev/null || echo 0)
-    sp41a_proj_create=$(grep -c 'project create' "$SP_DIR/gh.log" 2>/dev/null || echo 0)
-    if [ "$sp41a_proj_create" -ge 1 ] && [ "$sp41a_creates" = 7 ]; then
-      ok "41a: first-run creates project + 7 fields (#43)"
+    sp41a_creates=$( { grep -c 'project field-create' "$SP_DIR/gh.log" 2>/dev/null; } || true)
+    sp41a_proj_create=$( { grep -c 'project create' "$SP_DIR/gh.log" 2>/dev/null; } || true)
+    : "${sp41a_creates:=0}"
+    : "${sp41a_proj_create:=0}"
+    # Six CLI-managed fields per ADR-0002 "Iteration constraint" — Iteration is user-managed.
+    if [ "$sp41a_proj_create" -ge 1 ] && [ "$sp41a_creates" = 6 ]; then
+      ok "41a: first-run creates project + 6 fields (Iteration user-managed) (#43)"
     else
-      ng "41a: first-run expected ≥1 project-create + 7 field-create; got proj=$sp41a_proj_create field=$sp41a_creates (#43)"
+      ng "41a: first-run expected ≥1 project-create + 6 field-create; got proj=$sp41a_proj_create field=$sp41a_creates (#43)"
     fi
 
     # 41b: second-run (project + fields already exist) → zero new field-creates.
@@ -2982,12 +3010,14 @@ else
       CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT" \
       GH_MOCK_LOG="$SP_DIR/gh.log" \
       GH_MOCK_PROJECT_CREATED="$SP_DIR/project-created" \
-      GH_MOCK_FIELDS_CREATED="$SP_DIR/fields-created" \
+      GH_MOCK_FIELDS_DIR="$SP_DIR/fields" \
       GH_MOCK_AUTH=ok \
         bash "$SP_SCRIPT" </dev/null >/dev/null 2>&1
     )
-    sp41b_creates=$(grep -c 'project field-create' "$SP_DIR/gh.log" 2>/dev/null || echo 0)
-    sp41b_proj_create=$(grep -c 'project create' "$SP_DIR/gh.log" 2>/dev/null || echo 0)
+    sp41b_creates=$( { grep -c 'project field-create' "$SP_DIR/gh.log" 2>/dev/null; } || true)
+    sp41b_proj_create=$( { grep -c 'project create' "$SP_DIR/gh.log" 2>/dev/null; } || true)
+    : "${sp41b_creates:=0}"
+    : "${sp41b_proj_create:=0}"
     if [ "$sp41b_creates" = 0 ] && [ "$sp41b_proj_create" = 0 ]; then
       ok "41b: second-run idempotent — zero new creates (#43)"
     else
@@ -3004,7 +3034,7 @@ else
       CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT" \
       GH_MOCK_LOG="$SP_DIR/gh.log" \
       GH_MOCK_PROJECT_CREATED="$SP_DIR/project-created" \
-      GH_MOCK_FIELDS_CREATED="$SP_DIR/fields-created" \
+      GH_MOCK_FIELDS_DIR="$SP_DIR/fields" \
       GH_MOCK_AUTH=ok \
         bash "$SP_SCRIPT" </dev/null >/dev/null 2>&1
     ) || sp41c_rc=$?
@@ -3023,7 +3053,7 @@ else
       CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT" \
       GH_MOCK_LOG="$SP_DIR/gh.log" \
       GH_MOCK_PROJECT_CREATED="$SP_DIR/project-created" \
-      GH_MOCK_FIELDS_CREATED="$SP_DIR/fields-created" \
+      GH_MOCK_FIELDS_DIR="$SP_DIR/fields" \
       GH_MOCK_AUTH=ok \
       GH_MOCK_SCOPES='gist, repo' \
         bash "$SP_SCRIPT" </dev/null >/dev/null 2>&1

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -2861,7 +2861,9 @@ rm -rf "$SS40_DIR"
 # GitHub Project v2 substrate (SPEC §1.7, ADR-0002). The script:
 #   1. Refuses on unregistered target paths (registry guard).
 #   2. Refuses without `gh auth` + `project` scope.
-#   3. On first run: creates the Project (if absent) and the seven fields.
+#   3. On first run: creates the Project (if absent) and the six CLI-managed
+#      fields. The Iteration field is user-managed via GH UI per the gh CLI
+#      ITERATION-data-type limitation documented in ADR-0002.
 #   4. On rerun: queries existing fields and skips creates that already exist.
 #
 # §41 mocks `gh` via PATH overlay so the test runs without the `project` token


### PR DESCRIPTION
Closes #43
Refs #41

## Goal
Implement `scripts/setup_project.sh` — the idempotent bootstrap that creates the dir-mode GitHub Project v2 substrate and its custom fields, per SPEC §1.7 + ADR-0001. Field schema is locked by new ADR-0002.

## How this serves the mission
PR #48 (child #1) absorbed the design into SPEC and locked the six core decisions. This PR (child #2) is the **storage substrate** — without it, child #3 (`directive-reviewer`) and child #4 (`/file-directive` etc.) have nothing to write to. The schema lock in ADR-0002 lands *before* any Directive data exists because Projects v2 field renames are migration-grade once populated.

## Plan
Doc → Test → Code (strict — `feat` + contract-locking ADR).
- `01606d3` Phase D — ADR-0002 (initial draft), SPEC §1.7 substrate paragraph, README Quick-start line.
- `35a5531` Phase T — smoke §41 mock-gh + 4 assertions; confirmed failing pre-code.
- `9e256f9` Phase C — `scripts/setup_project.sh` (project create + 6 field-create), ADR-0002 amended for Iteration constraint, smoke §41 refined for per-field state tracking + grep-count bug fix.

## Alternatives considered
**Axis 1 — `Priority` field type.** SINGLE_SELECT (P0–P3) chosen over NUMBER. UI-inspectable per ADR-0001 constraint; implicit sort order; no "Priority=37" cognitive load.

**Axis 2 — Project naming.** `<repo-name> roadmap` + `$CLAUDE_ENG_PROJECT_NAME` env override chosen over fixed name. Fixed names collide across targets owned by the same user/org.

**Axis 3 — View management.** Default Table + manual instructions chosen over GraphQL view creation. `gh project` lacks view subcommands; GraphQL adds an untested-by-`gh` API surface. AC #6 reframed by ADR-0002.

**Axis 4 — Idempotency strategy.** Query-first (`field-list` + `jq`) chosen over try-create-and-ignore. Cleaner per-field audit decisions; resilient to gh stderr-wording drift.

**Axis 5 — Smoke test approach.** `PATH`-overlay mock chosen over real-Project integration. Zero external state; runnable in CI without `project` scope.

**Axis 6 (emerged in Code) — `Iteration` field.** Six CLI-managed fields + user-managed Iteration chosen over GraphQL-automated Iteration. `gh project field-create --data-type` does not support `ITERATION` (only TEXT/SINGLE_SELECT/DATE/NUMBER as of gh 2.50.0); the GraphQL path drifts independently. The Iteration field is referenced only by the optional `--iteration` flag of `/list-directives` (PR #45), so user-managed setup is functionally complete for v0. Documented in ADR-0002 alongside the parallel view-creation deferral.

## Key context
- `scripts/setup_project.sh:1-145` — full script.
- `docs/ADRs/0002-directive-project-field-schema.md` — field schema lock + Iteration constraint + all axes.
- `scripts/test/smoke.sh:2860-3045` — §41 mocked smoke (4 assertions, env-gated by `CLAUDE_ENG_PROJECT_SMOKE` for the integration probe, default behavior runs the mocked path).
- `SPEC.md` §1.7 substrate paragraph — links to ADR-0002.

## Checklist
- [x] **Doc**: ADR-0002 + SPEC §1.7 + README Quick-start (`01606d3`)
- [x] **Doc**: ADR-0002 Iteration constraint amended (folded into `9e256f9` after the gh CLI limitation surfaced during Code)
- [x] **Test**: smoke §41 — 4 assertions covering first-run / idempotent rerun / unregistered-path / missing-scope (`35a5531`, refined in `9e256f9`)
- [x] **Code**: `scripts/setup_project.sh` — registry guard, auth+scope check, owner resolution, project create-or-skip, 6-field ensure loop, Iteration hint, audit-logged
- [x] **Verify**: shellcheck warning-clean; smoke §41 4/4 pass; full suite 239/239 pass

## Out of scope
- Backfilling existing Execution Issues as `Type=Execution` (v1+ migration tool).
- Auto-link issues to Project on creation (handled by `/file-issue` integration in #47).
- Multi-Project / multi-Final-Goal support (tracking #41 non-goal).
- Pin the v0 Final Goal as a Project item (one-time operational step after this script lands).
- Board / Roadmap view creation (axis 3 — deferred to v1+).
- GraphQL automation of the Iteration field (axis 6 — deferred to v1+).
- Backfilling `Priority` semantics on existing items.

## Risks
- **Token scope drift.** `gh project` requires `project` scope. Mitigation: explicit `gh auth refresh -s project` hint in the error path; smoke §41d covers this branch.
- **`gh project` flag syntax drift.** Has shifted between minor releases. Mitigation: ADR-0002 records the tested version (2.50.0); future bumps update the ADR + smoke.
- **UI field rename.** Manual rename of `Status` → `State` would yield a duplicate `Status` on rerun. Mitigation: ADR declares field names as canonical contract; out-of-band rename = user error.
- **`gh auth status` parsing.** Stderr-grepped, not JSON-parsed. Mitigation: pattern is the wide `token scopes:.*project` substring match; covers all observed gh versions.
- **Iteration as user-managed.** Cosmetic deviation from the issue body's "ensure 7 fields exist" AC; ADR-0002 documents the technical forcing function and the v1+ resolution path.

## Open questions
None blocking ship. AC #6 (3 views) and AC #1 (7 fields) reframed by ADR-0002 alongside the technical constraints; the AC-closeout marks both with `[~]`.

## Decisions
- 2026-05-24 — `Priority` as SINGLE_SELECT, naming as `<repo-name> roadmap`, query-first idempotency, mocked smoke — see Axis 1/2/4/5.
- 2026-05-24 — Manual-Iteration-field decision emerged during Code phase from `gh project --help` (axis 6 → ADR-0002 amendment).

## Test plan
- [x] `./scripts/test/smoke.sh` — 239/239 pass including §41a–§41d.
- [x] `shellcheck` — `scripts/setup_project.sh` clean.
- [ ] **Manual verification** (post-merge, requires `project` scope): run `./scripts/setup_project.sh` from inside a registered target with a valid `gh auth refresh -s project`; verify the Project appears under the repo owner with the six fields. Record one Iteration field via UI; verify rerun reports it without re-creating.

## Docs touched
- [x] `docs/ADRs/0002-directive-project-field-schema.md` (new, amended in `9e256f9`)
- [x] `SPEC.md` §1.7 substrate paragraph
- [x] `README.md` Quick start

## Ship gate
- [x] All tests pass — smoke 239/239, shellcheck clean (verified at HEAD `e8222e3`) — smoke + shellcheck green at HEAD
- [x] code-reviewer passed (`ship` verdict; 3 of 7 nits fixed in `e8222e3`, others deferred)
- [~] (conditional) security-reviewer — N/A (no auth/input/crypto/deps surface; gh CLI invocations only)
- [x] Docs in sync — ADR-0002 + SPEC §1.7 + README quick-start coherent after `e8222e3`
- [x] PR body curated
- [ ] CI green

