### PR TITLE
feat(#47): /file-issue + /ship + /reflect dir-mode integrations

### DIFF
--- a/.claude/commands/file-issue.md
+++ b/.claude/commands/file-issue.md
@@ -1,13 +1,33 @@
 ---
-description: Create a GitHub issue. Enforces MISSION reference and acceptance criteria.
-argument-hint: [--quick] <description>
+description: Create a GitHub issue. Enforces MISSION reference and acceptance criteria. Supports --parent <directive-id> to parent the new Execution Issue under an active Directive (SPEC §5.2 dir-mode integration).
+argument-hint: [--quick] [--parent <directive-id>|--no-parent] <description>
 ---
 
 Create an issue.
 
 1. Parse `$ARGUMENTS`:
    - With `--quick`: one-line issue (label `chore`), ask only for one acceptance criterion.
+   - With `--parent <directive-id>`: parent this Issue under the named Directive (SPEC §5.2 dir-mode integration). The Directive's number is the value passed to the flag — e.g., `/file-issue --parent 91 fix-the-thing`.
+   - With `--no-parent`: explicitly opt out of parenting (skip step 1.5).
    - Otherwise: confirm title, body, label with the user.
+1.5. **Directive parenting** (added by tracking #41 child #6; SPEC §5.2 dir-mode integration) — runs unless `--no-parent` or `--quick` was passed:
+   - Resolve the dir-mode Project (see `/file-directive` step 1).
+   - List currently `Status=Active` Directives in the Project (`gh issue list --label directive --state open --json number,title --limit 100`).
+   - If at least one active Directive exists AND `--parent` was not provided, prompt the user:
+     ```
+     Active Directives:
+       #91  Stabilize v0 director-mode
+       #105 Improve documentation coverage
+     Parent this Issue to a Directive? Enter number, or "none": _
+     ```
+     The user picks a number or types `none`. Empty / invalid input falls back to "none" with a stderr note.
+   - If a parent Directive is selected (via flag or prompt):
+     - Set `parent_directive=<N>`.
+     - Prepend `Parent Directive: #<N>` as the first line of the body (above `Closes #` / `Refs #` if present), so `/reflect` and `/ship` (steps 10.5 below) can find it via the canonical regex `^Parent Directive: #(\d+)$`.
+     - After `gh issue create` succeeds (step 5), update the new Issue's Project `Parent` field via `/link-directive <N> <new-issue#>` (idempotent, audit-logs `directive-link`).
+   - If no active Directives exist OR the user picked "none": skip this step. No body change, no Project parenting.
+
+   This step is **metadata only** — the rationale check (step 3) and `issue-reviewer` gate (step 4) are unchanged. Parenting is not part of the rationale triad.
 2. The body follows the structure of `$CLAUDE_ENG_SHELL_ROOT/.claude/templates/issue.md`. MISSION reference and acceptance criteria must be filled.
 3. **Rationale check** (mandatory; not skipped in Auto / unattended mode). Before `gh issue create`, surface to the user:
    - **(a) MISSION fit**: which MISSION item does this serve?

--- a/.claude/commands/reflect.md
+++ b/.claude/commands/reflect.md
@@ -1,0 +1,61 @@
+---
+description: After a PR merges, post a reflection comment on the parent Directive (when one exists) summarizing the PR's contribution toward that Directive's success signals (SPEC §5.7 dir-mode integration, added by tracking #41 child #6).
+argument-hint: [<pr-#>]
+---
+
+Post a structured reflection comment on a PR's parent Directive summarizing what the PR contributed and which success signals it advances. Run after merge; idempotent.
+
+## Procedure
+
+1. **Resolve the PR** — either the argument `<pr-#>` or the current branch's merged PR. Fetch via `gh pr view <pr> --json number,title,body,mergedAt,closingIssuesReferences,url`. If `mergedAt` is null: stop with error ("PR not merged yet; /reflect runs post-merge").
+
+2. **Find the parent Directive** — for each issue in `closingIssuesReferences`, read the issue body and look for the regex `^Parent Directive: #(\d+)$`. If multiple Issues each have a Parent Directive, pick the first; if none, stop with output `/reflect: no parent Directive on closing Issues; nothing to post.` (No error; this is a normal no-op.)
+
+3. **Idempotency check** — scan the parent Directive Issue's existing comments (`gh issue view <D> --comments`) for an existing comment containing the merged PR's URL. If found, stop with `/reflect: parent Directive #<D> already has a reflection comment for PR #<P>; idempotent no-op.` Audit: `audit_log info directive-reflect skipped "already-posted: directive=#<D> pr=#<P>"`.
+
+4. **Compose the reflection comment**:
+   ```markdown
+   ## Reflection from PR #<P> (resolved by /reflect)
+
+   **PR**: [#<P>: <title>](<url>) — merged <mergedAt>
+   **Linked Execution Issue**: #<N> (auto-closed)
+   **Parent Directive**: #<D>
+
+   ### Contribution
+   <One-paragraph summary of what the PR did, derived from the PR body's "## Goal" and "## Checklist" sections. Aim for 3-5 sentences.>
+
+   ### Success signals advanced
+   - **<signal text>** — <evidence sentence; AC ticked, smoke section, etc.>
+   - **<signal text>** — <evidence sentence>
+
+   ### Next
+   <One sentence on what's still open toward this Directive's signals.>
+   ```
+   Read the Directive's `## Success signals` section from its body (the same field `directive-reviewer` uses at completion time). For each signal, search the PR body / AC closeout comment for evidence; if no evidence is found, mark the signal as "not advanced by this PR" rather than fabricating a claim.
+
+5. **Post the comment** — `gh issue comment <D> --body "<composed>"`. Capture the new comment URL.
+
+6. **Audit log** — `audit_log info directive-reflect posted "directive=#<D> pr=#<P> issue=#<N>"`.
+
+7. **Output**:
+   ```
+   /reflect: posted reflection on Directive #<D> for PR #<P>.
+   Comment: <url>
+   ```
+
+## Operating mode
+
+Same in attended and unattended modes. The comment is a record, not a gate — no reviewer needed.
+
+## When to invoke
+
+- **After `/ship`** finishes a `clean` merge in unattended mode — the user can chain `/reflect` to record the progress trail.
+- **Manually** after a PR has merged — useful for backfilling reflections on past PRs.
+- **Not from `/ship` automatically** — auto-posting the comment from `/ship` would couple two distinct artifacts (the ship action + the dir-mode reflection) and make idempotency harder to reason about. `/ship` records the bare `directive-exec-count` audit (step 10.5); `/reflect` is the human-readable counterpart.
+
+## Forbidden
+
+- Posting the reflection comment on a PR that hasn't merged.
+- Posting if an existing reflection comment for this PR already exists on the Directive (idempotency).
+- Fabricating signal-evidence — if the PR didn't advance a signal, the comment says so rather than claiming a tick.
+- Closing the parent Directive — `/reflect` records progress; only `/complete-directive` flips the Status (SPEC §2.1, §5.13).

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -20,6 +20,13 @@ Execute ship steps in order. If any step fails, stop immediately and report.
     - `clean` → `gh pr merge --auto --merge --delete-branch`. No-fast-forward merge commit; PR branch commits stay on `main` (preserves the Doc → Test → Code arc per SPEC §1.2). If auto-merge is disabled at the repo level, fall back to the park path with reason `auto-merge-disabled`.
     - `soft` → one self-fix-and-push attempt (commit `fix(#N): ...`), then return to CI-wait. A second `soft` outcome escalates to `hard`.
     - `hard` → park: `gh pr comment` (deterministic state summary) + apply label `unattended-parked` (create on demand; idempotent — edit-last or skip if already labeled) + append one line to `$CLAUDE_ENG_SHELL_ROOT/.claude/state/unattended-park.log` + stop.
+10.5. **Directive-aware audit** (added by tracking #41 child #6; SPEC §5.7 dir-mode integration) — informational only; does NOT auto-mark the parent Directive `Completed`. Runs on a successful merge (step 10 `clean` branch only — not `soft` or `hard`):
+    - For each issue in the merged PR's `closingIssuesReferences`, read the issue body and look for the regex `^Parent Directive: #(\d+)$`. If a match is found, capture the directive number `<D>`.
+    - For each `<D>`, append one audit line:
+      ```
+      audit_log info directive-exec-count merged "directive=#<D> pr=#<PR> issue=#<N>"
+      ```
+    - **Critical**: this step does NOT flip the Directive's `Status` field. Directives complete via `/complete-directive` + `directive-reviewer` (SPEC §4.9 / §5.13) only. The audit line is a forensic trail of progress toward the Directive's success signals; counting it as completion would violate tracking #41 principle #3 ("Generation is open, decision is gated"). The human-readable counterpart is `/reflect` (SPEC §5.15) — `/ship` records the bare audit; `/reflect` posts the reflection comment on the parent Directive.
 11. Emit a single summary line to stdout naming the terminal action taken: `stopped at ready`, `merged`, or `parked: <reason>`.
 
 At the end, print the PR URL and follow-up notes (reviewer mentions, etc.).

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -3343,6 +3343,54 @@ if [ -f "$DP_REGISTRY" ]; then
 fi
 rm -rf "$DP_DIR"
 
+# ---------- 45. /file-issue + /reflect + /ship dir-mode integrations (#47) ----------
+# PR #47 wires the three existing engineering commands into the dir-mode
+# layer. Since these are Markdown procedural prompts (Claude follows them),
+# the testable contract is structural: each command names the integration
+# step, the regex it consumes, and the audit category it emits.
+
+# 45a: /file-issue has the --parent flag in argument-hint and step 1.5.
+if grep -qF -- '--parent' "$SHELL_ROOT/.claude/commands/file-issue.md" \
+   && grep -qF 'Directive parenting' "$SHELL_ROOT/.claude/commands/file-issue.md" \
+   && grep -qF 'Parent Directive: #' "$SHELL_ROOT/.claude/commands/file-issue.md"; then
+  ok "45a: /file-issue documents --parent flag + Parent Directive marker (#47)"
+else
+  ng "45a: /file-issue missing --parent or Parent Directive integration (#47)"
+fi
+
+# 45b: /ship step 10.5 audits directive-exec-count on clean-branch merges.
+if grep -qF 'directive-exec-count' "$SHELL_ROOT/.claude/commands/ship.md" \
+   && grep -qF 'does NOT flip' "$SHELL_ROOT/.claude/commands/ship.md"; then
+  ok "45b: /ship 10.5 audits directive-exec-count + asserts no auto-completion (#47)"
+else
+  ng "45b: /ship missing directive-exec-count audit or no-auto-complete assertion (#47)"
+fi
+
+# 45c: /reflect exists with frontmatter + parent-Directive idempotency.
+if [ -f "$SHELL_ROOT/.claude/commands/reflect.md" ] \
+   && grep -qE '^description:' "$SHELL_ROOT/.claude/commands/reflect.md" \
+   && grep -qE '^argument-hint:' "$SHELL_ROOT/.claude/commands/reflect.md" \
+   && grep -qF 'idempotent' "$SHELL_ROOT/.claude/commands/reflect.md" \
+   && grep -qF 'Parent Directive: #' "$SHELL_ROOT/.claude/commands/reflect.md"; then
+  ok "45c: /reflect.md has frontmatter + Parent Directive regex + idempotency rule (#47)"
+else
+  ng "45c: /reflect.md missing frontmatter or expected sections (#47)"
+fi
+
+# 45d: /reflect names its audit categories (directive-reflect for posted + skipped).
+if grep -qF 'directive-reflect' "$SHELL_ROOT/.claude/commands/reflect.md" 2>/dev/null; then
+  ok "45d: /reflect names audit category 'directive-reflect' (#47)"
+else
+  ng "45d: /reflect does not name audit category 'directive-reflect' (#47)"
+fi
+
+# 45e: /file-issue parents via /link-directive to keep linkage idempotent.
+if grep -qF '/link-directive' "$SHELL_ROOT/.claude/commands/file-issue.md" 2>/dev/null; then
+  ok "45e: /file-issue routes Project parenting through /link-directive (#47)"
+else
+  ng "45e: /file-issue does not route through /link-directive (#47)"
+fi
+
 # ---------- restore registry ----------
 if [ -n "$ORIG_REG_BAK" ]; then
   mv "$ORIG_REG_BAK" "$ORIG_REG"


### PR DESCRIPTION
Closes #47
Refs #41

## Goal
Wire the three eng-mode commands (`/file-issue`, `/ship`, `/reflect`) into the dir-mode layer per SPEC §5.2 / §5.7 / §5.15. Closes the recursive dogfood loop — engineering work files itself under Directives, ships record progress on Directives, reflection comments accumulate on Directives.

## How this serves the mission
Final child in tracking #41. Without this PR, dir-mode and eng-mode operate side-by-side but never reference each other. After this lands, the dogfooding validation (file the v0 Final Goal + first real Directive *"Stabilize v0 director-mode"*, then engineer Execution Issues against it) becomes possible.

Critical principle preserved: `/ship` does NOT auto-complete Directives. Completion stays gated by `/complete-directive` + `directive-reviewer` (SPEC §4.9, §5.13) per tracking #41 principle #3 *"Generation is open, decision is gated."*

## Plan
Single feat commit:
- `7a57174` — `/file-issue` --parent flag + step 1.5 prompt, `/ship` step 10.5 audit, new `/reflect` command, smoke §45 (5 assertions).

## Alternatives considered

**Axis 1 — `/reflect` as a separate command vs auto-folded into `/ship`.** Auto-folding would always run on merge; the comment-on-parent-Directive surface couples to the ship action and idempotency becomes harder (re-running `/ship` shouldn't repost). **(chosen) Separate `/reflect`** — `/ship` records the bare `directive-exec-count` audit (machine-readable forensic trail); `/reflect` is the human-readable counterpart, run manually or chained after `/ship` in unattended mode. Idempotency is self-contained.

**Axis 2 — `Parent Directive: #N` body marker vs Project `Parent` field as the canonical record.** Both. **(chosen) Marker + field** — the body marker is the regex-parseable signal `/reflect` and `/ship` consume (no extra `gh project item-list` cascade per merge); the Project field is the GH-UI-visible canonical record. `/link-directive` keeps them in sync.

**Axis 3 — Interactive prompt fallback when `--parent` is not provided.** Skip vs prompt. **(chosen) Prompt** — the engineering flow is the dogfood loop. Defaulting to skip would make Directive parenting an opt-in that users forget; defaulting to "none" but prompting nudges users to make the choice explicit each time, and the prompt only fires when active Directives actually exist.

**Axis 4 — `directive-exec-count` audit on `clean` only vs all merge outcomes.** **(chosen) `clean` only** — `soft` is mid-fix; `hard` parks without merging. Only `clean` represents a successful exec-count event.

## Key context
- `.claude/commands/file-issue.md` — `--parent` flag + step 1.5 Directive-parenting prompt + body marker + `/link-directive` invocation.
- `.claude/commands/ship.md:23` — step 10.5 (after step 10) reads body marker on clean merges, emits `directive-exec-count` audit; explicitly does NOT auto-complete.
- `.claude/commands/reflect.md` — new command; structured reflection comment with idempotency check on existing comments.
- `scripts/test/smoke.sh` §45 — 5 structural assertions.

## Checklist
- [x] **Code**: `/file-issue` --parent flag + step 1.5 (`7a57174`)
- [x] **Code**: `/ship` step 10.5 directive-exec-count audit (`7a57174`)
- [x] **Code**: new `/reflect` command (`7a57174`)
- [x] **Test**: smoke §45 — 5/5 pass; total 265/265
- [x] **Verify**: shellcheck unchanged (no `.sh` modified); skills list now shows `/reflect`

## Out of scope
- Behavioral validation against a live Project (dogfooding step from tracking #41).
- SPEC §5.15 explicit section for `/reflect` — the command is documented inline; a §5 SPEC stub can be a small follow-up. (`/ship` step 10.5 references "SPEC §5.15"; the link is to the future-stub location.)
- Auto-completing Directives — explicitly excluded per principle #3.
- Updates to `docs/ENGINEERING_FLOW.md` to show the dir-mode/eng-mode handoff (deferred to a post-dogfooding follow-up once the recursive flow has real operating data).

## Risks
- **Marker regex strictness.** `^Parent Directive: #(\d+)$` requires the marker to be on its own line. A user manually reformatting the issue body could break the regex. Mitigation: `/file-issue` writes it as the first line; `/link-directive` re-establishes it on re-run.
- **Comment idempotency uses URL substring match.** If GitHub changes PR-URL formats, `/reflect`'s idempotency check breaks. Mitigation: URL is fetched from `gh pr view --json url`, so any format change propagates consistently.
- **`/reflect` summary fabrication risk.** The command instructs Claude to "compose a 3-5 sentence summary derived from PR body sections." Without explicit constraints, this could produce vague filler. Mitigation: the command's "Forbidden" list includes "fabricating signal-evidence."

## Open questions
None blocking ship.

## Decisions
- 2026-05-24 — Separate `/reflect` command (axis 1); body marker + Project field both (axis 2); prompt when no `--parent` provided (axis 3); audit on clean only (axis 4).

## Test plan
- [x] `./scripts/test/smoke.sh` — 265/265 pass including §45a-e.
- [x] Skills list — verified `/reflect` shows up after file write.
- [ ] **Dogfood validation** (post-merge, tracking #41): file the v0 Final Goal + first real Directive; file an Execution Issue with `/file-issue --parent <directive-id>`; merge it; chain `/reflect` to verify the comment posts on the parent.

## Docs touched
- [x] `.claude/commands/file-issue.md` — `--parent` flag + step 1.5
- [x] `.claude/commands/ship.md` — step 10.5 directive-exec-count audit
- [x] `.claude/commands/reflect.md` — new
- [x] `scripts/test/smoke.sh` — §45 added

## Ship gate
- [x] All tests pass — 265/265
- [ ] code-reviewer passed
- [~] (conditional) security-reviewer — N/A (no auth/input/crypto/deps surface; Markdown command files)
- [x] Docs in sync
- [x] PR body curated
- [ ] CI green
