### PR TITLE
test(#69): §42e behavioral smoke + directive-reviewer routing evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ All optional. Per-target state files live under `.claude/state/` (gitignored); e
 | Stop-hook throttle | — | `CLAUDE_ENG_STOP_THROTTLE` | `5` | Suggest `/review` every Nth response from the Stop hook (§6.3) |
 | Unattended park log | — | `SHIP_PARK_LOG_PATH` | `.claude/state/unattended-park.log` | Where `/ship` appends park entries in `unattended` mode (§5.7.1) |
 | PR cache repo override | — | `PR_CACHE_REPO` | — | Override the `owner/repo` `pr_cache` queries; falls back to `gh repo view` of the cwd (§5.4) |
+| Behavioral smoke gate | — | `CLAUDE_ENG_BEHAVIORAL_SMOKE` | unset | Set to `1` to exercise live `directive-reviewer` in smoke §42e (SPEC §4.9.3); default-unset keeps smoke offline + deterministic |
 
 *`STATUS_CACHE_DIR_OVERRIDE` is internal-only (smoke-test plumbing for `helpers/status.sh`) and intentionally not listed.*
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -779,7 +779,7 @@ Empirical confirmation (Directive #62 / PR #67-followup): in the v0 dogfood sess
 
 **Mitigation for the in-session window**: the falling-back-to-`general-purpose` path is functionally complete — the agent's prompt instructs `general-purpose` to behave as the new reviewer. The cost is the loss of Type-aware specialization (the harness's per-subagent prompt + tool restriction). Acceptable for one session; restart at session end is canonical.
 
-**Hook-side note**: the smoke `§42` structural assertions (PR #50) lock the agent file's shape, so the routing-layer regression is the only failure mode this caveat names. A future smoke section that invokes the agent end-to-end (Directive #62's deferred Execution) catches the routing regression by asserting `subagent_type: "directive-reviewer"` produces the agent's documented output rather than `general-purpose`'s.
+**Hook-side note**: the smoke `§42` structural assertions (PR #50) lock the agent file's shape, so the routing-layer regression is the only failure mode this caveat names. The behavioral surface that catches the routing regression is **smoke §42e** (issue #69, under Directive #62): two assertions gated behind `CLAUDE_ENG_BEHAVIORAL_SMOKE=1` invoke `directive-reviewer` with a synthetic minimal-but-valid Directive body (asserting `^VERDICT: ship`) and a synthetic body missing the `## Success signals` section (asserting `^VERDICT: (refine|block)`). Env-var unset → §42e is a no-op so default smoke stays deterministic and offline; env-var set → the block exercises the live `subagent_type: "directive-reviewer"` route end-to-end. A regression in either the agent file or the routing surface flips at least one of the two verdicts.
 
 ---
 

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -3135,6 +3135,97 @@ else
   fi
 fi
 
+# ---------- 42e. directive-reviewer behavioral assertions (#69 / Directive #62) ----------
+# Gated behind CLAUDE_ENG_BEHAVIORAL_SMOKE=1. When set, shells out to the live
+# agent via `claude -p --agent directive-reviewer` and asserts the documented
+# VERDICT-line output on two synthetic Directive bodies:
+#   - case A: minimal-but-valid body  → ^VERDICT: ship
+#   - case B: body missing the entire ## Success signals heading
+#                                     → ^VERDICT: (refine|block)
+# Default-unset → no-op so smoke stays offline + deterministic (preserves the
+# 278/278 baseline). See SPEC §4.9.3 for the routing-regression contract this
+# block protects.
+if [ "${CLAUDE_ENG_BEHAVIORAL_SMOKE:-}" = 1 ]; then
+  if ! command -v claude >/dev/null 2>&1; then
+    ng "42e: CLAUDE_ENG_BEHAVIORAL_SMOKE=1 but 'claude' CLI not on PATH (#69)"
+  else
+    # Case A — synthetic minimal-but-valid Directive body. All five sections
+    # present with substantive content; each success signal cites a concrete
+    # mechanically-verifiable artifact (smoke run, ok-line count).
+    # NOTE: `IFS= read -r -d ''` instead of `var=$(cat <<EOF)` — macOS default
+    # bash 3.2 has a parser bug where heredoc-inside-command-substitution
+    # mis-tokenizes special chars in the body. `read -d ''` avoids the nested
+    # construct entirely; the `|| true` absorbs read's EOF-exit (rc=1).
+    IFS= read -r -d '' dr_ship_prompt <<'PROMPT_EOF' || true
+Review the following proposed Directive body for /file-directive (proposal review per SPEC §1.7 / §2.1). No active Directives in this synthetic test environment — proceed with checks 1-5. Do not fetch the active-Directive list; treat it as empty.
+
+Proposed body:
+
+# Directive: Lock smoke §42e default-offline contract
+
+## Objective
+Keep `scripts/test/smoke.sh`'s default-unset path at exactly 278 passing assertions so CI and dev loops remain deterministic and offline regardless of whether the behavioral-smoke env var is set in the operator's shell.
+
+## Success signals
+- `bash scripts/test/smoke.sh` (with `CLAUDE_ENG_BEHAVIORAL_SMOKE` unset) prints `smoke: pass=278 fail=0` on the next merge to main; verified by the PR's CI summary and one local re-run on the merge commit.
+- `CLAUDE_ENG_BEHAVIORAL_SMOKE=1 bash scripts/test/smoke.sh` adds exactly two passing assertions under §42e (`42e-ship` and `42e-refine-or-block`) and the total becomes `pass=280 fail=0`; verified by counting `ok "42e-` lines in the output.
+
+## Non-goals
+- Does NOT include behavioral smoke for `issue-reviewer`, `plan-reviewer`, `code-reviewer`, or `security-reviewer` — their structural assertions are out of scope for this Directive.
+- Does NOT modify directive-reviewer's five checks or the VERDICT-line format (both locked by PR #50).
+
+## Constraints
+- §42e must be self-contained inside `scripts/test/smoke.sh`; no new helper scripts under `scripts/test/` or new entries in the registry.
+- The env-var guard must be a single `if` at the top of §42e — no scattered checks inside individual `ok`/`ng` calls.
+
+## Parent Goal
+First Directive in this synthetic test environment — bootstraps the Goal slot per directive-reviewer rule "The first Directive in a repo bootstraps the Goal slot".
+PROMPT_EOF
+    dr_ship_out=$(claude -p --agent directive-reviewer "$dr_ship_prompt" 2>&1 || true)
+    dr_ship_verdict=$(printf '%s\n' "$dr_ship_out" | tail -n 20 | grep -E '^VERDICT:' | tail -1)
+    case "$dr_ship_verdict" in
+      "VERDICT: ship"*)
+        ok "42e-ship: directive-reviewer returns 'ship' on minimal-but-valid synthetic body (#69)" ;;
+      *)
+        ng "42e-ship: expected '^VERDICT: ship', got '$dr_ship_verdict' (#69)" ;;
+    esac
+
+    # Case B — synthetic body missing the entire ## Success signals heading.
+    # Per check 1 (schema completeness), one missing section → refine; three
+    # or more → block. Either verdict signals the missing-section regression
+    # was caught; we accept both as pass to keep the assertion robust.
+    IFS= read -r -d '' dr_refine_prompt <<'PROMPT_EOF' || true
+Review the following proposed Directive body for /file-directive (proposal review per SPEC §1.7 / §2.1). No active Directives in this synthetic test environment — proceed with checks 1-5. Do not fetch the active-Directive list; treat it as empty.
+
+Proposed body:
+
+# Directive: Lock smoke §42e default-offline contract
+
+## Objective
+Keep `scripts/test/smoke.sh`'s default-unset path at exactly 278 passing assertions so CI and dev loops remain deterministic and offline regardless of whether the behavioral-smoke env var is set in the operator's shell.
+
+## Non-goals
+- Does NOT include behavioral smoke for `issue-reviewer`, `plan-reviewer`, `code-reviewer`, or `security-reviewer`.
+- Does NOT modify directive-reviewer's five checks or the VERDICT-line format.
+
+## Constraints
+- §42e must be self-contained inside `scripts/test/smoke.sh`.
+- The env-var guard must be a single `if` at the top of §42e.
+
+## Parent Goal
+First Directive in this synthetic test environment.
+PROMPT_EOF
+    dr_refine_out=$(claude -p --agent directive-reviewer "$dr_refine_prompt" 2>&1 || true)
+    dr_refine_verdict=$(printf '%s\n' "$dr_refine_out" | tail -n 20 | grep -E '^VERDICT:' | tail -1)
+    case "$dr_refine_verdict" in
+      "VERDICT: refine"*|"VERDICT: block"*)
+        ok "42e-refine-or-block: directive-reviewer rejects body missing '## Success signals' (got '$dr_refine_verdict') (#69)" ;;
+      *)
+        ng "42e-refine-or-block: expected '^VERDICT: refine' or '^VERDICT: block', got '$dr_refine_verdict' (#69)" ;;
+    esac
+  fi
+fi
+
 # ---------- 43. dir-mode command files structural sanity (#45) ----------
 # PR #45 ships the five dir-mode commands + a directive body template.
 # Command files are Markdown prompts for Claude (no executable code);

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -3145,6 +3145,14 @@ fi
 # Default-unset → no-op so smoke stays offline + deterministic (preserves the
 # 278/278 baseline). See SPEC §4.9.3 for the routing-regression contract this
 # block protects.
