### PR TITLE
fix(#83): ac-closeout matcher rc=1 happy-path arm

### DIFF
--- a/.claude/hooks/pre_tool_use.sh
+++ b/.claude/hooks/pre_tool_use.sh
@@ -236,6 +236,7 @@ case "$tool" in
                 fi
                 [ -z "$ac_directive_skip" ] && block ac-closeout "linked issue has unchecked AC and no '## AC closeout' marker comment. Run: scripts/ac_closeout.sh $ac_pr (idempotent). Or SKIP_HOOKS=ac-closeout SKIP_REASON='<why>' for legitimate edge cases."
                 ;;
+              1) mark_allow ac-closeout; decided=1 ;;
               2) audit_log warn ac-closeout notice "indeterminate (gh timeout / missing / malformed); merge allowed per fail-open"; decided=1 ;;
             esac
           else

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -2688,18 +2688,27 @@ pt39_run() {
 # whose state is already configured for the pass-through ac-closeout
 # scenario above.
 PT39_TABLE=(
-  "gh pr merge 200 --merge|ac-closeout|pass-through"
+  # Intentionally empty after #83. The original row
+  # ("gh pr merge 200 --merge|ac-closeout|pass-through") encoded the
+  # pre-fix bug behavior — the ac-closeout matcher's case-statement was
+  # missing the rc=1 happy-path arm, so allow-cases fell through to
+  # pass_through_trace. Issue #83's fix added `1) mark_allow ac-closeout`,
+  # making the happy path silent (per SPEC §6.1's mark_allow contract).
+  # §39d below asserts the corrected silence, including the pipe-form
+  # `gh pr merge ... 2>&1 | tail -N` shape that originally triggered #83.
 )
 
-# Subset notes for the v1 cut: only ac-closeout is included here.
+# Subset notes for the v1 cut: only ac-closeout was included originally.
 # Adding the other 10 matchers needs custom setup per matcher (cwd on
 # the right branch for backmerge; pushed-vs-unpushed for --amend; etc.)
-# — those are added incrementally in the Code phase as the matchers are
-# retrofitted. §39b's structural check is the safety net that catches
-# any matcher whose retrofit is forgotten.
+# — those are added incrementally as the matchers are retrofitted. §39b's
+# structural check is the safety net that catches any matcher whose
+# retrofit is forgotten.
 
 p39_fails=0
-for row in "${PT39_TABLE[@]}"; do
+# Guard empty-array iteration under `set -u`. PT39_TABLE is intentionally
+# empty after #83's mark_allow fix; §39d below tests the corrected silence.
+for row in ${PT39_TABLE[@]+"${PT39_TABLE[@]}"}; do
   IFS='|' read -r p39_cmd p39_cat p39_dec <<< "$row"
   p39_before=$(wc -l < "$REAL_AUDIT_39" 2>/dev/null | tr -d ' ' || echo 0)
   pt39_run "$p39_cmd" >/dev/null 2>&1
@@ -2760,6 +2769,27 @@ if [ "$p39c_new" = 0 ]; then
 else
   ng "pass-through: benign cmd produced $p39c_new unexpected audit records (#33)"
 fi
+
+# §39d: ac-closeout happy-path silence (#83). When pr_needs_closeout
+# returns 1 (allow: no unchecked AC items), the matcher's `1)` arm calls
+# mark_allow (silent per SPEC §6.1 mark_allow contract) and decides.
+# Pre-fix bug: the case statement had no `1)` arm, so the happy path
+# fell through to pass_through_trace, producing a spurious warn audit
+# line on every successful AC-closed-out merge. Tests both the bare form
+# and the pipe-with-redirect form (`gh pr merge ... 2>&1 | tail -5`) that
+# triggered #83's discovery on PR #77's auto-merge.
+for p39d_cmd in "gh pr merge 200 --merge" "gh pr merge 200 --auto --merge --delete-branch 2>&1 | tail -5"; do
+  p39d_before=$(wc -l < "$REAL_AUDIT_39" 2>/dev/null | tr -d ' ' || echo 0)
+  pt39_run "$p39d_cmd" >/dev/null 2>&1
+  p39d_after=$(wc -l < "$REAL_AUDIT_39" 2>/dev/null | tr -d ' ' || echo 0)
+  p39d_new=$(( p39d_after - p39d_before ))
+  if [ "$p39d_new" = 0 ]; then
+    ok "pass-through: ac-closeout happy path silent on \`${p39d_cmd:0:40}...\` (#83)"
+  else
+    p39d_tail=$(tail -"$p39d_new" "$REAL_AUDIT_39" 2>/dev/null | tr '\n' '|')
+    ng "pass-through: ac-closeout happy path emitted $p39d_new audit record(s) on \`$p39d_cmd\` — expected silent (mark_allow). tail=$p39d_tail (#83)"
+  fi
+done
 
 rm -rf "$PT39_DIR"
 


### PR DESCRIPTION
Closes #83

## How this serves the mission

SPEC §6.1 pass-through invariant: "Every matcher in `pre_tool_use.sh` reaches a decided state per fire." The ac-closeout matcher's happy path (rc=1 from `pr_needs_closeout`) was missing its case arm — fell through to `pass_through_trace`, producing spurious `warn ac-closeout pass-through` audit lines on every successful AC-closed-out merge. PR #77's auto-merge surfaced one such line on 2026-05-24T15:38:39Z, which became Issue #83.

Restores the invariant — every happy-path merge now decides silently via `mark_allow` per SPEC §6.1's "high-frequency happy paths call `mark_allow` (silent)" rule.

## Plan

`fix` type. Single-commit PR (Doc → Test → Code relaxation per CLAUDE.md: reproduce-first applies; no SSOT contract change; tests were missing the happy-path assertion entirely).

Root cause confirmed by reading `pre_tool_use.sh:212-240`:

```bash
case "$ac_rc" in
  0) ... block path ...;;
  2) ... fail-open warn + decided=1 ;;
esac    # ← no `1)` arm. rc=1 falls through. decided unset.
```

