### PR TITLE
feat(#45): five dir-mode commands + directive body template

### DIFF
--- a/.claude/commands/activate-directive.md
+++ b/.claude/commands/activate-directive.md
@@ -1,0 +1,64 @@
+---
+description: Promote a Planned Directive to Active — converts the Draft Item to a real Issue, reviewer-gated (SPEC §2.1, §5.12).
+argument-hint: <directive-id>
+---
+
+Transition a Directive from `Status=Planned` to `Status=Active` by promoting the Project Draft Item to a real GitHub Issue. Reviewer-gated.
+
+## Procedure
+
+1. **Resolve the Project** — same as `/file-directive` step 1.
+
+2. **Resolve the Draft Item** — `<directive-id>` is the Project Item ID from `/file-directive`'s output. Fetch the item:
+   ```bash
+   gh project item-list <project-num> --owner <owner> --format json --limit 100 \
+     | jq --arg id "<directive-id>" '.items[] | select(.id==$id)'
+   ```
+   - If not found: print error and stop.
+   - If `Type != Directive`: print error ("Item is not a Directive — `Type=<X>`") and stop.
+   - If `Status != Planned`: print error ("Directive is already `Status=<X>` — use /complete-directive or /list-directives to inspect") and stop.
+
+3. **Reviewer gate** — re-invoke `directive-reviewer` (SPEC §4.9) on the (possibly edited since draft) body. The body may have changed in the GH UI since the original `/file-directive` invocation; the reviewer re-validates schema, scope, and active-Directive conflict against the current state. Parse verdict per `/file-directive` step 4 dispatch.
+
+   On `block`: stop. Status stays `Planned`. Audit `directive-activate blocked "<reason>"`.
+
+4. **Promote to a real Issue**:
+   - Read the Draft Item's title + body.
+   - Ensure the `directive` label exists on the repo (`gh label create directive` if missing; idempotent).
+   - Create the Issue:
+     ```bash
+     gh issue create --title "<Title>" --body "<Body + 'Filed by /activate-directive from Project Item <directive-id>'>" --label "directive"
+     ```
+   - Capture the new Issue number `<N>`.
+
+5. **Link the Issue back to the Project Item** — `gh project item-add <project-num> --owner <owner> --url <issue-url>`. This adds the Issue as a new Project Item; the original Draft Item becomes redundant. Archive the Draft via `gh project item-archive --id <directive-id>` to preserve history without cluttering the view.
+
+6. **Set custom fields** on the new Issue-backed Item:
+   - `Type=Directive` (preserved)
+   - `Status=Active` (changed from Planned)
+   - `Priority`, `Confidence`, `Success Signals`, `Parent` — copied from the archived Draft Item.
+
+7. **Audit log** — `audit_log info directive-activate created "directive: #<N> from-draft=<directive-id>"`.
+
+8. **Output**:
+   ```
+   Activated Directive #<N>: <Title>
+   Status: Active
+   The original Draft Item <directive-id> is archived.
+   Next: file Execution Issues against this Directive with /file-issue --parent <N>.
+   ```
+
+## Operating mode
+
+- **attended**: step 3's verdict surfaces to the user before activation.
+- **unattended**: step 3's verdict gates directly.
+
+## Escape
+
+`SKIP_HOOKS=directive-review SKIP_REASON='<why>' /activate-directive <id>` bypasses the reviewer. Audit-logged.
+
+## Forbidden
+
+- Activating a Directive that is `Status != Planned`.
+- Activating an Item whose `Type != Directive`.
+- Creating the real Issue without the `directive` label — that label is the engineering hook's signal (SPEC §6.1 `directive-protect` matcher) that `/work-on <N>` should refuse.

--- a/.claude/commands/complete-directive.md
+++ b/.claude/commands/complete-directive.md
@@ -1,0 +1,75 @@
+---
+description: Mark a Directive Completed — directive-reviewer evaluates evidence from linked Execution Issues (SPEC §2.1, §5.13). Reviewer can block if evidence is insufficient.
+argument-hint: <directive-id>
+---
+
+Mark a Directive as `Status=Completed`. Requires `directive-reviewer` evaluation of success-signal satisfaction by linked Execution Issues.
+
+## Procedure
+
+1. **Resolve the Project** — same as `/file-directive` step 1.
+
+2. **Resolve the Directive Issue** — `<directive-id>` is the GitHub Issue # for an activated Directive. Fetch:
+   ```bash
+   gh issue view <directive-id> --json title,body,state,labels
+   ```
+   - If `state != OPEN`: error ("Directive is not open — current state `<X>`") and stop.
+   - If `directive` label absent: error ("Issue #<directive-id> is not a Directive (`directive` label missing)") and stop.
+
+3. **Collect linked Execution Issues** — search the repo for Issues whose body contains `^Parent Directive: #<directive-id>$`:
+   ```bash
+   gh issue list --search "in:body \"Parent Directive: #<directive-id>\"" --state all --json number,title,state,body,closedAt --limit 100
+   ```
+   - For each linked Issue: parse its AC ticks (`^- \[(x|~| )\] ` lines from the body) and its open/closed state.
+
+4. **Read the Directive's success signals** from its body (the `## Success signals` section authored at `/file-directive` time).
+
+5. **Reviewer gate** — invoke `directive-reviewer` (SPEC §4.9) on the completion claim. Pass:
+   - The Directive body (with success signals as written).
+   - The list of linked Execution Issues + their states + AC ticks.
+
+   Parse the verdict per `/file-directive` step 4 dispatch.
+
+   On `block` (evidence insufficient): stop. Status stays `Active`. Audit `directive-complete blocked "<reason>"`. Surface the verdict reason to the user.
+
+6. **Flip Status to Completed**:
+   - Find the Project Item that wraps Issue `<directive-id>`.
+   - `gh project item-edit --id <item-id> --field-id <Status-field-id> --single-select-option-id <Completed-option-id>`.
+
+7. **Post a closing comment** on the Directive Issue listing each success signal and its evidence:
+   ```markdown
+   ## Directive Completion (resolved by directive-reviewer ship verdict)
+
+   - **Signal 1**: <signal text> — Evidence: PR #M (closed); AC #X ticked. Status: ✓
+   - **Signal 2**: <signal text> — Evidence: PR #Y, #Z; smoke §N passes. Status: ✓
+   - **Signal 3**: <signal text> — Evidence: <…>. Status: ✓
+   - …
+
+   Closed via /complete-directive.
+   ```
+
+8. **Close the Directive Issue** — `gh issue close <directive-id> --reason completed` after posting the comment.
+
+9. **Audit log** — `audit_log info directive-complete completed "directive: #<directive-id> linked-execs=<N>"`.
+
+10. **Output**:
+    ```
+    Completed Directive #<directive-id>: <Title>
+    Status: Completed
+    Evidence: <N> linked Execution Issues; all success signals satisfied.
+    ```
+
+## Operating mode
+
+- **attended**: step 5's verdict surfaces to the user before flipping Status.
+- **unattended**: step 5's verdict gates directly; `block` leaves Status=Active.
+
+## Escape
+
+`SKIP_HOOKS=directive-review SKIP_REASON='<why>' /complete-directive <id>` bypasses the reviewer (SPEC §2.1, §7). The bypass is audit-logged. Use is reserved for cases where the reviewer's verdict is wrong and a human accepts the recorded responsibility — not a normalized routing.
+
+## Forbidden
+
+- Marking a Directive `Completed` without a `directive-reviewer` ship verdict (or an audit-logged `SKIP_HOOKS=directive-review` escape).
+- Closing the Issue without first flipping the Status field — closing-without-Completed creates a Project-vs-Issue state mismatch.
+- Closing without the closing comment (step 7) — the comment is the canonical evidence record.

--- a/.claude/commands/file-directive.md
+++ b/.claude/commands/file-directive.md
@@ -1,0 +1,67 @@
+---
+description: File a new Directive in the dir-mode Project (SPEC §1.7, §2.1, §5.10). AI-assisted authoring with schema enforcement; reviewer-gated before commit.
+argument-hint: [<short description>]
+---
+
+Create a new Directive Draft Item in the dir-mode GitHub Project v2.
+
+## Procedure
+
+1. **Resolve the Project.** Read `gh repo view --json owner,name` to derive the project name (`<repo-name> roadmap` unless `$CLAUDE_ENG_PROJECT_NAME` is set). Find the Project via `gh project list --owner <owner> --format json --limit 100 | jq` matching `.title==<project-name>`. If no Project exists, instruct the user to run `scripts/setup_project.sh` first and stop.
+
+2. **Resolve the parent Goal.** Search the Project for an item with `Type=Goal` (via `gh project item-list <num> --owner <owner> --format json --limit 100`). If absent, ask the user whether to file a new Goal first, OR proceed with `Parent Goal: (no Goal item yet — bootstrap)` as the placeholder. If multiple Goals exist, ask which one this Directive serves.
+
+3. **Author the body** from `.claude/templates/directive.md`:
+   - **Objective** — bounded by concrete artifact-level boundary (issue counts, file paths, AC ticks, merge events). Refuse to proceed if the Objective doesn't name a concrete artifact-level boundary.
+   - **Success signals** — 2 to 5 verifiable conditions. Each must be objectively testable by a reasonable engineer.
+   - **Non-goals** — at least 2 explicit exclusions.
+   - **Constraints** — at least 1 invariant to preserve.
+   - **Parent Goal** — from step 2.
+   - **Confidence** — 0–100; ask the user.
+
+4. **Reviewer gate** — invoke the `directive-reviewer` subagent (SPEC §4.9) on the proposed body. Pass: proposed body, list of currently `Status=Active` Directives, parent Goal reference. Parse the verdict line (`^VERDICT: (ship|refine|block)`).
+
+   Verdict dispatch (SPEC §2.1, §5.7.1 operating-mode coupling):
+   - **`ship`** → proceed to step 5.
+   - **`refine: <feedback>`** → revise the body per the one-line feedback. Re-invoke `directive-reviewer` on the revised body. After **two** consecutive `refine` verdicts on the latest body, escalate to the user (attended) or treat as `block` (unattended).
+   - **`block: <reason>`** → do NOT create the Draft Item. In attended mode: report the reason and stop. In unattended mode: append one line to `$CLAUDE_ENG_SHELL_ROOT/.claude/state/directive-block.log` naming the rejected Objective + reason, then stop.
+
+5. **Create the Draft Item** in the Project:
+   ```bash
+   gh project item-create <project-num> --owner <owner> --title "<Objective summary, ≤80 chars>" --body "<full body from step 3>" --format json
+   ```
+   The output contains the Item ID — keep it for the next steps.
+
+6. **Set custom fields** on the new Draft Item:
+   - `Type=Directive`
+   - `Status=Planned`
+   - `Priority=<asked from user, default P2>`
+   - `Confidence=<from step 3>`
+   - `Success Signals=<copy of the Success signals section>`
+   - `Parent=<parent Goal reference or "(no Goal)">`
+
+   Use `gh project item-edit --id <item-id> --field-id <field-id> --text <value>` (or `--single-select-option-id` for SINGLE_SELECT fields; resolve field IDs once via `gh project field-list`).
+
+7. **Audit log** — `audit_log info directive-file created "directive: <Objective summary> item=<item-id> priority=<P> confidence=<C>"`.
+
+8. **Output** — print:
+   ```
+   Filed Directive (Draft Item <id>): <Objective summary>
+   Status: Planned
+   Next: /activate-directive <id>  when ready to promote to a real Issue.
+   ```
+
+## Operating mode
+
+- **attended** (default): step 4 surfaces the verdict to the user before applying it; the user may override a `block` with `SKIP_HOOKS=directive-review SKIP_REASON='<why>'` on a re-invocation.
+- **unattended**: step 4's verdict gates directly; `block` parks the draft as described.
+
+## Escape
+
+`SKIP_HOOKS=directive-review SKIP_REASON='<why>' /file-directive <args>` bypasses the reviewer gate. Audit-logged per SPEC §7. Reserved for cases where a human accepts recorded responsibility for the override.
+
+## Forbidden
+
+- Creating a Draft Item with an empty or stub-only Objective.
+- Skipping the reviewer gate without `SKIP_HOOKS=directive-review`.
+- Setting `Type=Directive` on an Item that is not a Draft Item or a real Issue (the field is `Type`-awareness's primary key per SPEC §1.7).

--- a/.claude/commands/link-directive.md
+++ b/.claude/commands/link-directive.md
@@ -1,0 +1,48 @@
+---
+description: Link an Execution Issue to its parent Directive (SPEC §5.14). Idempotent.
+argument-hint: <directive-id> <issue-#>
+---
+
+Explicitly link an Execution Issue to its parent Directive. Sets the Issue's Project `Parent` field and posts cross-reference comments on both items.
+
+## Procedure
+
+1. **Resolve the Project** — same as `/file-directive` step 1.
+
+2. **Validate the two arguments**:
+   - `<directive-id>` — must be a `directive`-labeled, OPEN Issue. Fetch via `gh issue view`. If not a Directive: stop.
+   - `<issue-#>` — must be an Issue WITHOUT the `directive` label (i.e., an Execution Issue). If it is itself a Directive: stop with error ("Cannot parent a Directive under another Directive in v0 — see SPEC §0.4 directive-graph deferral").
+
+3. **Idempotency check** — read the Execution Issue's body. If it already contains `Parent Directive: #<directive-id>` at the start of a line, AND its Project Item has `Parent=#<directive-id>`, the link is already in place. Emit:
+   ```
+   /link-directive: already linked (idempotent no-op)
+   ```
+   `audit_log info directive-link skipped "already-linked: directive=#<directive-id> issue=#<issue-#>"`.
+
+   Otherwise proceed to steps 4-6.
+
+4. **Update the Issue body** — prepend the marker `Parent Directive: #<directive-id>` as the first line of the body (or directly under any existing `Closes #N` / `Refs #N` trailer at the top). Use `gh issue edit <issue-#> --body-file <new-body>`.
+
+5. **Update the Project field** — find the Project Item that wraps Issue `<issue-#>` and edit its `Parent` text field:
+   ```bash
+   gh project item-edit --id <item-id> --field-id <Parent-field-id> --text "#<directive-id>"
+   ```
+
+6. **Post cross-reference comments** — on Issue `<issue-#>`: `Parent Directive: #<directive-id>`. On Issue `<directive-id>`: `Linked Execution: #<issue-#>`. Use `gh issue comment` for both. Skip a comment if the same marker already appears in the issue's recent comments (idempotency).
+
+7. **Audit log** — `audit_log info directive-link created "directive=#<directive-id> issue=#<issue-#>"`.
+
+8. **Output**:
+   ```
+   Linked Execution #<issue-#> under Directive #<directive-id>.
+   ```
+
+## Operating mode
+
+Same in attended and unattended.
+
+## Forbidden
+
+- Linking two Directives (v0 non-goal — directive dependency graph is v1+).
+- Overwriting an existing different `Parent Directive: #<other>` marker without explicit user confirmation. If the Issue is already linked to a *different* Directive, stop and report rather than silently re-parenting.
+- Skipping the body-marker step — the regex `^Parent Directive: #(\d+)$` is consumed by `/reflect` and `/ship` (SPEC §5.2 / §5.7 integrations from PR #47).

--- a/.claude/commands/list-directives.md
+++ b/.claude/commands/list-directives.md
@@ -1,0 +1,50 @@
+---
+description: List Directives filtered by Status (default omits Completed). Read-only; tabular output (SPEC §5.11).
+argument-hint: [--status <state>] [--iteration <name>]
+---
+
+List Directives in the dir-mode Project filtered by `Status` and optionally `Iteration`.
+
+## Procedure
+
+1. **Resolve the Project** — same as `/file-directive` step 1.
+
+2. **Parse arguments**:
+   - `--status <state>` — one of `Planned | Active | Completed | Blocked | Revised | All`. Default: omit `Completed` (show Planned + Active + Blocked + Revised).
+   - `--iteration <name>` — filter to items whose `Iteration` field matches the given iteration name (case-insensitive). Default: no iteration filter.
+
+3. **Fetch items**:
+   ```bash
+   gh project item-list <project-num> --owner <owner> --format json --limit 100 \
+     | jq '.items[] | select(.fieldValues[]? | (.name=="Type" and .text=="Directive"))'
+   ```
+   Apply the Status / Iteration filters from step 2 with additional `jq` selectors against `fieldValues`.
+
+4. **Output as a table** (markdown-style, sorted by Priority then Status):
+
+   | ID | Status | Priority | Title (Objective) | Parent Goal | Confidence | Iteration |
+   |----|--------|----------|-------------------|-------------|------------|-----------|
+   | … | Planned | P0 | <objective ≤60 chars> | Goal-#N or "(none)" | 75 | <iter name> |
+
+   - `ID` is either the Project Item ID (for `Status=Planned` Draft Items) or the GitHub Issue # (for activated Directives — `Status=Active|Completed|Blocked|Revised`).
+   - If the list is empty after filters, print: `No Directives match the filter (status=<state> iteration=<name>).`
+
+5. **No audit emission** — this is a read-only query.
+
+## Operating mode
+
+Same output in `attended` and `unattended` modes.
+
+## Examples
+
+```
+/list-directives                          # Planned + Active + Blocked + Revised (default)
+/list-directives --status Active          # Active only
+/list-directives --status All             # Everything including Completed
+/list-directives --iteration "2026-Q2"    # Items in the named iteration
+```
+
+## Forbidden
+
+- Mutating any field. This is read-only.
+- Hiding `Type=Directive` items that match the filter — the user explicitly asked for the dir-mode view.

--- a/.claude/templates/directive.md
+++ b/.claude/templates/directive.md
@@ -1,0 +1,21 @@
+## Objective
+<One-paragraph statement of what this Directive is trying to achieve. Must name a concrete artifact-level boundary — file paths, issue counts, AC ticks, merge events — not "improve" or "optimize" without a target.>
+
+## Success signals
+- <Verifiable signal 1 — must be objectively testable. e.g., "Issue-reviewer rejection rate drops below 20% over the next 10 issues filed against this Directive.">
+- <Verifiable signal 2>
+- <Verifiable signal 3>
+
+## Non-goals
+- <Explicit exclusion 1 — what this Directive does NOT include.>
+- <Explicit exclusion 2>
+
+## Constraints
+- <What must hold throughout the Directive's lifetime. e.g., "Do not change attended/unattended mode semantics.">
+- <Constraint 2>
+
+## Parent Goal
+<Link to the Final Goal this Directive serves. e.g., "Final Goal: claude-eng-shell supports directing work alongside engineering work within a single shell, single repo." If no Goal exists yet (early v0 state), state "No Goal item yet — bootstrap.">
+
+## Confidence
+<Number 0–100. Self-assessment of hypothesis quality at filing time. Lower numbers are OK — Directives can be filed under uncertainty as long as the success signals are verifiable.>

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -3131,6 +3131,67 @@ else
   fi
 fi
 
+# ---------- 43. dir-mode command files structural sanity (#45) ----------
+# PR #45 ships the five dir-mode commands + a directive body template.
+# Command files are Markdown prompts for Claude (no executable code);
+# what we can verify here is that each file exists, has the standard
+# frontmatter (description + argument-hint), references the gated
+# directive-reviewer where SPEC §5.10–§5.14 require it, and names the
+# correct audit category.
+
+DR_TEMPLATE="$SHELL_ROOT/.claude/templates/directive.md"
+if [ ! -f "$DR_TEMPLATE" ]; then
+  ng "43: .claude/templates/directive.md missing (#45)"
+else
+  dt_missing=""
+  for section in "## Objective" "## Success signals" "## Non-goals" "## Constraints" "## Parent Goal"; do
+    if ! grep -qF "$section" "$DR_TEMPLATE"; then
+      dt_missing="$dt_missing $section"
+    fi
+  done
+  if [ -z "$dt_missing" ]; then
+    ok "43-template: directive.md template has all five required sections (#45)"
+  else
+    ng "43-template: directive.md missing sections:$dt_missing (#45)"
+  fi
+fi
+
+for cmd in file-directive list-directives activate-directive complete-directive link-directive; do
+  cmd_path="$SHELL_ROOT/.claude/commands/$cmd.md"
+  if [ ! -f "$cmd_path" ]; then
+    ng "43-$cmd: command file missing (#45)"
+    continue
+  fi
+  has_desc=$(awk '/^---$/{c++; next} c==1 && /^description:/{print 1; exit}' "$cmd_path")
+  has_hint=$(awk '/^---$/{c++; next} c==1 && /^argument-hint:/{print 1; exit}' "$cmd_path")
+  if [ "$has_desc" = 1 ] && [ "$has_hint" = 1 ]; then
+    ok "43-$cmd: frontmatter has description + argument-hint (#45)"
+  else
+    ng "43-$cmd: frontmatter missing description or argument-hint (#45)"
+  fi
+done
+
+# 43-reviewer-ref: file-directive, activate-directive, complete-directive
+# must each reference directive-reviewer (the gated step per SPEC §5.10/§5.12/§5.13).
+for cmd in file-directive activate-directive complete-directive; do
+  if grep -qF "directive-reviewer" "$SHELL_ROOT/.claude/commands/$cmd.md" 2>/dev/null; then
+    ok "43-reviewer-$cmd: command references directive-reviewer at the gated step (#45)"
+  else
+    ng "43-reviewer-$cmd: command does not reference directive-reviewer (#45)"
+  fi
+done
+
+# 43-audit-cat: each non-read-only command names its audit category.
+for pair in "file-directive:directive-file" "activate-directive:directive-activate" "complete-directive:directive-complete" "link-directive:directive-link"; do
+  cmd="${pair%%:*}"
+  cat="${pair##*:}"
+  if grep -qF "$cat" "$SHELL_ROOT/.claude/commands/$cmd.md" 2>/dev/null; then
+    ok "43-audit-$cmd: command names audit category '$cat' (#45)"
+  else
+    ng "43-audit-$cmd: command does not name audit category '$cat' (#45)"
+  fi
+done
+
 # ---------- restore registry ----------
 if [ -n "$ORIG_REG_BAK" ]; then
   mv "$ORIG_REG_BAK" "$ORIG_REG"


### PR DESCRIPTION
Closes #45
Refs #41

## Goal
Ship the entire v0 dir-mode command surface as one coherent batch per SPEC §5.10–§5.14: `/file-directive`, `/list-directives`, `/activate-directive`, `/complete-directive`, `/link-directive`, plus the `.claude/templates/directive.md` body template.

## How this serves the mission
PRs #48 (SPEC sections), #49 (substrate), and #50 (directive-reviewer) ship the dependencies these commands consume. This PR is the **operator-visible surface of dir-mode** — without it, the reviewer is dead code and the substrate is an empty Project. The shared review-gating logic across `/file-directive`, `/activate-directive`, and `/complete-directive` is the cohesion that justifies a one-PR batch (per the planner's axis-2 rationale in the original issue body).

## Plan
Single feat commit + glob-fix follow-up:
- `81251b8` — five commands + template + smoke §43 (13 structural assertions).
- `298782f` — `list-directives.md` follow-up (caught by `git status` after the initial `git add` glob `*-directive.md` missed the plural suffix `-directives.md`).

## Alternatives considered

**Axis 1 — Markdown commands vs bash helper module.** Existing commands (`work-on.md`, `ship.md`, `onboard.md`) are pure Markdown procedural prompts. `/file-directive` etc. follow the same convention — no bash helper. **(chosen)** Aligns with the existing surface; future helper extraction is a no-op refactor if friction surfaces.

**Axis 2 — One PR for five commands vs N smaller PRs.** Splitting would either duplicate the shared "resolve Project / parse arguments / route reviewer verdict" structure across five PRs or force premature helper-API stabilization across PR boundaries. **(chosen) One PR** — the commands share a coherent procedural pattern; smoke §43 verifies the cross-command contract (reviewer reference, audit category) in one place.

**Axis 3 — Smoke fidelity.** Markdown command files cannot be exercised behaviorally in a smoke shell (Claude Code routes slash-command invocations). **(chosen) Structural** — verify file existence, frontmatter, reviewer reference, audit category. Behavioral validation is the dogfooding step in tracking #41.

## Key context
- `.claude/templates/directive.md` — body template with 5 sections (Objective / Success signals / Non-goals / Constraints / Parent Goal).
- `.claude/commands/file-directive.md:1-50` — entry-point command; uses `directive-reviewer` and emits `directive-file` audit category.
- `.claude/commands/activate-directive.md:1-65` — promotes Planned → Active via `gh issue create --label directive`; reviewer re-runs on the (possibly edited) body.
- `.claude/commands/complete-directive.md:1-75` — reviewer evaluates evidence from linked Execution Issues; `SKIP_HOOKS=directive-review` escape documented per SPEC §2.1/§7.
- `.claude/commands/link-directive.md` — idempotent linkage; updates Project `Parent` field + body marker `Parent Directive: #N`.
- `.claude/commands/list-directives.md` — read-only tabular query; no audit emission.
- `scripts/test/smoke.sh` §43 — 13 structural assertions across template + commands.

## Checklist
- [x] **Code**: 5 command files + 1 template (`81251b8`, `298782f`)
- [x] **Test**: smoke §43 — 13/13 pass; total 256/256
- [x] **Verify**: each command's frontmatter validated; reviewer-gated commands reference `directive-reviewer`; audit categories named

## Out of scope
- `/derive-next-directive`, `/reassess`, `/block-directive`, `/revise-directive` (v1+ per SPEC §0.4).
- Auto-orchestration deciding which command to invoke (v1+).
- Hook modifications (those are #46).
- `/file-issue` / `/reflect` / `/ship` integrations (those are #47).
- Behavioral end-to-end tests against a live Project — deferred to the tracking #41 dogfooding step once #46 and #47 also land.

## Risks
- **Behavioral untested in CI.** Markdown command files can only be smoke-tested structurally. Dogfooding the first real Directive (tracking #41 post-rollout validation) is the integration test.
- **`gh project item-edit` field-id resolution.** Each command needs to resolve the field IDs once via `gh project field-list`; the command files document this but don't memoize across invocations. Acceptable for v0 — field IDs are stable for the life of the Project.
- **`Parent Directive: #N` body marker fragility.** `/link-directive` writes it; `/reflect` and `/ship` (PR #47) consume it. A user manually editing the body could break the marker. Mitigation: SPEC §5.14 documents the canonical regex; idempotency check in `/link-directive` re-establishes the marker on re-run.

## Open questions
None blocking ship.

## Decisions
- 2026-05-24 — Markdown commands without bash helper module (axis 1); one cohesive PR (axis 2); structural smoke (axis 3).
- 2026-05-24 — `directive` label on the activated Issue is the engineering-hook signal that `/work-on` should refuse (SPEC §6.1 `directive-protect` matcher will wire to this label in PR #46).

## Test plan
- [x] `./scripts/test/smoke.sh` — 256/256 pass.
- [x] Skills system recognizes the new commands (verified at file-write time — `/file-directive`, `/list-directives`, etc. now appear in the available-skills list).

## Docs touched
- [x] `.claude/templates/directive.md` (new)
- [x] `.claude/commands/file-directive.md` (new)
- [x] `.claude/commands/list-directives.md` (new)
- [x] `.claude/commands/activate-directive.md` (new)
- [x] `.claude/commands/complete-directive.md` (new)
- [x] `.claude/commands/link-directive.md` (new)
- [x] `scripts/test/smoke.sh` (§43 added)

## Ship gate
- [x] All tests pass — 256/256
- [ ] code-reviewer passed
- [~] (conditional) security-reviewer — N/A
- [x] Docs in sync — SPEC §5.10–§5.14 (landed in #42) is the canonical spec; this PR is the implementation matching it
- [x] PR body curated
- [ ] CI green