+#
+# Surface note: `claude -p --agent <name>` is the CLI session-agent override,
+# which resolves the agent from `.claude/agents/*.md` at subprocess startup.
+# This is a different invocation surface than the in-session `Agent({subagent_type:
+# "<name>"})` tool dispatch that SPEC §4.9.3's session-restart caveat is written
+# against; the two share the `.claude/agents/*.md` enumeration source but are
+# separate code paths. §42e protects the CLI surface; the in-session dispatch
+# is covered by Signal 1's session-trace evidence captured in the PR body.
 if [ "${CLAUDE_ENG_BEHAVIORAL_SMOKE:-}" = 1 ]; then
   if ! command -v claude >/dev/null 2>&1; then
     ng "42e: CLAUDE_ENG_BEHAVIORAL_SMOKE=1 but 'claude' CLI not on PATH (#69)"
@@ -3182,12 +3190,21 @@ Keep `scripts/test/smoke.sh`'s default-unset path at exactly 278 passing asserti
 First Directive in this synthetic test environment — bootstraps the Goal slot per directive-reviewer rule "The first Directive in a repo bootstraps the Goal slot".
 PROMPT_EOF
     dr_ship_out=$(claude -p --agent directive-reviewer "$dr_ship_prompt" 2>&1 || true)
-    dr_ship_verdict=$(printf '%s\n' "$dr_ship_out" | tail -n 20 | grep -E '^VERDICT:' | tail -1)
+    # Capture the LAST `^VERDICT:` line anchored on the documented delimiters
+    # (`ship —`, `refine:`, `block:` per .claude/agents/directive-reviewer.md:78-82).
+    # Anchoring avoids matching prose quotes of the agent's own `## Verdict
+    # dispatch` section if the agent cites itself; `tail -1` picks the terminal
+    # verdict if multiple anchored lines somehow appear.
+    dr_ship_verdict=$(printf '%s\n' "$dr_ship_out" | grep -E '^VERDICT: (ship —|ship -|refine:|block:)' | tail -1)
     case "$dr_ship_verdict" in
       "VERDICT: ship"*)
         ok "42e-ship: directive-reviewer returns 'ship' on minimal-but-valid synthetic body (#69)" ;;
       *)
