### PR TITLE
fix(#55): issue-reviewer filters Type=Directive from open-issues scan (under #54)

### DIFF
--- a/.claude/agents/issue-reviewer.md
+++ b/.claude/agents/issue-reviewer.md
@@ -9,7 +9,7 @@ You are the issue-reviewer. Called by `/file-issue` immediately before `gh issue
 ## Input
 - Proposed issue body (title + body + label), passed in the invocation.
 - Target `MISSION.md` (if absent, label as `(MISSION.md absent — review /onboard stub suggestion)`).
-- Open-issues list — fetch with `gh issue list --state open --limit 100 --json number,title,body`. The 100-cap is a heuristic, not authoritative; a near-cap list should be reported in the verdict reason so the caller knows existing-coverage may be incomplete.
+- Open-issues list — fetch with `gh issue list --state open --search "-label:directive" --limit 100 --json number,title,body`. The `-label:directive` exclusion is **Type-awareness** (SPEC §1.7): Directives (`Type=Directive` items) are parents of Execution Issues, not duplicate candidates for them. Overlap *between* Directives is `directive-reviewer`'s concern (§4.9), not yours. The 100-cap is a heuristic, not authoritative; a near-cap list should be reported in the verdict reason so the caller knows existing-coverage may be incomplete.
 
 ## Premise
 You assume no prior knowledge of the main assistant's discussion. The proposed body must stand on its own. The user / agent that drafted it is not your reference — only the four inputs above.
@@ -24,10 +24,11 @@ You assume no prior knowledge of the main assistant's discussion. The proposed b
 - Pass: a concrete trigger ("main CI red since X", "blocks unattended mode for users on Y", "PR review noise per N PRs").
 - Fail: "someday" / "would be nice" / no rationale given.
 
-**3. Existing-coverage** — scan the open-issues list for overlap:
-- A pre-existing open issue with the same title token or addressing the same file/function is a strong signal of duplicate work.
+**3. Existing-coverage** — scan the open-issues list (Type=Execution only — Directives are excluded at fetch time per the Input section) for overlap:
+- A pre-existing open Execution Issue with the same title token or addressing the same file/function is a strong signal of duplicate work.
 - An open PR that already touches the file the proposed issue names may be the cheaper venue (a comment on the PR or a follow-up commit).
 - If a duplicate or open-PR-coverage candidate exists, the verdict should be `block` or `refine` with a pointer.
+- If the proposed body declares a `Parent Directive: #<D>` (SPEC §5.2 dir-mode integration), do NOT treat the parent Directive as duplicate — it is the umbrella. Directive-vs-Directive overlap is `directive-reviewer`'s job, not yours.
 
 **4. Acceptance criteria** — explicit, testable, ≥1 item.
 - Pass: "[ ] X function returns Y on input Z" / "[ ] CI on main goes green."

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -3391,6 +3391,41 @@ else
   ng "45e: /file-issue does not route through /link-directive (#47)"
 fi
 
+# ---------- 46. issue-reviewer Type-aware open-issues scan (#55) ----------
+# PR #55 fixes a bug where issue-reviewer's existing-coverage check could
+# spuriously refine/block a proposed Execution Issue because an open
+# Directive (now part of the open-issues set after v0 dir-mode landed)
+# matched as duplicate. The fix is documentation: the agent file now
+# instructs the reviewer to exclude `-label:directive` at fetch time and
+# to treat any `Parent Directive: #<D>` declaration as umbrella-not-dup.
+IR_PATH="$SHELL_ROOT/.claude/agents/issue-reviewer.md"
+if [ ! -f "$IR_PATH" ]; then
+  ng "46: issue-reviewer.md missing (#55)"
+else
+  # 46a: open-issues fetch instruction includes the `-label:directive` exclusion.
+  if grep -qF -- '-label:directive' "$IR_PATH"; then
+    ok "46a: issue-reviewer fetches with -label:directive exclusion (#55)"
+  else
+    ng "46a: issue-reviewer fetch does not exclude Type=Directive (#55)"
+  fi
+
+  # 46b: Existing-coverage paragraph documents the Parent-Directive umbrella case.
+  if grep -qF 'Parent Directive' "$IR_PATH"; then
+    ok "46b: issue-reviewer documents the Parent Directive umbrella case (#55)"
+  else
+    ng "46b: issue-reviewer does not document Parent Directive umbrella case (#55)"
+  fi
+
+  # 46c: No regression — the three VERDICT-line forms remain documented.
+  if grep -qE '^- `VERDICT: ship' "$IR_PATH" \
+     && grep -qE '^- `VERDICT: refine' "$IR_PATH" \
+     && grep -qE '^- `VERDICT: block' "$IR_PATH"; then
+    ok "46c: issue-reviewer VERDICT-line format unchanged (ship/refine/block) (#55)"
+  else
+    ng "46c: issue-reviewer VERDICT-line format broken (#55)"
+  fi
+fi
+
 # ---------- restore registry ----------
 if [ -n "$ORIG_REG_BAK" ]; then
   mv "$ORIG_REG_BAK" "$ORIG_REG"


### PR DESCRIPTION
Parent Directive: #54
Closes #55

## Goal
Fix the bug where `issue-reviewer`'s existing-coverage check could spuriously refine/block a proposed Execution Issue because an open Directive (now part of the open-issues set after v0 dir-mode landed) matches as a duplicate.

## How this serves the mission
This is the **first real Execution Issue** under Directive #54 ("Stabilize v0 director-mode"). It advances Directive #54's success signals #1 (an Execution Issue merges and produces a `directive-exec-count` audit line) and #2 (a `/reflect` comment lands on the Directive). MISSION.md absent; de-facto per `.claude/CLAUDE.md` + SPEC §1.7 — Type-awareness must extend from engineering hooks into the reviewer surface so the dir-mode/eng-mode distinction is preserved end-to-end.

## Plan
Doc → Test (fix-type, but the doc-edit IS the fix, so the arc collapses cleanly to two commits):
- `f7c5494` — `.claude/agents/issue-reviewer.md` — Input fetch uses `-label:directive` exclusion; Existing-coverage paragraph documents the Parent-Directive umbrella case.
- `71ef389` — smoke §46 (3 assertions covering the exclusion, the umbrella case, and the no-regression VERDICT-line preservation).

## Alternatives considered
**Axis 1 — Filter at fetch (GitHub search) vs filter post-fetch (jq).** GitHub search `-label:directive` happens server-side; jq filter happens client-side after pulling the full list. **(chosen) Server-side** — smaller payload, fewer JSON rows for the reviewer to parse, no risk of the reviewer reading a partially-filtered list. The 100-row `--limit` cap stays accurate against the filtered set rather than the full set, which is the right semantic.

**Axis 2 — Doc-only fix vs CLI-wrapper helper.** The reviewer agent file is the contract the subagent reads at invocation time; no shell wrapper handles its fetch. **(chosen) Doc-only.** Adding a wrapper would split the contract from the subagent's prompt and make the filter invisible at the place it actually fires.

**Axis 3 — Should `directive-reviewer` mirror this change?** No — `directive-reviewer`'s input is `gh issue list --label "Type=Directive"` (the inverse filter); it's already scoped correctly. Out of scope here.

## Key context
- `.claude/agents/issue-reviewer.md:12` — fetch instruction updated.
- `.claude/agents/issue-reviewer.md:27-32` — Existing-coverage check rewritten for Type-awareness.
- `scripts/test/smoke.sh` §46 — 3 assertions.
- `Parent Directive: #54` on line 1 is consumed by `/ship` step 10.5 (emits `directive-exec-count` audit) and `/reflect` (posts reflection comment on #54).

## Checklist
- [x] **Doc/Code**: agent file edit (`f7c5494`)
- [x] **Test**: smoke §46 — 3/3 pass; total 268/268 (`71ef389`)
- [x] **Verify**: shellcheck unchanged (no `.sh` modified); no regression in other smoke assertions

## Out of scope
- Modifying `issue-reviewer`'s VERDICT-line format or rationale-triad checks.
- Mirroring the filter into `plan-reviewer` / `code-reviewer` / `security-reviewer` — none of them consume open-issues lists.
- Type-aware filter for `/status` display — `_status_collect` reads the PR-linked Issue, not a list.
- `gh search` fallback for installations on very old `gh` releases — `-label:` exclusion is stable since gh 2.x.

## Risks
- **GitHub Search syntax stability.** `-label:directive` exclusion is a documented and supported `gh search` filter; has been stable across `gh` versions. Mitigation: smoke §46a is the regression detector if the syntax ever shifts.
- **Reviewer invocation context drift.** If a future PR changes how `issue-reviewer` is invoked (e.g. a wrapper that pre-filters via jq), the agent-side filter becomes redundant rather than wrong — no harm.

## Open questions
None blocking ship.

## Decisions
- 2026-05-24 — Server-side filter (axis 1) for smaller payload + correct limit semantic; doc-only (axis 2); no mirroring to other reviewers (axis 3).

## Test plan
- [x] `./scripts/test/smoke.sh` — 268/268 including §46a-c.
- [x] No regression elsewhere — full suite green.
- [ ] **Post-merge**: verify `/ship` emits `directive-exec-count` audit referencing #54; verify `/reflect 56` (this PR) posts a reflection comment on #54.

## Docs touched
- [x] `.claude/agents/issue-reviewer.md`
- [x] `scripts/test/smoke.sh` (§46 added)

## Ship gate
- [x] All tests pass — 268/268
- [ ] code-reviewer passed
- [~] (conditional) security-reviewer — N/A (pure subagent-prompt edit)
- [x] Docs in sync
- [x] PR body curated
- [ ] CI green
