### PR TITLE
docs(#96): cluster J2 — superseded headers on ADR-0001/0002

### DIFF
--- a/docs/ADRs/0001-v0-director-mode-decisions.md
+++ b/docs/ADRs/0001-v0-director-mode-decisions.md
@@ -1,8 +1,10 @@
 # ADR 0001: v0 director-mode core decisions
 
 - Date: 2026-05-24
-- Status: Accepted
+- Status: Accepted (Partially Superseded — see header note)
 - Context PR: #42 (tracker: #41)
+
+> **Header note (2026-05-26 / Directive #92 cluster J2)**: the Goal-as-substrate-item portion of this ADR is **superseded by [ADR-0003](0003-issues-ssot-substrate.md)** (dir-mode v3 reframe). Specifically: (1) the "GitHub Projects v2 as substrate" decision is narrowed — Project v2 is now a *derived-view* substrate (mirrored from Issues), not the SSOT; (2) the "Goal / Directive / Execution as Project Item types" decision is partially superseded — `Goal` is eliminated as an artifact (MISSION.md is the canonical direction); `Directive` and `Execution` move to Issues-as-SSOT with the Project as a one-direction-mirrored view. All other decisions in this ADR (the work-order, the audit-log shape, the subagent framework, the attended/unattended mode axis) are retained.
 
 ## Context
 

--- a/docs/ADRs/0002-directive-project-field-schema.md
+++ b/docs/ADRs/0002-directive-project-field-schema.md
@@ -1,8 +1,10 @@
 # ADR 0002: Directive / Project v2 field schema
 
 - Date: 2026-05-24
-- Status: Accepted
+- Status: Accepted (Superseded — see header note)
 - Context PR: #48 (tracker: #41 child #2 / issue #43)
+
+> **Header note (2026-05-26 / Directive #92 cluster J2)**: this ADR is **substantively superseded by [ADR-0003](0003-issues-ssot-substrate.md)** (dir-mode v3 reframe — Issues-as-SSOT substrate). The Project v2 field schema documented here remains the *derived-view* schema (the mirror workflow's target field set), but it is no longer the authoritative SSOT for dir-mode state. Specific changes per ADR-0003: (1) `Type` field loses the `Goal` option (Goal artifact eliminated; MISSION.md is canonical); (2) `Status` field's option set narrows from 5 (`Planned / Active / Completed / Blocked / Revised`) to 4 (`Proposed / Active / Blocked / Completed`) — `Revised` is dropped; `Planned` is renamed to `Proposed` to align with the OSS-standard "filed but not yet triaged" semantic; (3) `Confidence` and `Success Signals` Project fields are removed (content moves to Issue body sections); (4) `Iteration` stays user-managed on Project per ADR-0003 Decision 5; (5) `Parent` stays as TEXT, mirrored from the Issue body's `Parent Directive: #N` line-1 marker. The two-layer idempotency contract (field existence + SINGLE_SELECT option-set correctness, from issue #76) carries forward to the v3 schema. `scripts/setup_project.sh` is updated in cluster G to declare the v3 field schema; the mirror workflow (cluster D, `.github/workflows/issues-to-project-mirror.yml`) is the runtime data path that populates fields from Issue state. This ADR is preserved as the historical lock document for v0 substrate; future per-field decisions reference ADR-0003.
 
 ## Context
 


### PR DESCRIPTION
Refs #92
Refs #96

## How this serves the mission

Cluster J2 of dir-mode v3 reframe (Directive #92). Completes the ADR pair-lock with cluster J1 (PR #101, merged) — predecessor ADRs now carry visible header notes that their decisions are superseded. Future readers of ADR-0001 / ADR-0002 see the supersession before reading the v0 contents.

## Plan

Docs-only PR; two file-edits.

## Target base

`main`

## Alternatives considered

- (a) Move the superseded ADRs into an `archive/` subdirectory — rejected. ADRs are preserved in-place by convention; moving them would break in-line cross-references from SPEC and other docs.
- (b) Strike-through the ADR contents entirely — rejected. The historical content is valuable; the header note suffices to signal supersession.

## Key context

- `docs/ADRs/0001-v0-director-mode-decisions.md` — partial-supersession header (Goal + Projects v2 SSOT portions).
- `docs/ADRs/0002-directive-project-field-schema.md` — substantive-supersession header naming the specific schema changes in ADR-0003.

## Checklist

- [x] **Doc**: ADR-0001 header note added.
- [x] **Doc**: ADR-0002 header note added.
- [x] **Doc**: both Status lines updated to "(Partially/Superseded — see header note)".
- [x] **Verify**: smoke 329/329 (no code change).

## Out of scope

- Modifying ADR-0001 / ADR-0002 body content — explicitly retained as historical record.
- Cluster H (SPEC rewrite) — separate.
- Cluster I (migration) — separate.

## Risks

None material. Pure annotation.

## Docs touched

- `docs/ADRs/0001-v0-director-mode-decisions.md` (header)
- `docs/ADRs/0002-directive-project-field-schema.md` (header)

## Ship gate

- [x] All tests pass (smoke 329/329)
- [x] `code-reviewer` passed (annotation-only docs PR)
- [~] N/A — `security-reviewer` not required (docs-only)
- [x] Docs in sync (this PR IS the doc edit)
- [x] PR body curated (single-commit)
- [x] CI green
- [~] N/A — AC closeout comment posted (no closingIssuesReferences — Refs only)