`pr_needs_closeout` returns 0/1/2 per `helpers/ac_closeout_gate.sh:13` ("0 = needs closeout (block), 1 = allows, 2 = indeterminate"). With AC already closed out (the common case post-`/ship`), rc=1 is the dominant path — and it fell through silently.

## Target base

`main`

## Alternatives considered

- **(a) Add `*) ... ;;` catch-all that calls `mark_allow`** — rejected. A catch-all hides future rc additions (if `pr_needs_closeout` ever returns 3 with a different meaning, we'd want to know). Explicit `1)` arm names the contract.
- **(b) Refactor `pr_needs_closeout` to return only 0/2 (block-needed / indeterminate-or-allow)** — rejected. The 3-state return is informational and lets the matcher distinguish "fail-open warn" (rc=2, log it) from "happy path mark_allow" (rc=1, silent). Collapsing loses the audit-trail distinction.
- **(c) Issue #83's original hypothesis: fix command normalization for `gh pr merge ... 2>&1 | tail -5` pipe form** — rejected. The matcher's regex (`\bgh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)`) already handles the pipe form correctly; `extract_pr_from_merge_cmd` correctly returns "77" from PR #77's command. The audit-line evidence was misleading because it included the pipe in the captured `cmd` string; the bug had nothing to do with command shape.

## Key context

- `.claude/hooks/pre_tool_use.sh:212-240` — ac-closeout matcher case statement.
- `.claude/hooks/helpers/ac_closeout_gate.sh:62-90` — `pr_needs_closeout` definition with 0/1/2 return contract.
- `scripts/test/smoke.sh:2690-2722` — §39a PT39_TABLE that was encoding the bug as expected behavior.
- `scripts/test/smoke.sh:2758-2787` — §39d new assertion that locks the correct silent behavior on both bare and pipe-with-redirect command forms.

Not touched: SPEC (no contract change — §6.1's mark_allow rule was already documented; this PR makes ac-closeout obey it).

## Checklist

- [x] **Code**: pre_tool_use.sh case gains `1) mark_allow ac-closeout; decided=1 ;;` arm.
- [x] **Test**: §39d asserts ac-closeout happy path is silent on bare + pipe forms. §39a PT39_TABLE row removed (was encoding the bug). Empty-array iteration guarded against `set -u`.
- [x] **Verify**: smoke 292/292 (was 291; -1 removed row, +2 §39d iterations).

## Out of scope

- Other matchers' pass-through coverage — §39a PT39_TABLE comments still name "incrementally added" as the rollout. This PR fixes only ac-closeout.
- Refactoring `pr_needs_closeout`'s 3-state contract.
- Adding a `*)` catch-all to the case (rejected per Alternatives (a)).
- Backfilling the audit log to remove the prior `warn ac-closeout pass-through` line from PR #77's merge. Append-only contract preserved.

## Risks

- **Smoke fixture drift**: §39d uses the same `$PT39_SHIM`/`$PT39_STATE` fixture as §39a. State is pre-seeded for the rc=1 happy path (`pr_issues=100, issue_body='- [x] all done'`). If a future PR alters that fixture, §39d's assertion shifts. Mitigation: §39d's comment block names the pre-fix bug condition + the expected silent behavior; future authors editing §39 will see the why.
- **Matcher silence regression**: if a future change reverts the `1)` arm or breaks `mark_allow`, §39d fails immediately on next smoke run. The assertion shape (`p39d_new == 0`) is the strict mirror of the original bug.
- **`mark_allow` semantic drift**: SPEC §6.1 promises mark_allow is silent. If hookrt.sh's `mark_allow` ever changes to emit audit (e.g., for debug), §39d would suddenly fail. That's the right tripwire — mark_allow's silence is load-bearing for many matchers, not just ac-closeout.

## Open questions

None.

## Test plan

- [x] **AC reproducer** — §39d on `main` (pre-fix) fails: rc=1 falls through, emits one `warn ac-closeout pass-through` line, `p39d_new=1`. After fix: rc=1 hits `1) mark_allow`, emits nothing, `p39d_new=0`. Manually verified.
- [x] **AC pipe form coverage** — §39d second iteration uses the literal `2>&1 | tail -5` form from Issue #83's evidence trace. Same assertion result.
- [x] **AC no regression** — full smoke 292/292.

## Docs touched

None. SPEC §6.1's mark_allow contract was already documented; this PR makes ac-closeout obey it. No new behavior to document externally.

## Ship gate

- [x] All tests pass (smoke 292/292)
- [x] `code-reviewer` passed (ship clean)
- [~] N/A — `security-reviewer` not required (hook-matcher logic fix; no auth/input/deps/crypto surface)
- [x] Docs in sync (no SSOT changes)
- [x] PR body curated (single-commit PR)
- [x] CI green
- [x] AC closeout comment posted (auto via `/ship` step 7.6)


