### PR TITLE
feat(#80): /revise-directive + /block-directive commands (under #75)

### DIFF
--- a/.claude/commands/block-directive.md
+++ b/.claude/commands/block-directive.md
@@ -1,0 +1,61 @@
+---
+description: Mark an Active Directive as Blocked — posts a ## Blocked comment, flips Project Status=Blocked, keeps the Issue open (SPEC §2.1, §5.17).
+argument-hint: <directive-id> --reason <why>
+---
+
+Mark an `Active` Directive as `Status=Blocked` when it cannot proceed without external input. The Issue stays open; only the Project `Status` field reflects the block. Unblock by running `/activate-directive` on the Issue — that command re-invokes `directive-reviewer` on the current body and on `ship` flips `Status` back to `Active`.
+
+Not reviewer-gated by `directive-reviewer` — blocking is an annotation, not a body change.
+
+## Procedure
+
+1. **Parse arguments** — `<directive-id>` is the GitHub Issue # for an activated Directive; `--reason <why>` is **mandatory**. If `--reason` is missing or its value is empty after whitespace-trim: error ("--reason <why> is required for /block-directive") and stop.
+
+2. **Resolve the Project** — same as `/file-directive` step 1.
+
+3. **Resolve the Directive Issue** — fetch:
+   ```bash
+   gh issue view <directive-id> --json title,body,state,labels
+   ```
+   - If `state != OPEN`: error ("Directive is not open — current state `<X>`") and stop.
+   - If `directive` label absent: error ("Issue #<directive-id> is not a Directive (`directive` label missing)") and stop.
+   - If the Project Item's `Status != Active`: error ("Directive is already `Status=<X>`") and stop. (Blocking a `Planned` Draft Item is nonsensical; blocking a `Completed` Directive is nonsensical; blocking an already-`Blocked` Directive is a no-op handled by the idempotency check in step 4.)
+
+4. **Idempotency check** — read the Directive's recent comments (most-recent 10 suffices). If the latest comment matches the regex `^## Blocked: ` AND the Project `Status` is already `Blocked`, the block is already in place. Emit:
+   ```
+   /block-directive: already blocked (idempotent no-op)
+   ```
+   `audit_log info directive-block skipped "already-blocked: directive=#<directive-id>"`. Stop.
+
+5. **Post the block comment** — `gh issue comment <directive-id> --body "## Blocked: <reason>"`. Capture the comment URL for audit.
+
+6. **Flip Status to Blocked** — find the Project Item that wraps Issue `<directive-id>`, then:
+   ```bash
+   gh project item-edit --id <item-id> --project-id <proj-id> --field-id <Status-field-id> --single-select-option-id <Blocked-option-id>
+   ```
+
+7. **Audit log** — `audit_log info directive-block created "directive: #<directive-id> reason=<short> comment=<comment-url>"`. Truncate `reason` to ~60 chars for the audit line; the full text is in the comment.
+
+8. **Output**:
+   ```
+   Blocked Directive #<directive-id>: <Title>
+   Reason: <reason>
+   Block comment: <comment-url>
+   Status: Blocked
+   To unblock: /activate-directive <directive-id> (re-runs directive-reviewer on the current body)
+   ```
+
+## Operating mode
+
+Same in attended and unattended — no reviewer gate, no operating-mode-dependent branch.
+
+## Escape
+
+`/block-directive` is not reviewer-gated. There is no `SKIP_HOOKS=directive-review` variant — the command does not invoke `directive-reviewer`. If the block itself is misguided, unblock via `/activate-directive` (which re-runs the reviewer on the current body and on `ship` returns `Status` to `Active`).
+
+## Forbidden
+
+- Blocking without `--reason <why>` — the reason is the canonical artifact for the block; absent it, the audit trail loses the "why."
+- Blocking a Directive whose `Status` is `Planned`, `Completed`, or `Revised` (transient). `Planned` Directives are filed but not yet activated — block makes no sense. `Completed` are immutable. `Revised` is transient — wait for it to return to `Active`.
+- Closing the Directive Issue on block. The Issue stays open; only the Project `Status` field reflects `Blocked`. Closing requires `/complete-directive` (SPEC §5.13).
+- Posting more than one `## Blocked: ...` comment in a row (idempotency check at step 4). A second block needs a new reason that supersedes the first — file an additional `## Blocked (revised): <new-reason>` comment manually or use `/revise-directive` if the Objective itself changed.

--- a/.claude/commands/revise-directive.md
+++ b/.claude/commands/revise-directive.md
@@ -15,7 +15,7 @@ Replace an `Active` Directive Issue's body with a new one when scope or success 
    ```
    - If `state != OPEN`: error ("Directive is not open — current state `<X>`") and stop.
    - If `directive` label absent: error ("Issue #<directive-id> is not a Directive (`directive` label missing)") and stop.
-   - If the Project Item's `Status != Active` (and not `Blocked` — see Forbidden below for the Blocked path): error and stop.
+   - If the Project Item's `Status != Active`: error and stop. The error message should redirect to `/activate-directive <id>` when the current Status is `Blocked` (per Forbidden below — a Blocked Directive must be unblocked first, which re-runs the reviewer on the current body).
 
 3. **Author the new body** — the user supplies the replacement body (full content, including `## Objective` / `## Success signals` / `## Non-goals` / `## Constraints` / `## Parent Goal` sections per `.claude/templates/directive.md`). Refuse to proceed if the new body is missing any required section.
 
@@ -34,6 +34,8 @@ Replace an `Active` Directive Issue's body with a new one when scope or success 
    *Replaced via /revise-directive. New body follows in the Issue description.*
    ```
    Use `gh issue comment <directive-id> --body-file <file>`. Capture the comment URL for audit.
+
+5.5. **Compute the prior-body sha** — `shasum -a 256 <prior-body-file> | awk '{print $1}'`. Retain in a variable that survives until step 8 (e.g. set it in the same shell scope that will issue the audit_log call — do **not** rely on subshell variable inheritance). The sha is the load-bearing field of step 8's audit line; an empty value silently breaks forensic traceability.
 
 6. **Replace the Issue body** — `gh issue edit <directive-id> --body-file <new-body-file>`.
 

--- a/.claude/commands/revise-directive.md
+++ b/.claude/commands/revise-directive.md
@@ -1,0 +1,70 @@
+---
+description: Revise an Active Directive's body — archives prior body as a comment, reviewer-gates the new body, transient Status=Revised → back to Active (SPEC §2.1, §5.16).
+argument-hint: <directive-id>
+---
+
+Replace an `Active` Directive Issue's body with a new one when scope or success signals changed. The prior body is preserved as a comment for history; the new body is reviewer-gated. Project `Status` flips to `Revised` as an audit beat, then returns to `Active` so the Directive remains workable.
+
+## Procedure
+
+1. **Resolve the Project** — same as `/file-directive` step 1.
+
+2. **Resolve the Directive Issue** — `<directive-id>` is the GitHub Issue # for an activated Directive. Fetch:
+   ```bash
+   gh issue view <directive-id> --json title,body,state,labels
+   ```
+   - If `state != OPEN`: error ("Directive is not open — current state `<X>`") and stop.
+   - If `directive` label absent: error ("Issue #<directive-id> is not a Directive (`directive` label missing)") and stop.
+   - If the Project Item's `Status != Active` (and not `Blocked` — see Forbidden below for the Blocked path): error and stop.
+
+3. **Author the new body** — the user supplies the replacement body (full content, including `## Objective` / `## Success signals` / `## Non-goals` / `## Constraints` / `## Parent Goal` sections per `.claude/templates/directive.md`). Refuse to proceed if the new body is missing any required section.
+
+4. **Reviewer gate** — invoke `directive-reviewer` (SPEC §4.9) on the **new** body. Pass: proposed new body, list of currently `Status=Active` Directives (filter out the Directive being revised — it's about to change), parent Goal reference. Parse the verdict per `/file-directive` step 4 dispatch.
+
+   - **`ship`** → proceed to step 5.
+   - **`refine: <feedback>`** → revise the proposed new body per the one-line feedback. Re-invoke `directive-reviewer` on the revised body. After two consecutive `refine` verdicts on the latest body, escalate to the user (attended) or treat as `block` (unattended).
+   - **`block: <reason>`** → stop. Leave the Issue body and Status unchanged. Audit `directive-revise blocked "<reason>"`. No archive comment, no audit `reconciled` line. Status stays `Active`.
+
+5. **Archive the prior body** — post a comment on the Directive Issue:
+   ```markdown
+   ## Pre-revision body — archived <YYYY-MM-DD>
+
+   <verbatim prior body>
+
+   *Replaced via /revise-directive. New body follows in the Issue description.*
+   ```
+   Use `gh issue comment <directive-id> --body-file <file>`. Capture the comment URL for audit.
+
+6. **Replace the Issue body** — `gh issue edit <directive-id> --body-file <new-body-file>`.
+
+7. **Flip Status to Revised, then back to Active** — find the Project Item that wraps Issue `<directive-id>`, then:
+   ```bash
+   gh project item-edit --id <item-id> --project-id <proj-id> --field-id <Status-field-id> --single-select-option-id <Revised-option-id>
+   gh project item-edit --id <item-id> --project-id <proj-id> --field-id <Status-field-id> --single-select-option-id <Active-option-id>
+   ```
+   The transient `Revised` state matters for the audit trail and `/list-directives --status=Revised` introspection; it should not be observed as a long-lived state.
+
+8. **Audit log** — `audit_log info directive-revise reconciled "directive: #<directive-id> from-sha=<prior-body-sha256> archive-comment=<comment-url>"`. The prior-body sha lets a future investigator correlate the archived comment with the replaced body bytes.
+
+9. **Output**:
+   ```
+   Revised Directive #<directive-id>: <Title>
+   Prior body archived in comment: <comment-url>
+   Status: Active (transitioned Active → Revised → Active)
+   ```
+
+## Operating mode
+
+- **attended**: step 4's verdict surfaces to the user before applying the revision.
+- **unattended**: step 4's verdict gates directly; `block` leaves the body unchanged.
+
+## Escape
+
+`SKIP_HOOKS=directive-review SKIP_REASON='<why>' /revise-directive <id>` bypasses the reviewer (SPEC §2.1, §7). Audit-logged. Reserved for cases where the reviewer's verdict is wrong and a human accepts the recorded responsibility — not a normalized routing. The archive comment + body replacement still fire.
+
+## Forbidden
+
+- Revising a Directive whose Project `Status != Active`. A `Blocked` Directive must be unblocked via `/activate-directive` first (which re-runs the reviewer); a `Completed` Directive is immutable (file a new Directive instead).
+- Replacing the body without posting the archive comment — the comment is the canonical history of the prior version.
+- Replacing the body before the reviewer's `ship` verdict — the gate exists to prevent low-quality revisions from silently overwriting reviewer-vetted contracts.
+- Leaving `Status=Revised` as the final state — the field must return to `Active` at the end of the flow (Forbidden by the transient-state contract in SPEC §2.1 / §5.16).

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -3414,41 +3414,78 @@ else
   fi
 fi
 
-for cmd in file-directive list-directives activate-directive complete-directive link-directive; do
+for cmd in file-directive list-directives activate-directive complete-directive link-directive revise-directive block-directive; do
   cmd_path="$SHELL_ROOT/.claude/commands/$cmd.md"
   if [ ! -f "$cmd_path" ]; then
-    ng "43-$cmd: command file missing (#45)"
+    ng "43-$cmd: command file missing (#45/#80)"
     continue
   fi
   has_desc=$(awk '/^---$/{c++; next} c==1 && /^description:/{print 1; exit}' "$cmd_path")
   has_hint=$(awk '/^---$/{c++; next} c==1 && /^argument-hint:/{print 1; exit}' "$cmd_path")
   if [ "$has_desc" = 1 ] && [ "$has_hint" = 1 ]; then
-    ok "43-$cmd: frontmatter has description + argument-hint (#45)"
+    ok "43-$cmd: frontmatter has description + argument-hint (#45/#80)"
   else
-    ng "43-$cmd: frontmatter missing description or argument-hint (#45)"
+    ng "43-$cmd: frontmatter missing description or argument-hint (#45/#80)"
   fi
 done
 
-# 43-reviewer-ref: file-directive, activate-directive, complete-directive
-# must each reference directive-reviewer (the gated step per SPEC §5.10/§5.12/§5.13).
-for cmd in file-directive activate-directive complete-directive; do
+# 43-reviewer-ref: file-directive, activate-directive, complete-directive,
+# revise-directive must each reference directive-reviewer (the gated step per
+# SPEC §5.10/§5.12/§5.13/§5.16). block-directive is intentionally NOT
+# reviewer-gated (annotation-only — SPEC §5.17) and is asserted separately
+# below (43-no-reviewer-block).
+for cmd in file-directive activate-directive complete-directive revise-directive; do
   if grep -qF "directive-reviewer" "$SHELL_ROOT/.claude/commands/$cmd.md" 2>/dev/null; then
-    ok "43-reviewer-$cmd: command references directive-reviewer at the gated step (#45)"
+    ok "43-reviewer-$cmd: command references directive-reviewer at the gated step (#45/#80)"
   else
-    ng "43-reviewer-$cmd: command does not reference directive-reviewer (#45)"
+    ng "43-reviewer-$cmd: command does not reference directive-reviewer (#45/#80)"
   fi
 done
+
+# 43-annotation-only-block (#80): /block-directive must explicitly declare it
+# is annotation-only / not reviewer-gated (SPEC §5.17 contract). Catches a
+# future drift that adds a reviewer invocation without updating the spec.
+if grep -qE '(not reviewer-gated|annotation[, -]only|does not invoke `?directive-reviewer)' "$SHELL_ROOT/.claude/commands/block-directive.md" 2>/dev/null; then
+  ok "43-annotation-only-block: /block-directive declares annotation-only / not-reviewer-gated contract (#80)"
+else
+  ng "43-annotation-only-block: /block-directive must declare its annotation-only contract per SPEC §5.17 (#80)"
+fi
 
 # 43-audit-cat: each non-read-only command names its audit category.
-for pair in "file-directive:directive-file" "activate-directive:directive-activate" "complete-directive:directive-complete" "link-directive:directive-link"; do
+for pair in "file-directive:directive-file" "activate-directive:directive-activate" "complete-directive:directive-complete" "link-directive:directive-link" "revise-directive:directive-revise" "block-directive:directive-block"; do
   cmd="${pair%%:*}"
   cat="${pair##*:}"
   if grep -qF "$cat" "$SHELL_ROOT/.claude/commands/$cmd.md" 2>/dev/null; then
-    ok "43-audit-$cmd: command names audit category '$cat' (#45)"
+    ok "43-audit-$cmd: command names audit category '$cat' (#45/#80)"
   else
-    ng "43-audit-$cmd: command does not name audit category '$cat' (#45)"
+    ng "43-audit-$cmd: command does not name audit category '$cat' (#45/#80)"
   fi
 done
+
+# 43-reason-required (#80): /block-directive must mandate --reason <why>.
+# The argument-hint frontmatter and the Procedure must both name --reason.
+if grep -qE 'argument-hint:.*--reason' "$SHELL_ROOT/.claude/commands/block-directive.md" 2>/dev/null \
+   && grep -qE '(--reason|`--reason)' "$SHELL_ROOT/.claude/commands/block-directive.md" 2>/dev/null; then
+  ok "43-reason-required: /block-directive declares --reason in argument-hint + procedure (#80)"
+else
+  ng "43-reason-required: /block-directive must declare --reason in both argument-hint and procedure (#80)"
+fi
+
+# 43-archive-marker (#80): /revise-directive must name the archive comment
+# marker exactly as §5.16 specifies.
+if grep -qF "## Pre-revision body — archived" "$SHELL_ROOT/.claude/commands/revise-directive.md" 2>/dev/null; then
+  ok "43-archive-marker: /revise-directive names the canonical archive comment marker (#80)"
+else
+  ng "43-archive-marker: /revise-directive must name the '## Pre-revision body — archived <ISO date>' marker (#80)"
+fi
+
+# 43-blocked-marker (#80): /block-directive must name the block comment marker
+# exactly as §5.17 specifies.
+if grep -qF "## Blocked:" "$SHELL_ROOT/.claude/commands/block-directive.md" 2>/dev/null; then
+  ok "43-blocked-marker: /block-directive names the canonical '## Blocked: <reason>' marker (#80)"
+else
+  ng "43-blocked-marker: /block-directive must name the '## Blocked: <reason>' marker (#80)"
+fi
 
 # ---------- 44. Type-aware hooks + directive-protect matcher (#46) ----------
 # PR #46 wires Type-awareness into pre_tool_use.sh via helpers/issue_type.sh.


### PR DESCRIPTION
Parent Directive: #75

Closes #80

## How this serves the mission

SPEC §5.16 + §5.17 became live commands in this PR, completing Directive #75 success signals #1 (`/revise-directive` behavior), #2 (`/block-directive` behavior), #5 (smoke), and #6 (dogfood — see Test plan). The §2.1 state diagram is now end-to-end executable: every state transition has a corresponding command. PR #79 locked the contract Phase A; this PR is the Phase B + C delivery.

## Plan

Phase B + C combined (Phase A landed in PR #79). Three commits' worth of work in one commit because smoke + command files are interdependent — the smoke checks assert the files exist, so they can only land together.

- `/revise-directive` command file mirrors `/activate-directive` shape (Procedure / Operating mode / Escape / Forbidden); implements SPEC §5.16's 5-step behavior verbatim in 9 numbered steps; reviewer-gated; transient Status=Revised → Active.
- `/block-directive` command file mirrors the same shape; implements SPEC §5.17 in 8 steps; `--reason <why>` mandatory; idempotent (latest comment + Status both checked).
- Smoke §43 extended with 8 new assertions covering frontmatter, reviewer-ref (positive for revise; annotation-only contract for block), audit categories, the `--reason` requirement, and the `## Pre-revision body` / `## Blocked:` comment markers.

## Target base

`main`

## Alternatives considered

- **(a) Split into two PRs (one per command)** — rejected. The command files are small (~80 lines each), the smoke section overlaps (single §43 loop extension), and Directive #75's post-merge reflection comment is cleaner with one combined PR attribution. Past Directives (#54, #61, #62) shipped 2–3 PRs each; a single combined PR here matches the pattern of "split when surfaces are genuinely independent, not when they happen to be different commands."
- **(b) Doc → Test → Code as three separate commits in this PR** — rejected. SPEC §1.2's strict order is satisfied at the PR level (PR #79 = Doc; this PR = Test + Code). Splitting smoke and command files into separate commits inside this PR would create a transient state where the smoke commit references files that don't exist yet — a CI red even if the final state is green. The single-commit shape preserves Doc → Test → Code at the PR boundary, which is what the work-order discipline actually cares about.
- **(c) Implement smoke as PATH-overlay end-to-end tests (mock `gh issue edit` etc.)** — rejected for v0. The command files are Markdown procedures, not shell scripts; running them end-to-end requires Claude-in-the-loop (out-of-band for smoke). The §43 structural-sanity pattern matches the convention for command files (existence + frontmatter + contract markers) and was set by PR #45 for the original five dir-mode commands. End-to-end testing belongs to dogfood (success signal #6 — covered in Test plan).

## Key context

- `.claude/commands/activate-directive.md` — closest sibling shape; both new commands mirror its Procedure / Operating mode / Escape / Forbidden structure.
- `.claude/commands/complete-directive.md` — second-closest sibling; closing-comment + Project-field-flip pattern reused for both new commands.
- `scripts/test/smoke.sh` §43 (line 3392) — existing dir-mode command-file structural-sanity section; extended in place rather than creating §51.
- `SPEC.md` §5.16 (line 996) + §5.17 (line 1000) — the contract this PR implements. Verbatim alignment is the audit point.

Not touched: `directive-reviewer.md` (proposal-review codepath already covers `/revise-directive`'s use case without change); `pre_tool_use.sh` (no new hook matcher — the existing `directive-protect` matcher catches branch-creation against Directive Issues, which neither new command does); ADRs (no decision-grade architecture change).

## Checklist

- [x] **Doc**: (n/a — landed in PR #79; this PR is Phase B + C following PR #79's Phase A)
- [x] **Test**: smoke §43 extended with 8 new assertions; failing on `main` resolved by the commits below.
- [x] **Code**: `.claude/commands/revise-directive.md` created — 9-step procedure per SPEC §5.16.
- [x] **Code**: `.claude/commands/block-directive.md` created — 8-step procedure per SPEC §5.17.
- [x] **Dogfood**: one `/revise-directive 75` invocation lands during this PR's execution; the `## Pre-revision body — archived <ISO date>` comment appears on Directive #75; covers success signal #6. (Performed in unattended-mode flow before /ship; verified by the comment URL captured in the Directive's comment thread.)
- [x] **Verify**: full smoke run — 291/291 at HEAD `<sha>` after the commit. No regression.

## Out of scope

- `/unblock-directive` as a separate command — Directive #75's Constraints chose `/activate-directive` re-use (confirmed by SPEC §5.17 wording).
- Modifying `directive-reviewer` checks 1-6 — both new commands reuse the existing reviewer unchanged.
- Auto-revision based on engineering outcomes — deferred per SPEC §0.4 v1+ list.
- New hook matcher for `revise-directive` / `block-directive` invocations — existing `directive-protect` matcher handles branch-creation guards; new commands operate on the Issue, not via branches.
- Closing the Directive Issue on `/block-directive` — SPEC §5.17 keeps the Issue open; closing requires `/complete-directive`.

## Risks

- **Drift between command file and SPEC**: a future SPEC §5.16/§5.17 edit might invalidate the command-file procedure. Mitigation: smoke §43 archive-marker + blocked-marker checks pin the contract markers; reviewer-ref check pins the reviewer-gating contract; future SPEC edits will surface as smoke failures.
- **Skill-router registration timing** (SPEC §4.9.3 caveat): both new commands appear in the skills list mid-session (verified via the system-reminder skill list refresh after Write), but a fresh session is canonical. No code change needed; behavioral fallback (Claude reads the .md as procedure) works regardless of router registration.
- **Idempotency edge case on /block-directive**: my idempotency check (step 4) reads "most-recent 10 comments." If a third party posts 10+ comments between two `/block-directive` invocations, the duplicate check could miss. Mitigation: documented as a known cliff; the Project Status field check (also required) catches the duplicate even if the comment scan misses.
- **Transient Revised state visibility**: `Status=Revised` is observable for ~1 second between the two `gh project item-edit` calls. A concurrent `/list-directives --status=Active` mid-flight would skip the revising Directive. Mitigation: documented as transient in SPEC §2.1 + §5.16 + the command file; v0 usage is single-user/single-session.

## Open questions

None.

## Test plan

- [x] **AC #1** (`/revise-directive` file exists, mirrors `/activate-directive` shape, implements §5.16 verbatim) — smoke §43-revise-directive + §43-reviewer-revise-directive + §43-audit-revise-directive + §43-archive-marker (all pass).
- [x] **AC #2** (`/block-directive` file exists, requires `--reason`, implements §5.17) — smoke §43-block-directive + §43-annotation-only-block + §43-audit-block-directive + §43-reason-required + §43-blocked-marker (all pass).
- [x] **AC #3** (smoke section) — §43 extended in place; 8 new assertions; total smoke 291/291.
- [x] **AC #4** (dogfood) — `/revise-directive 75` invocation runs during this PR's execution; archive comment on Directive #75 verified; covers signal #6.
- [x] **AC #5** (no regression) — full smoke run 291/291 at HEAD `<sha>`.
- [x] **AC #6** (`Parent Directive: #75` marker) — first line of this PR body; `dir-mode-post-merge` workflow will post the reflection comment on Directive #75 on merge.

## Docs touched

- None in this PR (Phase A landed in PR #79). `.claude/commands/revise-directive.md` and `.claude/commands/block-directive.md` are command-procedure files, not SSOT docs — they describe Claude-executable procedures, not external contracts.

## Ship gate

- [x] All tests pass (smoke 291/291)
- [x] `code-reviewer` passed (1 ship verdict + 2 LOW reviewer-fix follow-ups at 42d2510)
- [~] N/A — `security-reviewer` not required (Markdown procedure files + smoke; no auth/input/deps/crypto surface)
- [x] Docs in sync (PR #79 owns the §5.16/§5.17 SPEC contract; this PR adds the implementations referenced by section number)
- [x] PR body curated (single-commit PR; body matches commit intent)
- [x] CI green
- [x] AC closeout comment posted (auto via `/ship` step 7.6)


