### PR TITLE
test(#58): smoke §34 covers directive-reviewer (under #54)

### DIFF
--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -1595,16 +1595,18 @@ mkdir -p "$COAUTHOR_TMP/.claude/state"
 
 rm -rf "$COAUTHOR_TMP"
 
-# ---------- 34. README currency (#65) ----------
+# ---------- 34. README currency (#65, extended for directive-reviewer #58) ----------
 # README.md is the project's landing page. Lock that it names all
-# eight subagents, the --base flag, the operating modes, and the
-# bootstrap dependencies. Future agent additions / flag changes
-# fail-fast here if they forget to update the README.
+# nine subagents (eight engineering + one dir-mode), the --base flag,
+# the operating modes, and the bootstrap dependencies. Future agent
+# additions / flag changes fail-fast here if they forget to update
+# the README.
 README_MD="$SHELL_ROOT/README.md"
 
 for agent in explorer planner doc-writer test-writer \
              code-reviewer security-reviewer \
-             issue-reviewer plan-reviewer; do
+             issue-reviewer plan-reviewer \
+             directive-reviewer; do
   if grep -q "$agent" "$README_MD" 2>/dev/null; then
     ok "readme: names subagent '$agent' (#65)"
   else


### PR DESCRIPTION
Parent Directive: #54
Closes #58

## Goal
Extend smoke §34's README-currency tripwire to include `directive-reviewer` in its iterated assertion, and correct the stale comment that named "eight subagents" (now nine since PR #50 / #44).

## How this serves the mission
Closes a nit `code-reviewer` flagged on PR #48 (finding #2) that `doc-writer` recommended fixing alongside the directive-reviewer agent file in PR #50 — but the alongside-PR-fix recommendation was missed at the time. Third of three Execution Issues under Directive [#54](https://github.com/ilgyu-yi/claude-eng-shell/issues/54), bringing the Execution count to the Objective's "at least three" bar.

## Plan
Single test commit:
- `70df8c8` — §34 comment + loop updated.

## Alternatives considered
**Axis 1 — Where to land the fix.** `doc-writer` on PR #48 said "in #44's PR" (lost). **(chosen) Standalone PR under #54** — a separate landing makes the rationale auditable in the dir-mode dogfood trail and counts toward #54's Execution-Issue count. Folding into another in-flight PR is no longer possible.

**Axis 2 — Loop format.** Add `directive-reviewer` inline vs reorder with line break vs leave the loop alone and add a separate assertion. **(chosen) Add inline with continuation backslash** matching the existing 8-name format. The single-loop shape keeps the assertion's structure self-evident; an extra section would split related coverage across two places.

## Checklist
- [x] **Test**: smoke §34 comment + loop updated (`70df8c8`)
- [x] **Verify**: 270/270 pass; directive-reviewer asserted; existing 8 names still asserted

## Out of scope
- README.md — already lists nine subagents (PR #48).
- Agent files — content canonical.
- Behavioral tests for directive-reviewer — covered structurally by §42 (PR #50).
- Auto-completion of Directive #54 — `/complete-directive`'s decision.

## Decisions
- 2026-05-24 — Standalone PR under #54 (axis 1); inline loop addition (axis 2).

## Test plan
- [x] `./scripts/test/smoke.sh` — 270/270.

## Docs touched
- [x] `scripts/test/smoke.sh` — §34 loop + comment

## Ship gate
- [x] All tests pass — 270/270
- [ ] code-reviewer passed
- [~] (conditional) security-reviewer — N/A
- [x] Docs in sync
- [x] PR body curated
- [ ] CI green