-        ng "42e-ship: expected '^VERDICT: ship', got '$dr_ship_verdict' (#69)" ;;
+        # On miss, surface the first 200 chars of the agent's output so the
+        # next operator can tell live-agent failures (auth, rate-limit, model
+        # overloaded) apart from genuine verdict regressions.
+        dr_ship_head=$(printf '%s' "$dr_ship_out" | head -c 200 | tr '\n' ' ')
+        ng "42e-ship: expected '^VERDICT: ship', got '$dr_ship_verdict' [out: $dr_ship_head] (#69)" ;;
     esac
 
     # Case B — synthetic body missing the entire ## Success signals heading.
@@ -3216,12 +3233,13 @@ Keep `scripts/test/smoke.sh`'s default-unset path at exactly 278 passing asserti
 First Directive in this synthetic test environment.
 PROMPT_EOF
     dr_refine_out=$(claude -p --agent directive-reviewer "$dr_refine_prompt" 2>&1 || true)
-    dr_refine_verdict=$(printf '%s\n' "$dr_refine_out" | tail -n 20 | grep -E '^VERDICT:' | tail -1)
+    dr_refine_verdict=$(printf '%s\n' "$dr_refine_out" | grep -E '^VERDICT: (ship —|ship -|refine:|block:)' | tail -1)
     case "$dr_refine_verdict" in
       "VERDICT: refine"*|"VERDICT: block"*)
         ok "42e-refine-or-block: directive-reviewer rejects body missing '## Success signals' (got '$dr_refine_verdict') (#69)" ;;
       *)
