### PR TITLE
feat(#96): cluster I — v3 migration script + MISSION.md (LAST per brief §13)

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -1,0 +1,49 @@
+# MISSION — claude-eng-shell
+
+> Canonical long-term direction for claude-eng-shell.
+> Per dir-mode v3 reframe ([ADR-0003](docs/ADRs/0003-issues-ssot-substrate.md) Decision 6), this document supersedes the v0/v1 Goal-as-Item artifact. Every Directive's `## MISSION fit` field references a section of this file.
+
+## What this exists for
+
+claude-eng-shell is the engineering scaffold a single Claude Code agent (or human + Claude pair) lives inside to do work on a GitHub-standard repository. It captures the procedural discipline of senior engineering — issue → branch → draft PR → reviewed commits → ready merge — and renders it as hooks, slash commands, subagents, and audit trails that an AI agent cannot drift past without leaving evidence.
+
+## Success looks like
+
+Twelve months out, the shell's success is best summarized as **a Claude Code session running in `unattended` mode against a real engineering issue produces a merged PR whose quality matches what a careful senior engineer would have produced in the same hours.** That requires:
+
+- **The flow holds in unattended runs.** Clean execution end-to-end (issue → branch → Doc → Test → Code → /ship → merge) is the dominant path, not the exception. Hard blockers (incompatible plan, secret detected, AC unticked) surface as audit-logged `parked` states rather than silent regressions.
+- **The directing layer works.** A team that picks up claude-eng-shell uses the dir-mode hierarchy (Goal → Directive → Execution Issue) to plan two or three weeks of work, ship it under reviewer gates, and reach the Directive's success signals without revising the shell. This Goal Item is the first concrete example.
+- **Multiple repos run on it.** At least two unrelated upstream repos — beyond claude-eng-shell itself — adopt the shell as their canonical Claude Code workflow. Each contributes friction back into the SPEC.
+- **The escape hatch stays narrow.** Audit-log queries (`/audit`) show that bypasses (`SKIP_HOOKS=...`) cluster in the small set of legitimate cases the SPEC names — not as a normalized routing around inconvenient gates.
+- **The v1+ orchestrator lands.** Automatic mode-switching between eng-mode and dir-mode, kill-switches, and budget controls (SPEC §0.4) ship after v0 operating experience surfaces the right design for them.
+
+## Who this is for
+
+The primary user is **a person running Claude Code on a GitHub-standard repository who wants the AI to operate at engineering discipline they themselves would apply.** That person might be:
+
+- A solo engineer using Claude Code to extend a project they own.
+- An engineer at a small team standardizing Claude Code workflows so the AI's output is reviewable on the same axes as a human teammate's PRs.
+- An engineer running Claude Code overnight (`unattended` mode) against well-scoped issues, expecting wake-up to find quality-controlled merged PRs or audit-logged blockers — not silent half-finished work.
+
+Secondary users include teams adopting AI-assisted engineering more broadly, who can fork the shell, replace the subagent definitions, and keep the rest of the GitHub-standard scaffolding intact.
+
+## Explicitly NOT goals
+
+- **Not a general dotfiles or shell-customization framework.** The shell is scoped to GitHub-standard engineering workflows. Personal shell preferences, prompt customization, and UI theming are out of scope.
+- **Not a replacement for engineering judgment.** Every hook has an escape; every reviewer subagent surfaces verdicts humans can override; the directing layer never autonomously decides direction (SPEC §1.7). The shell exists to *catch mistakes* and *enforce discipline*, not to be smart on its own.
+- **Not an AI orchestrator for arbitrary tasks.** It's specifically a *Claude Code on GitHub* shell. Multi-agent orchestrators, general AI workflow managers, custom RAG systems are different products.
+- **Not the target repo's MISSION or SPEC.** The shell never owns the *what* and *why* of the user's project — that lives in the target repo's `MISSION.md` / `SPEC.md`. The shell owns the *how*.
+- **Not a drop-in for non-GitHub workflows.** GitLab, Forgejo, Bitbucket, and bare-git workflows are out of scope. The shell's hooks reference `gh` everywhere; porting belongs to a fork or a future Directive far beyond v0.
+
+## Stakeholders
+
+- **Author**: ilgyu-yi (primary engineer + dogfooder).
+- **Future users**: any engineer adopting claude-eng-shell as their Claude Code workflow.
+- **AI agents**: the shell is the operating environment Claude Code reads from; the SPEC is the contract Claude Code is held to.
+
+## Last reviewed: 2026-05-25
+
+
+---
+
+*Last reviewed: 2026-05-26. Updated by Directive #92 cluster I migration (transcribed from PVTI #84, the v0/v1 Goal Item that this MISSION.md supersedes).*

--- a/scripts/migrate_v3.sh
+++ b/scripts/migrate_v3.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# scripts/migrate_v3.sh — one-time migration from v0/v1 (Projects-as-SSOT)
+# to v3 (Issues-as-SSOT) per ADR-0003 / Directive #92 cluster I.
+#
+# Procedure (brief §8 step 1-5):
+#   Step 1. Snapshot every Item in the dir-mode Project to a timestamped
+#           directory under .claude/state/v2-snapshot/<ISO>/. One JSON file
+#           per Item, plus a manifest. Read-only history.
+#   Step 2. Verify MISSION.md exists and contains the canonical content
+#           (already populated by the Cluster I PR — this script does NOT
+#           write MISSION.md; that's an explicit human-curated step).
+#   Step 3. Delete each Item from the Project via `gh project item-delete`.
+#           Idempotent: items already deleted are skipped.
+#   Step 4. Reconcile field schema by re-running setup_project.sh which
+#           drops the Goal Type option, drops Confidence + Success Signals
+#           fields, and updates Status options to the v3 4-state set.
+#   Step 5. The mirror workflow re-creates Items on the next Issue event;
+#           no manual backfill.
+#
+# Refuses on:
+#   - cwd not in $CLAUDE_ENG_SHELL_ROOT/.claude/state/registry.txt
+#   - missing MISSION.md (must be populated before running)
+#   - --confirm flag absent (destructive operation — explicit opt-in)
+#
+# Idempotent on snapshot: re-running with the same date does nothing if
+# the snapshot dir is already populated AND all Items already deleted.
+
+set -euo pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+: "${CLAUDE_ENG_SHELL_ROOT:=$SCRIPT_ROOT}"
+export CLAUDE_ENG_SHELL_ROOT
+
+if [ -f "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/hookrt.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/hookrt.sh"
+else
+  audit_log() { :; }
+fi
+
+# shellcheck disable=SC2034  # consumed by sourced dir_mode_project_resolve.sh
+DR_SCRIPT_NAME=migrate_v3
+# shellcheck disable=SC2034  # consumed by sourced dir_mode_project_resolve.sh
+DR_AUDIT_CATEGORY=project-setup
+# shellcheck source=/dev/null
+. "$CLAUDE_ENG_SHELL_ROOT/scripts/lib/dir_mode_project_resolve.sh"
+
+dr_check_registry_guard || exit 1
+dr_check_gh_auth || exit 1
+dr_check_gh_scope || exit 1
+dr_check_jq || exit 1
+dr_resolve_owner_repo || exit 1
+dr_find_project || exit 1
+
+owner="$DR_OWNER"
+project_num="$DR_PROJECT_NUM"
+
+# --confirm gate — destructive.
+if [ "${1:-}" != "--confirm" ]; then
+  echo "migrate_v3: DESTRUCTIVE one-shot — re-run with --confirm to proceed."
+  echo ""
+  echo "  Project: #${project_num} (${owner}/$DR_REPO_NAME, name=\"$DR_PROJECT_NAME\")"
+  echo "  Action:  snapshot all Items + delete each from Project"
+  echo "  Target:  $CLAUDE_ENG_SHELL_ROOT/.claude/state/v2-snapshot/<ISO>/"
+  echo ""
+  echo "After this script: setup_project.sh reconciles the field schema to v3"
+  echo "  (drops Goal/Confidence/Success Signals; Status → 4-state set per ADR-0003)."
+  echo "  Mirror workflow re-creates Items from Issues on the next Issue event."
+  exit 2
+fi
+
+# MISSION.md presence check (brief §8 step 2).
+if [ ! -f "$CLAUDE_ENG_SHELL_ROOT/MISSION.md" ]; then
+  echo "migrate_v3: MISSION.md missing — populate before running migration." >&2
+  echo "  PVTI #84's body should be transcribed into MISSION.md per ADR-0003 Decision 6." >&2
+  audit_log block "$DR_AUDIT_CATEGORY" deny "migrate_v3: MISSION.md missing — refused"
+  exit 1
+fi
+
+# Step 1: snapshot
+ts=$(date -u +%Y%m%dT%H%M%SZ)
+snap_dir="$CLAUDE_ENG_SHELL_ROOT/.claude/state/v2-snapshot/$ts"
+mkdir -p "$snap_dir"
+echo "migrate_v3: snapshot directory $snap_dir"
+
+# Fetch all Items as JSON. Use --limit 200 to capture all (we have <20 today).
+items_json=$(gh project item-list "$project_num" --owner "$owner" --format json --limit 200 2>/dev/null)
+total=$(printf '%s' "$items_json" | jq -r '.items | length')
+echo "migrate_v3: $total items found in Project #${project_num}"
+
+# Write manifest + per-item JSON files.
+printf '%s\n' "$items_json" | jq '.' > "$snap_dir/manifest.json"
+
+item_ids=$(printf '%s' "$items_json" | jq -r '.items[].id')
+saved=0
+for item_id in $item_ids; do
+  printf '%s\n' "$items_json" \
+    | jq --arg id "$item_id" '.items[] | select(.id==$id)' \
+    > "$snap_dir/item__${item_id}.json"
+  saved=$((saved+1))
+done
+echo "migrate_v3: snapshotted $saved items to $snap_dir"
+
+# Step 3: delete each item.
+# We use --owner because user-owned Project Items can be deleted with that scope.
+deleted=0
+skipped=0
+for item_id in $item_ids; do
+  if gh project item-delete --id "$item_id" 2>/dev/null; then
+    deleted=$((deleted+1))
+  else
+    # Idempotent: item already deleted, or transient error.
+    skipped=$((skipped+1))
+  fi
+done
+echo "migrate_v3: deleted=$deleted skipped=$skipped"
+
+audit_log info "$DR_AUDIT_CATEGORY" migrated "v3-migration: project=#${project_num} snapshot=$snap_dir items_total=$total deleted=$deleted skipped=$skipped"
+
+# Step 4: reconcile field schema to v3 by re-running setup_project.sh.
+echo "migrate_v3: re-running setup_project.sh to reconcile field schema..."
+bash "$CLAUDE_ENG_SHELL_ROOT/scripts/setup_project.sh" || {
+  echo "migrate_v3: setup_project.sh failed — fields may need manual reconciliation" >&2
+  audit_log warn "$DR_AUDIT_CATEGORY" notice "v3-migration: setup_project.sh failed post-snapshot+delete"
+  exit 1
+}
+
+echo ""
+echo "migrate_v3: done. Project #${project_num} is now v3-schema-aligned."
+echo ""
+echo "Next steps:"
+echo "  1. Re-fire mirror workflow by editing one Directive Issue (or wait for next event)."
+echo "  2. Verify: \`gh project item-list ${project_num} --owner ${owner}\` returns mirror-created Items."
+echo "  3. Project #84 (the Goal Item) is gone — MISSION.md is the canonical direction now."

--- a/scripts/migrate_v3.sh
+++ b/scripts/migrate_v3.sh
@@ -38,6 +38,22 @@ else
   audit_log() { :; }
 fi
 
+# --confirm gate FIRST — destructive operation; explicit opt-in must
+# precede infrastructure checks so the gate is visible even when run on
+# a fresh runner (no registry entry, no gh auth). Subsequent guards
+# protect actual execution.
+if [ "${1:-}" != "--confirm" ]; then
+  echo "migrate_v3: DESTRUCTIVE one-shot — re-run with --confirm to proceed."
+  echo ""
+  echo "  Action: snapshot all Items in the dir-mode Project + delete each"
+  echo "  Target: \$CLAUDE_ENG_SHELL_ROOT/.claude/state/v2-snapshot/<ISO>/"
+  echo ""
+  echo "After this script: setup_project.sh reconciles the field schema to v3"
+  echo "  (drops Goal/Confidence/Success Signals; Status → 4-state set per ADR-0003)."
+  echo "  Mirror workflow re-creates Items from Issues on the next Issue event."
+  exit 2
+fi
+
 # shellcheck disable=SC2034  # consumed by sourced dir_mode_project_resolve.sh
 DR_SCRIPT_NAME=migrate_v3
 # shellcheck disable=SC2034  # consumed by sourced dir_mode_project_resolve.sh
@@ -54,20 +70,6 @@ dr_find_project || exit 1
 
 owner="$DR_OWNER"
 project_num="$DR_PROJECT_NUM"
-
-# --confirm gate — destructive.
-if [ "${1:-}" != "--confirm" ]; then
-  echo "migrate_v3: DESTRUCTIVE one-shot — re-run with --confirm to proceed."
-  echo ""
-  echo "  Project: #${project_num} (${owner}/$DR_REPO_NAME, name=\"$DR_PROJECT_NAME\")"
-  echo "  Action:  snapshot all Items + delete each from Project"
-  echo "  Target:  $CLAUDE_ENG_SHELL_ROOT/.claude/state/v2-snapshot/<ISO>/"
-  echo ""
-  echo "After this script: setup_project.sh reconciles the field schema to v3"
-  echo "  (drops Goal/Confidence/Success Signals; Status → 4-state set per ADR-0003)."
-  echo "  Mirror workflow re-creates Items from Issues on the next Issue event."
-  exit 2
-fi
 
 # MISSION.md presence check (brief §8 step 2).
 if [ ! -f "$CLAUDE_ENG_SHELL_ROOT/MISSION.md" ]; then

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -4609,6 +4609,46 @@ else
   ng "58f: SPEC §1.7 missing v3 substrate naming (#96/cluster H)"
 fi
 
+# ---------- 59. v3 migration script + MISSION.md (#96 / cluster I) ----------
+# Cluster I (brief §8) — one-shot snapshot + delete migration. Structural
+# sanity: script exists with --confirm gate, MISSION.md populated.
+
+# 59a: migrate_v3.sh exists, is executable, refuses without --confirm.
+MIG_SH="$SHELL_ROOT/scripts/migrate_v3.sh"
+if [ -x "$MIG_SH" ]; then
+  s59a_out=$(bash "$MIG_SH" 2>&1 || true)
+  if printf '%s' "$s59a_out" | grep -qE 'DESTRUCTIVE'; then
+    ok "59a: migrate_v3.sh requires --confirm + warns DESTRUCTIVE (#96/cluster I)"
+  else
+    ng "59a: migrate_v3.sh missing DESTRUCTIVE warning on no-confirm invocation (#96/cluster I)"
+  fi
+else
+  ng "59a: scripts/migrate_v3.sh missing or not executable (#96/cluster I)"
+fi
+
+# 59b: MISSION.md exists with the 5 canonical sections.
+MISSION="$SHELL_ROOT/MISSION.md"
+if [ -f "$MISSION" ]; then
+  s59b_missing=""
+  for section in "## What this exists for" "## Success looks like" "## Who this is for" "## Explicitly NOT goals" "## Stakeholders"; do
+    grep -qF "$section" "$MISSION" 2>/dev/null || s59b_missing="$s59b_missing $section"
+  done
+  if [ -z "$s59b_missing" ]; then
+    ok "59b: MISSION.md has all 5 canonical sections (#96/cluster I)"
+  else
+    ng "59b: MISSION.md missing sections:$s59b_missing (#96/cluster I)"
+  fi
+else
+  ng "59b: MISSION.md missing (#96/cluster I)"
+fi
+
+# 59c: MISSION.md references ADR-0003 (supersession context).
+if grep -qE 'ADR-0003' "$MISSION" 2>/dev/null; then
+  ok "59c: MISSION.md cross-references ADR-0003 (#96/cluster I)"
+else
+  ng "59c: MISSION.md missing ADR-0003 cross-reference (#96/cluster I)"
+fi
+
 # ---------- restore registry ----------
 if [ -n "$ORIG_REG_BAK" ]; then
   mv "$ORIG_REG_BAK" "$ORIG_REG"


### PR DESCRIPTION
Refs #92
Refs #96

## How this serves the mission

Final cluster of dir-mode v3 reframe (Directive #92). Lands the one-shot migration tooling + canonical MISSION.md content. The migration **script** is non-destructive (just lands files); the migration **execution** (running the script with --confirm) is destructive and happens after merge.

## Plan

Two new files:
- `MISSION.md` — transcribed from PVTI #84's 5-section body; canonical direction per ADR-0003 Decision 6
- `scripts/migrate_v3.sh` — snapshot + delete one-shot; --confirm-gated

Smoke §59 (3 assertions) covers structural sanity. Smoke 338/338.

## Target base

`main`

## Out of scope

- Actually running migrate_v3.sh — happens after PR merges (separate, audit-logged step).
- Completing Directive #92 — happens after migration succeeds.

## Risks

- **migrate_v3.sh is destructive**: explicit --confirm gate. The PR landing the script is reversible (revert removes the script + MISSION.md); running the script after merge is the destructive cutover.
- **MISSION.md content is verbatim from PVTI #84**: if PVTI #84's body had errors, they propagate to MISSION.md. Mitigation: PVTI #84 was reviewer-vetted at filing time (Directive #84 via PR #86).

## Ship gate

- [x] All tests pass (smoke 338/338)
- [x] `code-reviewer` passed (script + MISSION transcription)
- [~] N/A — `security-reviewer` not required (script is destructive but scoped to Project Items + setup_project.sh; no auth/input/deps/crypto surface)
- [x] Docs in sync (MISSION.md is the doc; ADR-0003 cross-references it)
- [x] PR body curated
- [x] CI green
- [~] N/A — no Closes (Refs only)