### PR TITLE
docs(#73): README — CLAUDE_ENG_PROJECT_NAME toggles row + smoke count refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ All optional. Per-target state files live under `.claude/state/` (gitignored); e
 | Unattended park log | — | `SHIP_PARK_LOG_PATH` | `.claude/state/unattended-park.log` | Where `/ship` appends park entries in `unattended` mode (§5.7.1) |
 | PR cache repo override | — | `PR_CACHE_REPO` | — | Override the `owner/repo` `pr_cache` queries; falls back to `gh repo view` of the cwd (§5.4) |
 | Behavioral smoke gate | — | `CLAUDE_ENG_BEHAVIORAL_SMOKE` | unset | Set to `1` to exercise live `directive-reviewer` in smoke §42e (SPEC §4.9.3); default-unset keeps smoke offline + deterministic |
-| Dir-mode Project name | — | `CLAUDE_ENG_PROJECT_NAME` | `<repo-name> roadmap` | Override the dir-mode Project v2 title resolved by `scripts/setup_project.sh` and `scripts/dir_mode_project.sh resolve` (SPEC §1.7 Substrate guard) |
+| Dir-mode Project name | — | `CLAUDE_ENG_PROJECT_NAME` | `<repo-name> roadmap` (literal) | Override the dir-mode Project v2 title resolved by `scripts/setup_project.sh` and `scripts/dir_mode_project.sh resolve` (SPEC §1.7 Substrate guard) |
 
 *`STATUS_CACHE_DIR_OVERRIDE` is internal-only (smoke-test plumbing for `helpers/status.sh`) and intentionally not listed.*
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ All optional. Per-target state files live under `.claude/state/` (gitignored); e
 | Unattended park log | — | `SHIP_PARK_LOG_PATH` | `.claude/state/unattended-park.log` | Where `/ship` appends park entries in `unattended` mode (§5.7.1) |
 | PR cache repo override | — | `PR_CACHE_REPO` | — | Override the `owner/repo` `pr_cache` queries; falls back to `gh repo view` of the cwd (§5.4) |
 | Behavioral smoke gate | — | `CLAUDE_ENG_BEHAVIORAL_SMOKE` | unset | Set to `1` to exercise live `directive-reviewer` in smoke §42e (SPEC §4.9.3); default-unset keeps smoke offline + deterministic |
+| Dir-mode Project name | — | `CLAUDE_ENG_PROJECT_NAME` | `<repo-name> roadmap` | Override the dir-mode Project v2 title resolved by `scripts/setup_project.sh` and `scripts/dir_mode_project.sh resolve` (SPEC §1.7 Substrate guard) |
 
 *`STATUS_CACHE_DIR_OVERRIDE` is internal-only (smoke-test plumbing for `helpers/status.sh`) and intentionally not listed.*
 
@@ -99,6 +100,6 @@ All optional. Per-target state files live under `.claude/state/` (gitignored); e
 ## Verify
 
 ```bash
-./scripts/test/smoke.sh           # ~190 assertions across hooks, helpers, slash commands
+./scripts/test/smoke.sh           # ~280 assertions across hooks, helpers, slash commands
 ./scripts/build_toc.sh --check    # SPEC.md TOC freshness
 ```


### PR DESCRIPTION
Closes #73

## Goal
Close two pre-existing `README.md` staleness items that `doc-writer` flagged during `/ship` SSOT audits on PR #70 (#69 closeout) and PR #72 (#71 closeout). Both deferrals are recorded in those PRs' bodies; this PR resolves them in a single doc-only landing.

## How this serves the mission
SPEC §3 designates `README.md` as the operator-facing entry point. Configuration toggles and Verify are the two surfaces an operator hits first. Drift between them and the actual shell state means operators don't know they can override the dir-mode Project name (`CLAUDE_ENG_PROJECT_NAME`) and won't notice if smoke regresses to a count still well above the stale 190 baseline.

## Plan
Two edits to `README.md`:

1. **`README.md:88`** (commit `37d136e`; clarified in `2bcb2e0`) — append one row to the Configuration toggles table for `CLAUDE_ENG_PROJECT_NAME`. Position chosen to co-locate dir-mode-substrate knobs (after `CLAUDE_ENG_BEHAVIORAL_SMOKE` rather than alphabetical — table is thematic). `File=—` (env-only), `Default=` `` `<repo-name> roadmap` (literal) `` (matches SPEC §1.7:283 and `scripts/lib/dir_mode_project_resolve.sh:98`), `Purpose` cross-refs SPEC §1.7 Substrate guard + the new `scripts/dir_mode_project.sh resolve` resolver (PR #72).

2. **`README.md:103`** (commit `37d136e`) — change `# ~190 assertions across hooks, helpers, slash commands` to `# ~280 assertions ...`. Stable range chosen over exact `280` because the count has already drifted once (190 → 280) and will drift again; tilde documents order of magnitude without inviting a new staleness-PR after the next smoke-extending feat lands. AC #2 explicitly authorizes author's call.

**Doc → Test → Code split**: single-phase docs PR — entire payload IS the Doc phase. Phase B (Test) absent — README is not exercised by any test harness; AC #3 satisfied by running existing smoke. Phase C (Code) absent — no code change.

## Alternatives considered
- **Exact `280` instead of `~280`**: rejected — exact is correct on PR HEAD but stale on the first subsequent smoke addition; we'd re-open the same issue.
- **Insert the new row alphabetically** (between `CLAUDE_ENG_LINT_TIMEOUT` and `CLAUDE_ENG_STOP_THROTTLE`): rejected — table is thematic, not alphabetical (mode/coauthor come first despite later-alphabet env names); forcing alphabetical would break the existing pattern.
- **Combine this fix with a full README link-freshness audit across `docs/*.md`**: rejected — scope creep; AC #4 is an explicit scope fence.

## Key context
- `README.md:76-88` — toggles table; new row inserted at line 88.
- `README.md:103` — Verify section smoke-count comment.
- `SPEC.md:283` — `$CLAUDE_ENG_PROJECT_NAME` contract (override of default `<repo-name> roadmap`).
- `scripts/lib/dir_mode_project_resolve.sh:98` — resolver: `DR_PROJECT_NAME="${CLAUDE_ENG_PROJECT_NAME:-$DR_REPO_NAME roadmap}"`.
- `scripts/setup_project.sh:5` — bootstrap honors the override.
- Smoke baseline: `pass=280 fail=0` pre/post-edit (README not exercised by smoke; count unchanged by definition).

## Checklist
- [x] **Doc**: `README.md:88` — append `CLAUDE_ENG_PROJECT_NAME` toggles-table row (commit `37d136e`).
- [x] **Doc**: `README.md:103` — change `~190 assertions` to `~280 assertions` (commit `37d136e`).
- [x] **Review fix**: clarify default cell as placeholder via `(literal)` parenthetical (commit `2bcb2e0` — code-reviewer NIT).

(No Test or Code phase — see Plan above.)

## Out of scope
- Any other README section.
- Any `docs/*.md` link freshness audit.
- Any `SPEC.md` edit (would force a TOC rebuild — explicitly not in this PR).
- Re-running `setup_project.sh` or any dir-mode bootstrap.
- Adding `CLAUDE_ENG_PROJECT_NAME` to any other doc surface — SPEC §1.7, ADR-0002, and the three scripts already document it; README mirror is sufficient (verified by doc-writer audit).

## Risks
- **Smoke count drifts past `~280` band.** Mitigated by tilde; if count hits `~300+`, a future PR updates the figure. Low-severity, recurring-by-design.
- **SPEC §1.7 wording shifts.** Low — the new row points to a section, not a line; section numbers are stable per SPEC's TOC convention.
- **Row formatting drift.** Markdown renderer is forgiving; reviewer eyeballed; column count and pipe alignment verified.
- No code, no behavior change, no security surface.

## Open questions
None.

## Test plan
- [x] `bash scripts/test/smoke.sh` → `pass=280 fail=0` (default; verified pre- and post-edit; README not exercised by smoke).
- [x] `bash scripts/build_toc.sh --check` → fresh (SPEC.md not touched).
- [x] `git diff --stat main..HEAD` → exactly one file changed (`README.md`), confirming AC #4 scope fence.
- [~] Visual table-render check via `gh pr view --web` — N/A in unattended flow; column shape and pipe alignment verified by code-reviewer.

## Docs touched
- [x] `README.md:88` — Configuration toggles table (1 new row).
- [x] `README.md:103` — Verify section (count update).

## Ship gate
- [x] code-reviewer passed (`ship` with one NIT on rendering, addressed in `2bcb2e0`)
- [~] security-reviewer N/A — pure doc content, no surface
- [x] doc-writer passed (`ship`, all four audit items IN-SYNC or N/A)
- [x] Default smoke 280/280 (verified)
- [x] PR body curated
- [x] CI green (4 checks SUCCESS)