-        ng "42e-refine-or-block: expected '^VERDICT: refine' or '^VERDICT: block', got '$dr_refine_verdict' (#69)" ;;
+        dr_refine_head=$(printf '%s' "$dr_refine_out" | head -c 200 | tr '\n' ' ')
+        ng "42e-refine-or-block: expected '^VERDICT: refine' or '^VERDICT: block', got '$dr_refine_verdict' [out: $dr_refine_head] (#69)" ;;
     esac
   fi
 fi

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -3079,12 +3079,14 @@ fi
 rm -rf "$SP_DIR"
 
 # ---------- 42. directive-reviewer subagent structural sanity (#44) ----------
-# Subagent behavior cannot be invoked from a smoke shell (Claude Code routes
-# Agent calls). What we can verify is the file's structural conformance to
-# the reviewer-subagent contract: frontmatter (name, description, tools),
-# required body sections, and the VERDICT-line format documented in the body.
-# Behavioral validation happens via actual /file-directive and
-# /complete-directive invocations once those commands ship in PR #45.
+# Structural assertions (42a-42d) verify the agent file's contract:
+# frontmatter (name, description, tools), required body sections, and the
+# VERDICT-line format documented in the body. These run by default.
+#
+# Behavioral validation lives in §42e below, gated behind
+# CLAUDE_ENG_BEHAVIORAL_SMOKE=1 — it shells out to the live agent and asserts
+# its VERDICT output on synthetic inputs (SPEC §4.9.3, issue #69 under
+# Directive #62). Default smoke stays deterministic and offline.
 
 DR_PATH="$SHELL_ROOT/.claude/agents/directive-reviewer.md"
 if [ ! -f "$DR_PATH" ]; then


### PR DESCRIPTION
Closes #69
Parent Directive: #62

## Goal
Close Directive #62's three remaining Success signals (routing verification, real-invocation audit, behavioral smoke §42e) — deferred by #64 pending the session restart that makes `directive-reviewer` first-class.

## How this serves the mission
MISSION.md absent — de-facto mission is `.claude/CLAUDE.md` + SPEC §1.7 / §4.9 / Directive #62. This Execution makes the v0-shipped `directive-reviewer` agent **verifiably first-class and behaviorally tested**. Without §42e, every `/file-directive` and `/complete-directive` would continue to rely on structural assertions only; a silent routing regression (e.g., agent file renamed, frontmatter broken, harness enumeration changed) would land unnoticed until the next manual `/complete-directive` failed for an unrelated-looking reason.

## Plan
1. **Phase A — Doc** (commit `864a530`): SPEC §4.9.3 names §42e as the concrete behavioral surface; smoke.sh §42 header comment redirects from "behavioral validation happens elsewhere" to "behavioral validation lives in §42e below".
2. **Phase B — Test** (commit `9074406`): append §42e block to `scripts/test/smoke.sh` after §42d, gated behind `CLAUDE_ENG_BEHAVIORAL_SMOKE=1`. Two synthetic Directive bodies (all-five-sections-valid → `^VERDICT: ship`; missing `## Success signals` → `^VERDICT: (refine|block)`) piped through `claude -p --agent directive-reviewer`. Default-unset path → no `ok`/`ng` calls so 278/278 preserved.
3. **Phase C — Code**: none. §42e is self-contained inside smoke.sh and uses existing `ok`/`ng` helpers.
4. **Review fixes** (commits `c6ae3c5`, `6491a8c`):
   - `c6ae3c5`: code-reviewer ask — surface-clarification comment (`--agent` CLI vs in-session `Agent({subagent_type: ...})`), anchored verdict-line capture on documented delimiters (`ship —|ship -|refine:|block:`), ng-arm diagnostic with first 200 chars of agent output.
   - `6491a8c`: doc-writer ask — README Configuration-toggles table adds `CLAUDE_ENG_BEHAVIORAL_SMOKE` row.

