### PR TITLE
fix(#66): dir-mode-post-merge gh calls need --repo (under #61)

### DIFF
--- a/.claude/templates/dir-mode-post-merge.yml
+++ b/.claude/templates/dir-mode-post-merge.yml
@@ -39,15 +39,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # No actions/checkout step — the workflow only uses gh API. Every gh
+          # call carries --repo so it doesn't try to read git context from the
+          # runner's cwd (which has no .git directory).
           # Fetch closing-issue numbers from the merged PR.
-          closing=$(gh pr view "$PR_NUM" --json closingIssuesReferences \
+          closing=$(gh pr view "$PR_NUM" --repo "$REPO" --json closingIssuesReferences \
             --jq '.closingIssuesReferences[].number')
           directive=""
           exec_issue=""
           for n in $closing; do
-            body=$(gh issue view "$n" --json body --jq .body)
+            body=$(gh issue view "$n" --repo "$REPO" --json body --jq .body)
             if [[ "$body" =~ ^Parent\ Directive:\ \#([0-9]+) ]]; then
               directive="${BASH_REMATCH[1]}"
               exec_issue="$n"
@@ -65,6 +69,7 @@ jobs:
         if: steps.resolve.outputs.directive != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           DIRECTIVE: ${{ steps.resolve.outputs.directive }}
           EXEC: ${{ steps.resolve.outputs.exec_issue }}
           PR: ${{ github.event.pull_request.number }}
@@ -76,7 +81,7 @@ jobs:
           # Idempotency: skip if a comment containing this PR's URL already exists
           # on the parent Directive. Matches the /reflect Markdown procedure's
           # existing-URL check, so Claude-in-loop and hook-enforced paths dedupe.
-          existing=$(gh issue view "$DIRECTIVE" --comments --json comments \
+          existing=$(gh issue view "$DIRECTIVE" --repo "$REPO" --comments --json comments \
             --jq ".comments[] | select(.body | contains(\"$PR_URL\")) | .url" | head -1)
           if [ -n "$existing" ]; then
             echo "Already reflected: $existing"
@@ -102,4 +107,4 @@ jobs:
           Posted by \`.github/workflows/dir-mode-post-merge.yml\` on \`pull_request.closed\` (merged=true).
           COMMENT
           )
-          gh issue comment "$DIRECTIVE" --body "$comment"
+          gh issue comment "$DIRECTIVE" --repo "$REPO" --body "$comment"

--- a/.github/workflows/dir-mode-post-merge.yml
+++ b/.github/workflows/dir-mode-post-merge.yml
@@ -39,15 +39,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # No actions/checkout step — the workflow only uses gh API. Every gh
+          # call carries --repo so it doesn't try to read git context from the
+          # runner's cwd (which has no .git directory).
           # Fetch closing-issue numbers from the merged PR.
-          closing=$(gh pr view "$PR_NUM" --json closingIssuesReferences \
+          closing=$(gh pr view "$PR_NUM" --repo "$REPO" --json closingIssuesReferences \
             --jq '.closingIssuesReferences[].number')
           directive=""
           exec_issue=""
           for n in $closing; do
-            body=$(gh issue view "$n" --json body --jq .body)
+            body=$(gh issue view "$n" --repo "$REPO" --json body --jq .body)
             if [[ "$body" =~ ^Parent\ Directive:\ \#([0-9]+) ]]; then
               directive="${BASH_REMATCH[1]}"
               exec_issue="$n"
@@ -65,6 +69,7 @@ jobs:
         if: steps.resolve.outputs.directive != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           DIRECTIVE: ${{ steps.resolve.outputs.directive }}
           EXEC: ${{ steps.resolve.outputs.exec_issue }}
           PR: ${{ github.event.pull_request.number }}
@@ -76,7 +81,7 @@ jobs:
           # Idempotency: skip if a comment containing this PR's URL already exists
           # on the parent Directive. Matches the /reflect Markdown procedure's
           # existing-URL check, so Claude-in-loop and hook-enforced paths dedupe.
-          existing=$(gh issue view "$DIRECTIVE" --comments --json comments \
+          existing=$(gh issue view "$DIRECTIVE" --repo "$REPO" --comments --json comments \
             --jq ".comments[] | select(.body | contains(\"$PR_URL\")) | .url" | head -1)
           if [ -n "$existing" ]; then
             echo "Already reflected: $existing"
@@ -102,4 +107,4 @@ jobs:
           Posted by \`.github/workflows/dir-mode-post-merge.yml\` on \`pull_request.closed\` (merged=true).
           COMMENT
           )
-          gh issue comment "$DIRECTIVE" --body "$comment"
+          gh issue comment "$DIRECTIVE" --repo "$REPO" --body "$comment"

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -3498,6 +3498,19 @@ else
   else
     ng "48f: workflow install drifts from template (#63)"
   fi
+
+  # 48g: every `gh <subcommand>` in the workflow carries --repo (#66 fix).
+  # The runner has no checkout step; gh would otherwise read git context from
+  # cwd and fail. Lock the --repo flag on every gh invocation. The pattern
+  # matches gh-with-subcommand anywhere on a line (including inside $(...)
+  # substitutions) so multi-line gh calls (continuation with backslash) count.
+  gh_calls=$(grep -cE '\bgh[[:space:]]+(pr|issue|repo|project|api|auth|run|workflow|release|search|label)\b' "$DPM_TEMPLATE" 2>/dev/null || echo 0)
+  gh_with_repo=$(grep -cE '\bgh[[:space:]]+(pr|issue|repo|project|api|auth|run|workflow|release|search|label)\b.*--repo' "$DPM_TEMPLATE" 2>/dev/null || echo 0)
+  if [ "$gh_calls" -gt 0 ] && [ "$gh_calls" = "$gh_with_repo" ]; then
+    ok "48g: all $gh_calls gh invocations carry --repo flag (no-checkout runner) (#66)"
+  else
+    ng "48g: $gh_calls gh invocations but only $gh_with_repo carry --repo — runner will fail without git context (#66)"
+  fi
 fi
 
 # ---------- restore registry ----------


### PR DESCRIPTION
Parent Directive: #61
Closes #66

## Goal
Fix-forward the post-merge workflow shipped in PR #65 so `gh` invocations work in the no-checkout runner. Every `gh` call gains `--repo "${{ github.repository }}"`.

## Surfaced by
The first hook-enforced workflow run (Run 26359350509 on PR #65 at 2026-05-24T10:57Z) failed with `failed to run git: fatal: not a git repository`. The workflow correctly tried to read PR/Issue data via `gh`, but `gh` without `--repo` reads repo context from cwd's `.git` directory — which doesn't exist in a workflow runner without `actions/checkout`. Explicit `--repo` is the right fix (no checkout needed; workflow uses GH API only).

## Plan
Single fix commit (`16f6e58`):
- Add `--repo "${{ github.repository }}"` to all 4 `gh` invocations in `.claude/templates/dir-mode-post-merge.yml` (`pr view`, `issue view ×2`, `issue comment`).
- Sync `.github/workflows/dir-mode-post-merge.yml` to match.
- Smoke §48g added: regex check `\bgh <subcommand>\b.*--repo` against the template; catches future drift.

## Self-validation
This PR's own merge will be the second test of the workflow:
1. CI runs (green expected — `bash -n` + smoke 277/277).
2. Auto-merge fires.
3. The fixed workflow runs against this PR's `pull_request.closed` event.
4. The workflow resolves Parent Directive #61 from issue #66's body.
5. A `github-actions[bot]` reflection comment lands on Directive #61.

If steps 4–5 succeed, Directive #61's Success signals 1 (audit line on UI/auto merge), 2 (bot-authored comment, idempotent), and 6 (real non-Claude path merge produces both records) are all satisfied at once. The original PR #56 (Execution #55) provided the design pattern; #65 shipped the workflow but with a runtime bug; #66 closes the bug and validates the end-to-end on its own merge.

## Checklist
- [x] `.claude/templates/dir-mode-post-merge.yml` updated (all 4 gh calls)
- [x] `.github/workflows/dir-mode-post-merge.yml` synced
- [x] Smoke §48g — locks `--repo` on every gh call
- [x] 277/277 smoke green
- [ ] **Post-merge verification**: `gh run list --workflow=dir-mode-post-merge.yml` shows green; Directive #61 has a new comment

## Out of scope
- Refactoring workflow structure.
- Adding new audit categories.
- Forgejo/GitLab-CI portability.

## Risks
- **Runner permissions.** `secrets.GITHUB_TOKEN` with `issues: write` should suffice; if a target has a restricted token policy, this surfaces noisily on first run (right behavior).
- **Idempotency under workflow re-run.** If a user manually re-runs the workflow (Actions tab → Re-run), the existing-URL check sees its own previous comment and no-ops. Correct.

## Ship gate
- [x] All tests pass — 277/277
- [ ] code-reviewer passed
- [~] (conditional) security-reviewer — N/A
- [x] Docs in sync (no doc surface affected by the fix)
- [x] PR body curated
- [ ] CI green
