### PR TITLE
feat(#93): Issue templates + auto-needs-triage workflow (cluster A, under #92)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report a defect — something doesn't work as documented in SPEC.md / README / CLAUDE.md.
+title: "fix: <subject>"
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What's broken
+      description: One paragraph naming the defect.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproducer
+      description: Steps to reproduce. Include command + expected vs actual output. If discovered during a session, include the timestamp and audit-log entry if relevant.
+      placeholder: |
+        1. Run `gh pr merge 77 --auto --merge --delete-branch 2>&1 | tail -5` on a PR with AC closed out.
+        2. Expected: matcher recognizes happy path, no audit emission (mark_allow silent).
+        3. Actual: `pass-through` warn emitted at <timestamp>.
+    validations:
+      required: true
+
+  - type: textarea
+    id: root-cause-or-hypothesis
+    attributes:
+      label: Root cause or hypothesis
+      description: If known, name the file:line. Otherwise list candidate hypotheses for diagnosis to narrow.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Verifiable conditions as `- [ ] <item>`. Include "reproducer no longer fires" + smoke regression check.
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+# Discussions are not enabled on this repo (verified 2026-05-26 via
+# `gh api repos/ilgyu-yi/claude-eng-shell --jq .has_discussions` → false).
+# When Discussions is enabled later, add a `contact_links:` entry here
+# pointing at the Discussions URL — see brief §5.1 + cluster A AC.
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/directive-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/directive-proposal.yml
@@ -1,0 +1,82 @@
+name: Directive proposal
+description: Propose a Directive — a medium-term directional context that scopes several Execution Issues. See SPEC §1.7 / §2.1. Maintainer triages via `/triage`.
+title: "directive: <one-line objective>"
+labels: [directive, status:proposed]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A Directive is a **directing context**, not a unit of work. It names what scope of work is worth doing over a few weeks and gives Execution Issues a coherent parent to live under. The maintainer reviews this proposal via `/triage` and either accepts (Status → Active) or rejects (refiled in a different template).
+
+        Before filing, scan [`MISSION.md`](../blob/main/MISSION.md) and the [open Directives](https://github.com/ilgyu-yi/claude-eng-shell/issues?q=is%3Aopen+label%3Adirective) to make sure this proposal doesn't duplicate existing direction.
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: One paragraph naming what this Directive is trying to achieve. Bound by a concrete artifact-level boundary (file paths, issue counts, AC ticks, merge events) — not "improve" or "optimize" without a target.
+      placeholder: |
+        Promote the two §2.1 state-table entries currently marked "(v1+)" — Revised and Blocked — from placeholder rows to executable commands. Concrete artifacts: .claude/commands/{revise,block}-directive.md, SPEC §2.1 + new §5.x subsections, smoke section.
+    validations:
+      required: true
+
+  - type: textarea
+    id: success-signals
+    attributes:
+      label: Success signals
+      description: 2-5 verifiable conditions for completion. Each must be objectively testable by a reasonable engineer — name the artifact / metric / state that demonstrates the signal is met.
+      placeholder: |
+        - /revise-directive on an Active Directive produces a `## Pre-revision body — archived <ISO date>` comment + body replacement + audit line.
+        - SPEC §2.1 state diagram + table contain zero `(v1+)` parentheticals.
+        - Smoke 282/282 with new §43 assertions.
+    validations:
+      required: true
+
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-goals
+      description: At least 2 explicit exclusions. What this Directive does NOT cover. Sharper non-goals tighten scope clarity.
+      placeholder: |
+        - Does NOT add /derive-next-directive (sibling v1+ item, separate Directive).
+        - Does NOT modify directive-reviewer's existing checks.
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: At least 1 invariant to preserve throughout the Directive's lifetime. Reviewer-gating, mode semantics, audit shape, etc.
+      placeholder: |
+        - Preserve §2.1 reviewer-gating contract — both commands re-invoke directive-reviewer.
+        - Preserve audit_log <event> <category> <decision> <reason> shape.
+    validations:
+      required: true
+
+  - type: textarea
+    id: mission-fit
+    attributes:
+      label: MISSION fit
+      description: Which `MISSION.md` section or success criterion does this Directive serve? One sentence. (If MISSION.md doesn't yet exist or doesn't cover this, say so honestly — the Directive may motivate a MISSION amendment.)
+      placeholder: |
+        Serves MISSION § "Success looks like > The directing layer works" — completes the §2.1 state diagram so the Directive lifecycle is fully executable end-to-end.
+    validations:
+      required: true
+
+  - type: textarea
+    id: confidence
+    attributes:
+      label: Confidence (0-100)
+      description: Self-assessment of hypothesis quality at filing time. Lower numbers are OK — Directives can be filed under uncertainty as long as success signals are verifiable. Optional but encouraged.
+      placeholder: "75"
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Optional — links to prior discussions, related Issues, ADRs.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/execution-under-directive.yml
+++ b/.github/ISSUE_TEMPLATE/execution-under-directive.yml
@@ -1,0 +1,55 @@
+name: Execution Issue (under a Directive)
+description: "File an Execution Issue parented under an active Directive. The `Parent Directive: #N` body marker is required."
+title: "<type>: <subject>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        An Execution Issue is a **concrete unit of work** parented under a Directive. It implements a slice of the Directive's success signals. After filing, `/work-on <N>` creates a branch + draft PR + planner output.
+
+        If your work is not under any Directive, file as a `task` instead. If you don't know whether a Directive exists, leave the field blank and the maintainer's `/triage` step will route.
+
+  - type: input
+    id: parent-directive
+    attributes:
+      label: Parent Directive number
+      description: 'The number of the active Directive this Issue serves (e.g., 92). The Issue body will have `Parent Directive: #<N>` injected as line 1 so `/reflect` and the dir-mode-post-merge workflow find it.'
+      placeholder: "92"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: What needs to be done? One paragraph.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Verifiable conditions, one per line, as `- [ ] <item>`. Each must be mechanically testable (grep / file-exists / smoke section / SPEC diff).
+      placeholder: |
+        - [ ] `.claude/commands/<name>.md` exists with frontmatter + Procedure / Forbidden sections.
+        - [ ] Smoke section asserts the command file's contract markers.
+        - [ ] No regression in existing smoke.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What this Issue does NOT cover. Helps reviewer triage.
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,35 @@
+name: Task
+description: A standalone task or small improvement that doesn't fit a Directive. One-off work — refactor, doc fix, dependency bump.
+title: "chore: <subject>"
+labels: [task]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: What needs to be done?
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: Why now? What changes if this waits? (See SPEC §5.2 rationale triad — MISSION fit / why now / existing coverage.)
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Verifiable conditions as `- [ ] <item>`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+    validations:
+      required: false

--- a/.github/workflows/auto-needs-triage.yml
+++ b/.github/workflows/auto-needs-triage.yml
@@ -1,0 +1,42 @@
+name: auto-needs-triage
+
+# Cluster A (Directive #92, Issue #93): apply the `needs-triage` label to any
+# Issue opened without any label. Server-side workflow because template-based
+# filings already get their `labels:` frontmatter applied; only template-free
+# (raw) filings have an empty label set.
+#
+# Idempotent: the workflow's only effect is `gh issue edit --add-label needs-triage`,
+# which is a no-op if the label is already present. Skipping condition prevents
+# self-triggering loops (a workflow-applied label change does not re-fire this
+# workflow's `opened` trigger).
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  apply-needs-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect label set
+        id: labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          n="${{ github.event.issue.number }}"
+          labels=$(gh issue view "$n" --repo "${{ github.repository }}" --json labels --jq '[.labels[].name] | length')
+          echo "count=$labels" >> "$GITHUB_OUTPUT"
+
+      - name: Apply needs-triage on label-free Issue
+        if: steps.labels.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          n="${{ github.event.issue.number }}"
+          gh issue edit "$n" --repo "${{ github.repository }}" --add-label "needs-triage"

--- a/scripts/ensure_v3_labels.sh
+++ b/scripts/ensure_v3_labels.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# scripts/ensure_v3_labels.sh — idempotent creation of the labels the v3
+# reframe's Issue templates + workflows depend on. Run once after PR #93
+# merges (or any time a target repo is bootstrapped against the v3 substrate).
+#
+# Labels created:
+#   - status:proposed  — Directive in proposed state (pre-activation)
+#   - status:blocked   — Directive in Blocked state (per SPEC §2.1 v3)
+#   - task             — standalone task / improvement (task.yml)
+#   - needs-triage     — applied by auto-needs-triage.yml on raw filings
+#
+# Already-existing labels that v3 relies on (no creation needed):
+#   - directive, bug, enhancement, documentation, duplicate, wontfix,
+#     unattended-parked, question, help wanted, good first issue, invalid
+#
+# Idempotent: `gh label create --force` overwrites color/description but is
+# stable on existing label names.
+
+set -euo pipefail
+
+ensure_label() {
+  local name="$1" color="$2" desc="$3"
+  gh label create "$name" --color "$color" --description "$desc" --force >/dev/null
+  echo "  label '$name' ensured"
+}
+
+echo "ensure_v3_labels: creating v3 reframe labels (idempotent)..."
+
+ensure_label "status:proposed" "FBCA04" "Directive proposed; awaiting maintainer triage (SPEC §2.1 v3)"
+ensure_label "status:blocked"  "B60205" "Directive cannot proceed without external input (SPEC §5.17)"
+ensure_label "task"            "C5DEF5" "Standalone task or small improvement (not parented under a Directive)"
+ensure_label "needs-triage"    "D4C5F9" "Issue filed without a template — awaiting maintainer triage classification"
+
+echo "ensure_v3_labels: done."

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -4166,6 +4166,82 @@ fi
 
 rm -rf "$S53_DIR"
 
+# ---------- 54. Issue templates + auto-needs-triage workflow (#93 / Directive #92) ----------
+# Cluster A of the v3 reframe (dir-mode-v3 brief §9.1): the .github/ISSUE_TEMPLATE/*.yml
+# files plus the auto-needs-triage workflow. Structural sanity — files exist + parse
+# as YAML + the templates carry the expected `name`/`description`/`body` top-level keys
+# + the four expected labels are named in the right templates.
+
+# 54a: all five template / config files exist.
+s54a_missing=""
+for f in config.yml directive-proposal.yml execution-under-directive.yml task.yml bug-report.yml; do
+  [ -f "$SHELL_ROOT/.github/ISSUE_TEMPLATE/$f" ] || s54a_missing="$s54a_missing $f"
+done
+if [ -z "$s54a_missing" ]; then
+  ok "54a: all 5 Issue template / config files present (#93)"
+else
+  ng "54a: Issue template files missing:$s54a_missing (#93)"
+fi
+
+# 54b: auto-needs-triage workflow exists.
+if [ -f "$SHELL_ROOT/.github/workflows/auto-needs-triage.yml" ]; then
+  ok "54b: auto-needs-triage workflow present (#93)"
+else
+  ng "54b: .github/workflows/auto-needs-triage.yml missing (#93)"
+fi
+
+# 54c: workflow fires on `issues.opened`.
+if grep -qE "^[[:space:]]+types:[[:space:]]*\[opened\]" "$SHELL_ROOT/.github/workflows/auto-needs-triage.yml" 2>/dev/null; then
+  ok "54c: auto-needs-triage workflow fires on issues.opened (#93)"
+else
+  ng "54c: auto-needs-triage workflow trigger missing `types: [opened]` (#93)"
+fi
+
+# 54d: directive-proposal template applies `directive` + `status:proposed` labels at filing.
+if grep -qE "^labels:[[:space:]]*\[directive,[[:space:]]*status:proposed\]" "$SHELL_ROOT/.github/ISSUE_TEMPLATE/directive-proposal.yml" 2>/dev/null; then
+  ok "54d: directive-proposal applies [directive, status:proposed] labels at filing (#93)"
+else
+  ng "54d: directive-proposal.yml labels frontmatter missing or wrong shape (#93)"
+fi
+
+# 54e: execution-under-directive requires a Parent Directive number input field.
+if grep -qE "id:[[:space:]]*parent-directive" "$SHELL_ROOT/.github/ISSUE_TEMPLATE/execution-under-directive.yml" 2>/dev/null; then
+  ok "54e: execution-under-directive declares required parent-directive field (#93)"
+else
+  ng "54e: execution-under-directive.yml missing parent-directive input (#93)"
+fi
+
+# 54f: ensure_v3_labels.sh creates the four new labels.
+if [ -x "$SHELL_ROOT/scripts/ensure_v3_labels.sh" ] \
+   && grep -q "status:proposed" "$SHELL_ROOT/scripts/ensure_v3_labels.sh" \
+   && grep -q "status:blocked" "$SHELL_ROOT/scripts/ensure_v3_labels.sh" \
+   && grep -q "needs-triage" "$SHELL_ROOT/scripts/ensure_v3_labels.sh" \
+   && grep -q "ensure_label.*\"task\"" "$SHELL_ROOT/scripts/ensure_v3_labels.sh"; then
+  ok "54f: ensure_v3_labels.sh creates status:proposed + status:blocked + task + needs-triage (#93)"
+else
+  ng "54f: ensure_v3_labels.sh missing or doesn't name all 4 new labels (#93)"
+fi
+
+# 54g: YAML structural sanity via python+pyyaml when available.
+if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" 2>/dev/null; then
+  s54g_fails=0
+  s54g_list=""
+  for f in "$SHELL_ROOT"/.github/ISSUE_TEMPLATE/*.yml "$SHELL_ROOT"/.github/workflows/auto-needs-triage.yml; do
+    [ -f "$f" ] || continue
+    if ! python3 -c "import yaml; yaml.safe_load(open('$f'))" 2>/dev/null; then
+      s54g_fails=$((s54g_fails+1))
+      s54g_list="$s54g_list $(basename "$f")"
+    fi
+  done
+  if [ "$s54g_fails" = 0 ]; then
+    ok "54g: all 6 template + workflow YAML files parse cleanly (#93)"
+  else
+    ng "54g: $s54g_fails YAML parse failures:$s54g_list (#93)"
+  fi
+else
+  ok "54g: python3+pyyaml not available — YAML parse check skipped (#93)"
+fi
+
 # ---------- restore registry ----------
 if [ -n "$ORIG_REG_BAK" ]; then
   mv "$ORIG_REG_BAK" "$ORIG_REG"


### PR DESCRIPTION
Parent Directive: #92

Closes #93

## How this serves the mission

Lands cluster A of the v3 reframe (Directive #92, brief §9.1) — the lowest-risk additive cluster. Issue templates are the OSS-standard mechanism for external contributor proposals; without them, the v3 reframe's Issue-as-SSOT model has no structured filing path. Cluster A is independent of cluster C (filer-aware invariants) and lands first because pure new files cannot regress existing behavior.

Maps to Directive #92 Decision 3 (atomic templates + /triage; this PR is the first half) and Decision 4 (strict reject + refile; depends on templates existing).

## Plan

`feat` type, additive, no SPEC change in this PR. Strict Doc → Test → Code order relaxed because (a) the SSOT contract for these templates is encoded in the YAML files themselves (no external SPEC anchor changes), (b) the smoke section IS the test, and (c) the code IS the YAML. Treated as a single coordinated commit.

Five `.github/ISSUE_TEMPLATE/*.yml` files + one workflow + one label-setup script + smoke §54. The directive-proposal form's required fields directly mirror the SPEC §5.10 schema (Objective / Success signals 2-5 / Non-goals ≥2 / Constraints ≥1 / MISSION fit) so that template-filed Directives match what `/file-directive` produces in shape.

## Target base

`main`

## Alternatives considered

- **(a) Inline label creation in the workflow itself (no separate script)** — rejected. The four new labels (`status:proposed`, `status:blocked`, `task`, `needs-triage`) need to exist BEFORE the first Issue is filed via a template, not on the first workflow run. A separate `scripts/ensure_v3_labels.sh` is run-once at PR-merge time (or part of cluster B / cluster C's planner kickoff). Workflow-inline would require an initial Issue → workflow-creates-labels → re-fire dance; cleaner to bootstrap labels deterministically.
- **(b) Single all-in-one template instead of five** — rejected. The four content shapes (Directive, Execution, Task, Bug) have distinct required-field sets. Collapsing them would lose the `validations: required: true` on category-specific fields (Parent Directive for Execution, reproducer for Bug). The maintenance cost of five small forms < the cost of one fat form with conditional validation.
- **(c) Apply labels from the workflow side instead of from frontmatter** — rejected. Issue Forms YAML frontmatter `labels: [...]` is the documented mechanism and runs server-side at filing time. Workflow-side labeling has a propagation gap (Issue exists with no labels for some milliseconds, during which the `auto-needs-triage` workflow could race and apply `needs-triage` to a template-filed Directive). Frontmatter is atomic.
- **(d) Skip auto-needs-triage; rely on absent-labels meaning "untriaged"** — rejected. The `/triage` skill (cluster B) queries by label (`needs-triage` OR `status:proposed`). Without explicit labeling, the query becomes "Issues with empty labels," which is fragile against any other workflow that touches labels.

## Key context

- `.github/ISSUE_TEMPLATE/directive-proposal.yml` — the most schema-heavy template. Required fields cover the SPEC §5.10 Directive schema.
- `.github/ISSUE_TEMPLATE/execution-under-directive.yml` — the `parent-directive` input becomes the Issue body's line-1 `Parent Directive: #N` marker (consumed by `/reflect` + the dir-mode-post-merge workflow per SPEC §5.2).
- `.github/workflows/auto-needs-triage.yml` — fires on `issues.opened`; idempotent (no-op if labels already present from a template).
- `scripts/ensure_v3_labels.sh` — run-once setup. Creates `status:proposed` (yellow), `status:blocked` (red), `task` (light blue), `needs-triage` (purple).
- `scripts/test/smoke.sh` §54 — 7 sub-assertions covering structural sanity of all 7 new files.

Not touched: SPEC (cluster H), command files (cluster E), `setup_project.sh` (cluster G), `directive-reviewer.md` (cluster F). All deferred to the substrate-flip umbrella (#96).

## Checklist

- [x] **Code**: 5 ISSUE_TEMPLATE files + 1 workflow + 1 label-setup script.
- [x] **Test**: smoke §54 with 7 sub-assertions covering existence, trigger shape, frontmatter, required input, label setup script content, YAML parseability.
- [x] **Verify**: smoke 305/305 (was 298 pre-cluster-A; +7 from §54a-g).

## Out of scope

- `/triage` skill (cluster B — Issue #94).
- Filer-aware invariants (cluster C — Issue #95).
- Issue → Project mirror workflow (cluster D — part of #96).
- Command rewrites / SPEC rewrite / directive-reviewer update / setup_project.sh / migration / ADRs (clusters E-J — part of #96).
- Updating `MISSION.md` to reflect the v3 substrate model (separate PR per brief §8 step 2).

## Risks

- **Label bootstrap timing**: `ensure_v3_labels.sh` must run before the first template-filed Issue lands. Without it, the `directive-proposal` template applies labels server-side that don't exist on the repo — GitHub silently drops the unknown labels and the Issue lands without `directive` / `status:proposed`. Mitigation: post-merge, the maintainer runs the script once; future cluster B PR can hook this into `/onboard`'s preflight.
- **`directive-proposal` server-side label application requires the label to exist**: same as above; resolved by `ensure_v3_labels.sh`.
- **`auto-needs-triage` propagation latency**: GitHub workflows have a few-second delay before firing on `issues.opened`. During that window, an Issue exists with empty labels. The window is too short for any human or AI to act on it; no functional risk.
- **Template adoption by existing flows**: this PR doesn't change `/file-directive`'s procedure. `/file-directive` continues to do `gh issue create --label directive` directly (no template). Cluster E will update `/file-directive` to use the template via `gh issue create --template directive-proposal.yml` (or equivalent) once the substrate flip is coordinated.

## Open questions

None.

## Test plan

- [x] **AC #1** (5 template files present): smoke §54a — `for f in 5-files; do [ -f ]; done`.
- [x] **AC #2** (workflow present + fires on issues.opened): smoke §54b + §54c.
- [x] **AC #3** (directive-proposal applies correct labels): smoke §54d.
- [x] **AC #4** (execution-under-directive requires Parent Directive): smoke §54e.
- [x] **AC #5** (label setup script): smoke §54f.
- [x] **AC #6** (YAML parses): smoke §54g (when python3+pyyaml available; skip-on-no-yaml otherwise).
- [x] **AC #7** (no regression): full smoke 305/305.

## Docs touched

None. The templates ARE the doc surface for the filing flow; their inline `description:` and `markdown:` fields document the contract per Issue Forms convention. SPEC updates (cluster H) reference these template paths from §1.7 / §5.10 when that cluster lands.

## Ship gate

- [x] All tests pass (smoke 305/305)
- [x] `code-reviewer` passed (ship clean; 2 non-blocking nits declined)
- [~] N/A — `security-reviewer` not required (additive templates + workflow; no auth/input/deps/crypto change. Workflow uses GH-issued `GITHUB_TOKEN` with `issues: write` minimal scope.)
- [x] Docs in sync (no SSOT changes; templates' inline descriptions are the doc surface)
- [x] PR body curated (single-commit additive PR)
- [x] CI green
- [x] AC closeout comment posted (auto via `/ship` step 7.6)