## Alternatives considered
- **Inline agent JSON (`claude --agents '<json>'`)**: bypasses the file-registration path that signal 1 is specifically about. Falsifies the verification intent.
- **Fixture-script mock of `directive-reviewer`**: defeats the purpose of a behavioral smoke — we'd be testing the test, not the agent. Structural §42a–d already cover file shape.
- **Replay a captured session transcript**: brittle, transcript format is not a documented stable contract; shifts evidence into a binary-ish repo artifact instead of human-readable PR body.

## Key context
- `scripts/test/smoke.sh:3081-3134` — existing §42a–d structural block; §42e appends immediately after.
- `scripts/test/smoke.sh:3516-3549` — §49 agent-file loadability block (PR #68); precedent for "behavioral checks that augment §42".
- `.claude/agents/directive-reviewer.md:42-67` — the five checks; check 1 (schema completeness) drives the synthetic-body design.
- `.claude/agents/directive-reviewer.md:78-84` — VERDICT-line format contract (`ship` / `refine` / `block`).
- `SPEC.md` §4.9.3 — session-restart caveat; updated in this PR to name §42e.
- `README.md` — Configuration toggles table; updated to list the new env var.

## Checklist
- [x] **Doc**: SPEC §4.9.3 sub-paragraph + smoke §42 header comment announce §42e (commit `864a530`).
- [x] **Test**: append §42e block to `scripts/test/smoke.sh` (commit `9074406`).
- [x] **Review fix**: header-comment surface clarification + anchored verdict-line capture + ng-arm diagnostic (commit `c6ae3c5`).
- [x] **Doc sync**: README env-var table (commit `6491a8c`).
- [x] **Verify**: `bash scripts/test/smoke.sh` → `pass=278 fail=0` with env unset.
- [x] **Verify**: `CLAUDE_ENG_BEHAVIORAL_SMOKE=1 bash scripts/test/smoke.sh` → §42e fires, both VERDICT assertions pass (final count `pass=280 fail=0`).
- [x] **Evidence**: routing trace excerpts pasted into `## Evidence` section below.

## Out of scope
- Restructuring the `general-purpose` fallback.
- Behavioral smoke for other reviewers (`issue-reviewer`, `plan-reviewer`, `code-reviewer`, `security-reviewer`).
- Adding `roadmap-reviewer` (SPEC §0.4 / §4.9.2 — v1+).
- Modifying `directive-reviewer`'s checks or VERDICT-line format (locked by PR #50).
- Editing `.claude/agents/directive-reviewer.md` frontmatter or tools list.
- Fixing the stale `~190 assertions` figure in README's Verify section — pre-existing, not §42e's regression; leave for a follow-up `docs` issue.

## Risks
- **CLI flag drift**: §42e relies on `claude -p --agent <name>` as the non-interactive invocation path. If upstream renames or removes the flag, §42e fails loudly when the env var is set — desirable failure mode (signals the routing surface changed). Comment in §42e references SPEC §4.9.3.
- **Surface boundary**: `claude -p --agent <name>` is the **CLI session-agent** surface; the in-session `Agent({subagent_type: ...})` tool dispatch is a separate code path that shares the `.claude/agents/*.md` enumeration source. §42e protects the CLI surface; the in-session surface is covered by Signal 1's session-trace evidence in this PR body. Comment in §42e header now states this explicitly.
- **Non-deterministic agent output**: the agent might emit `VERDICT: refine` for an under-specified "valid" body. Mitigation: case A body is explicit and over-specified — each signal cites a concrete artifact (smoke count, ok-line grep); each non-goal names a concrete exclusion. Verified locally — `42e-ship` returns `ship` cleanly across multiple runs.
- **Cost when env var set**: one real Claude API call per VERDICT assertion (×2). Mitigation: env-var gating is the explicit mitigation per the issue body. Recommend gated smoke locally pre-merge, not in CI.
- **macOS bash 3.2 heredoc-in-`$()` parser bug**: discovered during Phase B implementation — `var=$(cat <<EOF ... EOF)` mis-tokenizes when the heredoc body contains backticks or unbalanced quotes (the body has both). Mitigation: §42e uses `IFS= read -r -d '' var <<EOF || true` instead, bash-3.2-safe and avoids the nested construct. Documented inline in §42e.
- **No-regression on 278/278**: a stray `ok`/`ng` outside the env-var branch silently inflates the default count. Mitigation: all `ok`/`ng` strictly inside the `if [ ... = 1 ]; then ... fi` branch. Verified — `bash scripts/test/smoke.sh | tail -1` returns `smoke: pass=278 fail=0` exactly.

## Open questions
- **Evidence destination**: PR body `## Evidence` (chosen — this PR is its natural home) vs SPEC §4.9.3 permanent paragraph. SPEC §4.9.3 was updated to *name* §42e but does not embed the trace excerpts (those are PR-ephemeral).
- **Exact `claude -p` invocation shape**: positional `prompt` arg chosen (vs stdin) — fits `"$dr_ship_prompt"` cleanly and works regardless of the calling shell's heredoc rules.
- **VERDICT-line capture robustness**: anchored on documented delimiters per `directive-reviewer.md:78-82` (`ship —|ship -|refine:|block:`); `tail -1` picks the terminal anchored line if multiple appear. Tighter than initial `tail -n 20 | grep '^VERDICT:'` — avoids matching prose quotes of the agent's own `## Verdict dispatch` section.

## Evidence

### Signal 1 — Routing verification

Direct `Agent({subagent_type: "directive-reviewer"})` invocation from this session (`/work-on 69`'s Phase-B verification step). Probe body: a synthetic minimal-but-valid Directive whose Objective is to capture this very evidence. Response excerpt (verbatim):

> **Check 1 — Schema completeness:** All five required sections are present (Objective, Success signals, Non-goals, Constraints, Parent Goal), each with substantive content beyond the heading. … **pass**
>
> **Check 2 — Success-signal verifiability:** Signal 1 is mechanically verifiable by inspection of this very response — the reviewer (me) either produces the paragraph-per-check + `VERDICT:` structure or doesn't, and a human or grep can confirm against `.claude/agents/directive-reviewer.md`. … **pass**
>
> **Check 3 — Scope clarity:** … Tight and recognizable. **pass**
>
> **Check 4 — Non-goal clarity:** Two explicit exclusions are stated … **pass**
>
> **Check 5 — Active-Directive conflict:** Per the routing-probe instruction, the active-Directive list is treated as empty in this synthetic test environment, so no overlap is possible by construction. (In a real proposal review I would fetch and scan; here I'm honoring the test stipulation.) **pass**
>
> VERDICT: ship — schema-complete, signals verifiable by inspection and grep, scope bounded to a single probe response, two explicit non-goals, no active-Directive conflict in scope.

This response is unmistakably `directive-reviewer.md`'s output, **not** `general-purpose`'s:
- Five paragraphs in the documented "Check N — `<name>`" structure (per `.claude/agents/directive-reviewer.md:42-67`).
- Each check terminates with `pass` / `refine` / `block` per the documented rule (`directive-reviewer.md:84`).
- Terminal `VERDICT: ship — <one-line>` matches the exact format at `directive-reviewer.md:78-82`.
- Honors the "do not invent active Directives you didn't see in the fetched data" rule (`directive-reviewer.md:90`) by explicitly noting it's treating the active-Directive list as empty per the test stipulation.

A `general-purpose` fallback would not produce the five-check paragraph structure, nor the named checks, nor the verbatim terminology — its prompt has none of these.

### Signal 2 — Real-invocation audit (embedded `/complete-directive` reviewer call)

Manual execution of `/complete-directive 62` steps 2-5 in this session (full Project-edit flow requires `read:project` scope this token lacks; the reviewer-gate at step 5 is the in-scope evidence). Inputs assembled per the command's documented procedure: Directive #62's body, linked Execution list (#64 closed via PR #68, #69 OPEN). Response excerpt (verbatim):

> ## Check 6 — Evidence sufficiency (completion-only)
>
> Mapping signals to linked Execution Issues:
>
> - **Signal 1** (Agent routing to `.claude/agents/directive-reviewer.md`): #69 plans to capture this in PR #70's Evidence section. PR #70 is **still draft** with the evidence capture in flight — this very review invocation is the evidence. Routing **has not yet been observed as merged artifact state**.
> - **Signal 2** (real `/file-directive` or `/complete-directive` routes through `directive-reviewer`): this current invocation is exactly such a routing, but until PR #70 captures and merges the trace, it is not yet recorded artifact state. **In-flight via #69**.
> - **Signal 3** (smoke §42e with two assertions): #69 has Phase A + Phase B commits on draft PR #70; gated smoke 280/280 locally. **Not yet merged.**
> - **Signal 4** (documentation surface lists `directive-reviewer`): #64/PR #68 shipped smoke §49 which structurally validates all 9 agent files including `directive-reviewer.md`. The agent file itself is the enumeration surface. **pass via #64 merged.**
> - **Signal 5** (§42a-d no regression): default smoke 278/278 per #69's local run; #64/PR #68 merged without regressing §42. **pass via #64 merged + #69 in-flight confirmation.**
> - **Signal 6** (270/270 default-smoke no regression; gated §42e additive): default count has grown to 278/278 (additive growth from §49 etc.); no regression. **pass.**
>
> VERDICT: block: Directive #62 has signals 1, 2, 3 dependent on #69/PR #70, which is still open/draft — completion is premature until PR #70 merges and #69 closes.

Diagnostic markers confirming this is directive-reviewer (and not general-purpose):
- Six checks (1-6) — check 6 (evidence sufficiency) **only exists for completion review** per `directive-reviewer.md:69-74`; the completion-only branch is correctly engaged.
- Each signal mapped to a specific linked Execution Issue per the documented check-6 pass condition (`directive-reviewer.md:72`).
- `VERDICT: block:` form matches `directive-reviewer.md:82` exactly.
- The block is operationally correct: #62 cannot ship until #69 closes. The agent reasoning is sound, not generic.

After PR #70 merges and #69 closes, a re-run of `/complete-directive 62` should flip the verdict to `ship` — which is the canonical signal-2 evidence per the issue body ("if its verdict flips to `ship`, that is the same evidence").

### Signal 3 — Behavioral smoke §42e

Local run of `CLAUDE_ENG_BEHAVIORAL_SMOKE=1 bash scripts/test/smoke.sh` (commits `9074406` + `c6ae3c5`):

```
✓ 42e-ship: directive-reviewer returns 'ship' on minimal-but-valid synthetic body (#69)
✓ 42e-refine-or-block: directive-reviewer rejects body missing '## Success signals' (got 'VERDICT: refine: add a `## Success signals` section — the body has four of five required sections; without verifiable completion signals (the document's whole point per `directive.md` and check 2) the Directive cannot later be completion-reviewed.') (#69)

smoke: pass=280 fail=0
```

Default run (env unset): `smoke: pass=278 fail=0` — §42e is a no-op, baseline preserved.

The case-B verdict reason explicitly names `## Success signals` as the missing heading and references "check 2" by number — both are directive-reviewer-specific artifacts of the agent's own prompt. Confirms the agent's check 1 (schema completeness) drove the verdict and the anchored grep `^VERDICT: (ship —|ship -|refine:|block:)` correctly captures the documented delimiter forms.

## Test plan
- [x] `bash scripts/test/smoke.sh` → `pass=278 fail=0` (default path, env unset, no behavioral cost).
- [x] `CLAUDE_ENG_BEHAVIORAL_SMOKE=1 bash scripts/test/smoke.sh` → `42e-ship` and `42e-refine-or-block` both green; final count `pass=280 fail=0`.
- [x] Existing §42a–d still green in both runs.
- [x] §49 (agent-file loadability) still green.

## Docs touched
- [x] `SPEC.md` §4.9.3 — sub-paragraph naming §42e as the behavioral surface.
- [x] `scripts/test/smoke.sh` §42 header comment — redirected to §42e for behavioral validation; surface-boundary note (CLI vs in-session) added.
- [x] `README.md` — Configuration toggles table lists `CLAUDE_ENG_BEHAVIORAL_SMOKE`.

## Ship gate
- [x] code-reviewer passed (re-reviewed after fix commit; `VERDICT: ship`)
- [~] security-reviewer N/A — no auth/input/deps/crypto change in the diff
- [x] doc-writer passed (after README env-var row added)
- [x] Default smoke 278/278; gated smoke 280/280
- [x] PR body curated
- [x] CI green (4 checks SUCCESS)
