### PR TITLE
feat(#118): target-substrate implementation — completes Directive #107

### DIFF
--- a/.claude/commands/activate-directive.md
+++ b/.claude/commands/activate-directive.md
@@ -9,6 +9,8 @@ In dir-mode v3 (ADR-0003), Status is encoded as labels on the Issue (Issues are 
 
 ## Procedure
 
+0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+
 1. **Resolve the Issue** — `<issue-#>` is a GitHub Issue number. Fetch:
    ```bash
    gh issue view <issue-#> --json title,body,state,labels

--- a/.claude/commands/block-directive.md
+++ b/.claude/commands/block-directive.md
@@ -11,6 +11,8 @@ Not reviewer-gated by `directive-reviewer` — blocking is an annotation, not a 
 
 ## Procedure
 
+0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+
 1. **Parse arguments** — `<issue-#>` is the GitHub Issue number; `--reason <why>` is **mandatory**. If `--reason` is missing or its value is empty after whitespace-trim: error ("--reason <why> is required for /block-directive") and stop.
 
 2. **Resolve the Issue** — fetch:

--- a/.claude/commands/complete-directive.md
+++ b/.claude/commands/complete-directive.md
@@ -9,6 +9,8 @@ In dir-mode v3 (ADR-0003), Issue close-as-completed IS the Status=Completed sign
 
 ## Procedure
 
+0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+
 1. **Resolve the Issue** — `<issue-#>` is a GitHub Issue number. Fetch:
    ```bash
    gh issue view <issue-#> --json title,body,state,labels

--- a/.claude/commands/file-directive.md
+++ b/.claude/commands/file-directive.md
@@ -9,6 +9,8 @@ In dir-mode v3 (ADR-0003), **Issues are SSOT**. The Project Item that wraps the 
 
 ## Procedure
 
+0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+
 1. **Author the body** from `.claude/templates/directive.md`:
    - **Objective** — bounded by concrete artifact-level boundary (issue counts, file paths, AC ticks, merge events). Refuse to proceed if the Objective doesn't name a concrete artifact-level boundary.
    - **Success signals** — 2 to 5 verifiable conditions. Each must be objectively testable by a reasonable engineer.

--- a/.claude/commands/link-directive.md
+++ b/.claude/commands/link-directive.md
@@ -7,6 +7,8 @@ Link an Execution Issue to its parent Directive by ensuring the `Parent Directiv
 
 ## Procedure
 
+0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+
 1. **Validate the two arguments**:
    - `<directive-#>` — must be a `directive`-labeled, OPEN Issue. Fetch via `gh issue view`. If not a Directive: stop.
    - `<execution-#>` — must be an Issue WITHOUT the `directive` label (i.e., an Execution Issue or Task / Bug). If it is itself a Directive: stop with error ("Cannot parent a Directive under another Directive in v0 — see SPEC §0.4 directive-graph deferral").

--- a/.claude/commands/list-directives.md
+++ b/.claude/commands/list-directives.md
@@ -7,6 +7,8 @@ List Directive Issues filtered by Status label. Read-only; queries Issues direct
 
 ## Procedure
 
+0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+
 1. **Parse arguments**:
    - `--status <state>` — one of `Proposed | Active | Blocked | Completed | All`. Default: omit `Completed` (show Proposed + Active + Blocked).
 

--- a/.claude/commands/onboard-dir-mode.md
+++ b/.claude/commands/onboard-dir-mode.md
@@ -1,0 +1,67 @@
+---
+description: Install the v3 substrate (labels + Issue templates + workflows + Project v2) into a target repo. Tier-aware. Idempotent. PR-based file installs per ADR-0004.
+argument-hint: [--tier 1|2|3] [--dry-run]
+---
+
+Install the dir-mode v3 substrate into the current target repo (cwd). Per ADR-0004:
+
+- **Tier 1**: no install — eng-mode works without v3 substrate.
+- **Tier 2**: install the 10-label v3 set via `gh label create --force`. Unlocks `/file-directive` / `/activate-directive` / `/complete-directive` directly against Issues. No Project mirror.
+- **Tier 3**: tier 2 + install ISSUE_TEMPLATE files + workflow files via a PR to the target + create Project v2 via `gh project create` + populate fields via `scripts/setup_project.sh`. Unlocks `/triage` + template chooser + Project-as-derived-view.
+
+Each tier is a strict superset. Re-running is idempotent at every step.
+
+## Procedure
+
+1. **Parse `$ARGUMENTS`** — `--tier <1|2|3>` (default 3) + optional `--dry-run` (no mutations; print would-do). Other values → error.
+
+2. **Verify target context** — must be in a registered target repo (per `scripts/register.sh`). If cwd not in registry: error. If not a git repo: error.
+
+3. **Resolve target's owner/repo** via `gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"'`.
+
+4. **Tier 1**: print confirmation that no install is needed; exit.
+
+5. **Tier 2** (label install):
+   - Invoke `bash $CLAUDE_ENG_SHELL_ROOT/scripts/onboard_target.sh --tier 2` (idempotent — uses `gh label create --force`).
+   - Verify via `gh label list` that all 10 labels exist: `directive`, `status:proposed`, `status:blocked`, `task`, `needs-triage`, `discussion`, `P0`, `P1`, `P2`, `P3`.
+
+6. **Tier 3** (full v3):
+   - Run step 5 (tier 2 prerequisite).
+   - Invoke `bash $CLAUDE_ENG_SHELL_ROOT/scripts/onboard_target.sh --tier 3`:
+     - Copies canonical files from `$CLAUDE_ENG_SHELL_ROOT/.claude/templates/target-substrate/` into target's `.github/`:
+       - `ISSUE_TEMPLATE/{config,directive-proposal,execution-under-directive,task,bug-report,discussion}.yml`
+       - `workflows/{auto-needs-triage,issues-to-project-mirror,dir-mode-post-merge}.yml`
+     - Creates branch `onboard-dir-mode-substrate`, commits the files, pushes, opens a PR via `gh pr create --title "chore: onboard claude-eng-shell dir-mode v3 substrate"` — **target maintainer reviews + merges**.
+     - Direct push to target's `main` is forbidden (protected-branch hook fires; this is by design per ADR-0004 Decision 2).
+   - Project v2 setup: invoke `bash $CLAUDE_ENG_SHELL_ROOT/scripts/setup_project.sh` (idempotent — creates the Project if absent, reconciles fields if present).
+
+7. **Audit log** — `audit_log info onboard-dir-mode created "target=<owner>/<repo> tier=<N>"`.
+
+8. **Output**:
+   ```
+   Onboarded <owner>/<repo> to tier <N>.
+   Tier-2 (labels): <K> labels installed.
+   Tier-3 (PR): <pr-url> opened — maintainer to review + merge.
+   Tier-3 (Project): <project-url>.
+   ```
+
+## Idempotency contract
+
+- Re-running with the same tier produces no new artifacts: labels via `--force` overwrite-without-error; ISSUE_TEMPLATE / workflow files re-committed are no-op if `git diff` is empty (the install script `git diff --quiet` checks before committing).
+- Downgrades are out-of-scope (the maintainer reverts manually per ADR-0004 reversibility paths).
+
+## Operating mode
+
+- **attended**: each tier step prints the action and waits for confirmation.
+- **unattended**: auto-applies all steps; logs every install as an audit line.
+
+## Escape
+
+`SKIP_HOOKS=onboard-dir-mode SKIP_REASON='<why>' /onboard-dir-mode <args>` bypasses the install entirely (use for sandbox/test contexts where the substrate would interfere).
+
+## Forbidden
+
+- Direct push to target's `main` branch (protected-branch hook enforces this).
+- Installing files outside the target's `.github/` (the canonical-substrate allow-list is the typed boundary per ADR-0004 Decision 1).
+- Auto-deleting target files (uninstall is the maintainer's call; ADR-0004 reversibility paths name the manual commands).
+- Skipping the audit log (the trail is the foundation for `/audit` queries).

--- a/.claude/commands/revise-directive.md
+++ b/.claude/commands/revise-directive.md
@@ -9,6 +9,8 @@ In dir-mode v3 (ADR-0003), Issues are SSOT. The Project Item is unchanged by thi
 
 ## Procedure
 
+0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+
 1. **Resolve the Issue** — `<issue-#>` is a GitHub Issue number. Fetch:
    ```bash
    gh issue view <issue-#> --json title,body,state,labels

--- a/.claude/templates/target-substrate/ISSUE_TEMPLATE/bug-report.yml
+++ b/.claude/templates/target-substrate/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report a defect — something doesn't work as documented in SPEC.md / README / CLAUDE.md.
+title: "fix: <subject>"
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What's broken
+      description: One paragraph naming the defect.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproducer
+      description: Steps to reproduce. Include command + expected vs actual output. If discovered during a session, include the timestamp and audit-log entry if relevant.
+      placeholder: |
+        1. Run `gh pr merge 77 --auto --merge --delete-branch 2>&1 | tail -5` on a PR with AC closed out.
+        2. Expected: matcher recognizes happy path, no audit emission (mark_allow silent).
+        3. Actual: `pass-through` warn emitted at <timestamp>.
+    validations:
+      required: true
+
+  - type: textarea
+    id: root-cause-or-hypothesis
+    attributes:
+      label: Root cause or hypothesis
+      description: If known, name the file:line. Otherwise list candidate hypotheses for diagnosis to narrow.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Verifiable conditions as `- [ ] <item>`. Include "reproducer no longer fires" + smoke regression check.
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+    validations:
+      required: false

--- a/.claude/templates/target-substrate/ISSUE_TEMPLATE/config.yml
+++ b/.claude/templates/target-substrate/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+# Discussions are not enabled on this repo (verified 2026-05-26 via
+# `gh api repos/ilgyu-yi/claude-eng-shell --jq .has_discussions` → false).
+# When Discussions is enabled later, add a `contact_links:` entry here
+# pointing at the Discussions URL — see brief §5.1 + cluster A AC.
+contact_links: []

--- a/.claude/templates/target-substrate/ISSUE_TEMPLATE/directive-proposal.yml
+++ b/.claude/templates/target-substrate/ISSUE_TEMPLATE/directive-proposal.yml
@@ -1,0 +1,82 @@
+name: Directive proposal
+description: Propose a Directive — a medium-term directional context that scopes several Execution Issues. See SPEC §1.7 / §2.1. Maintainer triages via `/triage`.
+title: "directive: <one-line objective>"
+labels: [directive, status:proposed]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A Directive is a **directing context**, not a unit of work. It names what scope of work is worth doing over a few weeks and gives Execution Issues a coherent parent to live under. The maintainer reviews this proposal via `/triage` and either accepts (Status → Active) or rejects (refiled in a different template).
+
+        Before filing, scan [`MISSION.md`](../blob/main/MISSION.md) and the [open Directives](https://github.com/ilgyu-yi/claude-eng-shell/issues?q=is%3Aopen+label%3Adirective) to make sure this proposal doesn't duplicate existing direction.
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: One paragraph naming what this Directive is trying to achieve. Bound by a concrete artifact-level boundary (file paths, issue counts, AC ticks, merge events) — not "improve" or "optimize" without a target.
+      placeholder: |
+        Promote the two §2.1 state-table entries currently marked "(v1+)" — Revised and Blocked — from placeholder rows to executable commands. Concrete artifacts: .claude/commands/{revise,block}-directive.md, SPEC §2.1 + new §5.x subsections, smoke section.
+    validations:
+      required: true
+
+  - type: textarea
+    id: success-signals
+    attributes:
+      label: Success signals
+      description: 2-5 verifiable conditions for completion. Each must be objectively testable by a reasonable engineer — name the artifact / metric / state that demonstrates the signal is met.
+      placeholder: |
+        - /revise-directive on an Active Directive produces a `## Pre-revision body — archived <ISO date>` comment + body replacement + audit line.
+        - SPEC §2.1 state diagram + table contain zero `(v1+)` parentheticals.
+        - Smoke 282/282 with new §43 assertions.
+    validations:
+      required: true
+
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-goals
+      description: At least 2 explicit exclusions. What this Directive does NOT cover. Sharper non-goals tighten scope clarity.
+      placeholder: |
+        - Does NOT add /derive-next-directive (sibling v1+ item, separate Directive).
+        - Does NOT modify directive-reviewer's existing checks.
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: At least 1 invariant to preserve throughout the Directive's lifetime. Reviewer-gating, mode semantics, audit shape, etc.
+      placeholder: |
+        - Preserve §2.1 reviewer-gating contract — both commands re-invoke directive-reviewer.
+        - Preserve audit_log <event> <category> <decision> <reason> shape.
+    validations:
+      required: true
+
+  - type: textarea
+    id: mission-fit
+    attributes:
+      label: MISSION fit
+      description: Which `MISSION.md` section or success criterion does this Directive serve? One sentence. (If MISSION.md doesn't yet exist or doesn't cover this, say so honestly — the Directive may motivate a MISSION amendment.)
+      placeholder: |
+        Serves MISSION § "Success looks like > The directing layer works" — completes the §2.1 state diagram so the Directive lifecycle is fully executable end-to-end.
+    validations:
+      required: true
+
+  - type: textarea
+    id: confidence
+    attributes:
+      label: Confidence (0-100)
+      description: Self-assessment of hypothesis quality at filing time. Lower numbers are OK — Directives can be filed under uncertainty as long as success signals are verifiable. Optional but encouraged.
+      placeholder: "75"
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Optional — links to prior discussions, related Issues, ADRs.
+    validations:
+      required: false

--- a/.claude/templates/target-substrate/ISSUE_TEMPLATE/discussion.yml
+++ b/.claude/templates/target-substrate/ISSUE_TEMPLATE/discussion.yml
@@ -1,0 +1,29 @@
+name: Discussion
+description: An observation or half-formed idea; develop in comments, close as `promoted` or `no-action` (SPEC §5.19).
+title: "discussion: <subject>"
+labels: [discussion]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Discussion tier** (SPEC §5.19): use this when you have a deliberately-ambiguous observation — a "weird but not a bug" report, a half-formed idea, a smell, an RFC-style probe. Develop it in comments. Close via exactly one of two paths:
+        - **promoted** — a concrete Issue (bug / task / Directive) was filed; close-as-completed with a `promoted to #M` comment.
+        - **no-action** — the discussion concluded nothing needs doing; close-as-not-planned with a one-line reason.
+
+        No acceptance criteria, no MISSION fit, no rationale triad — those belong in the conversation, not in the form.
+
+  - type: textarea
+    id: body
+    attributes:
+      label: What you noticed
+      description: One-paragraph framing of the observation. Comments expand from here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Related Issues / PRs (optional)
+      description: Links to related Issues or PRs that motivated this discussion.
+    validations:
+      required: false

--- a/.claude/templates/target-substrate/ISSUE_TEMPLATE/execution-under-directive.yml
+++ b/.claude/templates/target-substrate/ISSUE_TEMPLATE/execution-under-directive.yml
@@ -1,0 +1,55 @@
+name: Execution Issue (under a Directive)
+description: "File an Execution Issue parented under an active Directive. The `Parent Directive: #N` body marker is required."
+title: "<type>: <subject>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        An Execution Issue is a **concrete unit of work** parented under a Directive. It implements a slice of the Directive's success signals. After filing, `/work-on <N>` creates a branch + draft PR + planner output.
+
+        If your work is not under any Directive, file as a `task` instead. If you don't know whether a Directive exists, leave the field blank and the maintainer's `/triage` step will route.
+
+  - type: input
+    id: parent-directive
+    attributes:
+      label: Parent Directive number
+      description: 'The number of the active Directive this Issue serves (e.g., 92). The Issue body will have `Parent Directive: #<N>` injected as line 1 so `/reflect` and the dir-mode-post-merge workflow find it.'
+      placeholder: "92"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: What needs to be done? One paragraph.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Verifiable conditions, one per line, as `- [ ] <item>`. Each must be mechanically testable (grep / file-exists / smoke section / SPEC diff).
+      placeholder: |
+        - [ ] `.claude/commands/<name>.md` exists with frontmatter + Procedure / Forbidden sections.
+        - [ ] Smoke section asserts the command file's contract markers.
+        - [ ] No regression in existing smoke.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What this Issue does NOT cover. Helps reviewer triage.
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+    validations:
+      required: false

--- a/.claude/templates/target-substrate/ISSUE_TEMPLATE/task.yml
+++ b/.claude/templates/target-substrate/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,35 @@
+name: Task
+description: A standalone task or small improvement that doesn't fit a Directive. One-off work — refactor, doc fix, dependency bump.
+title: "chore: <subject>"
+labels: [task]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: What needs to be done?
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: Why now? What changes if this waits? (See SPEC §5.2 rationale triad — MISSION fit / why now / existing coverage.)
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Verifiable conditions as `- [ ] <item>`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+    validations:
+      required: false

--- a/.claude/templates/target-substrate/workflows/auto-needs-triage.yml
+++ b/.claude/templates/target-substrate/workflows/auto-needs-triage.yml
@@ -1,0 +1,42 @@
+name: auto-needs-triage
+
+# Cluster A (Directive #92, Issue #93): apply the `needs-triage` label to any
+# Issue opened without any label. Server-side workflow because template-based
+# filings already get their `labels:` frontmatter applied; only template-free
+# (raw) filings have an empty label set.
+#
+# Idempotent: the workflow's only effect is `gh issue edit --add-label needs-triage`,
+# which is a no-op if the label is already present. Skipping condition prevents
+# self-triggering loops (a workflow-applied label change does not re-fire this
+# workflow's `opened` trigger).
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  apply-needs-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect label set
+        id: labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          n="${{ github.event.issue.number }}"
+          labels=$(gh issue view "$n" --repo "${{ github.repository }}" --json labels --jq '[.labels[].name] | length')
+          echo "count=$labels" >> "$GITHUB_OUTPUT"
+
+      - name: Apply needs-triage on label-free Issue
+        if: steps.labels.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          n="${{ github.event.issue.number }}"
+          gh issue edit "$n" --repo "${{ github.repository }}" --add-label "needs-triage"

--- a/.claude/templates/target-substrate/workflows/dir-mode-post-merge.yml
+++ b/.claude/templates/target-substrate/workflows/dir-mode-post-merge.yml
@@ -1,0 +1,110 @@
+# .claude/templates/dir-mode-post-merge.yml
+# Source-of-truth for the hook-enforced post-merge dir-mode workflow.
+# Installed into target repos at .github/workflows/dir-mode-post-merge.yml
+# by scripts/setup_project.sh (future work) or /onboard.
+#
+# Purpose (SPEC §5.7, §5.15; Directive #61):
+#   When a PR merges, parse the closed Issue's body for `Parent Directive: #N`.
+#   If found, post a single hook-enforced reflection comment on the parent
+#   Directive Issue. The comment is the canonical audit surface for events
+#   the Action emits — it doubles as the `directive-exec-count` and
+#   `directive-reflect` audit records that /ship step 10.5 and /reflect
+#   produce when Claude is in the loop.
+#
+# Idempotency: scans existing comments on the parent Directive for the
+# merged PR's URL. If found, exits 0 with a no-op.
+#
+# Defense in depth: the Markdown procedures in .claude/commands/ship.md
+# step 10.5 and .claude/commands/reflect.md remain valid for Claude-in-loop
+# execution. Both paths arrive at the same comment shape; the existing-URL
+# idempotency check prevents duplicates.
+
+name: dir-mode-post-merge
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  reflect:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve parent Directive from closing issue bodies
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # No actions/checkout step — the workflow only uses gh API. Every gh
+          # call carries --repo so it doesn't try to read git context from the
+          # runner's cwd (which has no .git directory).
+          # Fetch closing-issue numbers from the merged PR.
+          closing=$(gh pr view "$PR_NUM" --repo "$REPO" --json closingIssuesReferences \
+            --jq '.closingIssuesReferences[].number')
+          directive=""
+          exec_issue=""
+          for n in $closing; do
+            body=$(gh issue view "$n" --repo "$REPO" --json body --jq .body)
+            if [[ "$body" =~ ^Parent\ Directive:\ \#([0-9]+) ]]; then
+              directive="${BASH_REMATCH[1]}"
+              exec_issue="$n"
+              break
+            fi
+          done
+          if [ -n "$directive" ]; then
+            {
+              echo "directive=$directive"
+              echo "exec_issue=$exec_issue"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post hook-enforced reflection (idempotent)
+        if: steps.resolve.outputs.directive != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DIRECTIVE: ${{ steps.resolve.outputs.directive }}
+          EXEC: ${{ steps.resolve.outputs.exec_issue }}
+          PR: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
+        run: |
+          set -euo pipefail
+          # Idempotency: skip if a comment containing this PR's URL already exists
+          # on the parent Directive. Matches the /reflect Markdown procedure's
+          # existing-URL check, so Claude-in-loop and hook-enforced paths dedupe.
+          existing=$(gh issue view "$DIRECTIVE" --repo "$REPO" --comments --json comments \
+            --jq ".comments[] | select(.body | contains(\"$PR_URL\")) | .url" | head -1)
+          if [ -n "$existing" ]; then
+            echo "Already reflected: $existing"
+            exit 0
+          fi
+          # Compose comment. The `directive-exec-count` line is the audit
+          # record for this event — GitHub's comment surface is the audit
+          # surface for hook-enforced emissions (the per-clone .claude/audit/
+          # path is not accessible from a workflow runner).
+          comment=$(cat <<COMMENT
+          ## Reflection from PR #${PR} (resolved by hook-enforced post-merge workflow)
+
+          **PR**: [${PR_TITLE}](${PR_URL}) — merged ${MERGED_AT}
+          **Linked Execution Issue**: #${EXEC} (auto-closed)
+          **Parent Directive**: #${DIRECTIVE}
+
+          ### Audit
+          \`directive-exec-count merged directive=#${DIRECTIVE} pr=#${PR} issue=#${EXEC}\` — recorded by \`.github/workflows/dir-mode-post-merge.yml\` (SPEC §5.7 + §5.15, Directive #61). The Markdown procedures in \`/ship\` step 10.5 and \`/reflect\` remain valid for Claude-in-loop runs; the existing-URL idempotency check dedupes across both paths.
+
+          ### Contribution
+          Auto-generated — see the merged PR body for the substantive narrative. A Claude-in-loop \`/reflect\` invocation can re-run this Action's emission with a richer per-signal evidence block; the existing-URL check will replace this comment's content if the second emission references the same PR URL, OR the second emission will skip per idempotency.
+
+          Posted by \`.github/workflows/dir-mode-post-merge.yml\` on \`pull_request.closed\` (merged=true).
+          COMMENT
+          )
+          gh issue comment "$DIRECTIVE" --repo "$REPO" --body "$comment"

--- a/.claude/templates/target-substrate/workflows/issues-to-project-mirror.yml
+++ b/.claude/templates/target-substrate/workflows/issues-to-project-mirror.yml
@@ -1,0 +1,199 @@
+name: issues-to-project-mirror
+
+# Cluster D of dir-mode v3 reframe (Directive #92 brief §7, Issue #96 umbrella).
+#
+# One-direction sync: Issue events → Project Item fields. The Project remains
+# a derived view; Issues are SSOT (§1.7). On `issues.{opened, edited, labeled,
+# unlabeled, closed, reopened, milestoned, demilestoned}`, derive the four
+# mirrored fields from the Issue's labels + body + open/closed state, and
+# write them to the Project Item that wraps this Issue (creating the Item
+# if it doesn't exist yet).
+#
+# Mirrored fields:
+#   - Type      ← `directive` label → Directive; else → Execution
+#   - Status    ← labels + open/closed → Proposed | Active | Blocked | Completed
+#                 (v3 4-state lifecycle; Revised dropped per Decision 7)
+#   - Priority  ← P0 / P1 / P2 / P3 label
+#   - Parent    ← body line 1 `Parent Directive: #N` (the marker `/file-issue
+#                 --parent` writes per SPEC §5.2)
+#
+# NOT mirrored:
+#   - Iteration (user-managed on Project, owner-cadence — brief Decision 5)
+#   - Confidence / Success Signals (content lives in body, not field per
+#     v3 schema)
+#
+# Failures degrade gracefully — the Project view goes stale, but Issues
+# remain authoritative. A `mirror-stale-warn` audit category is reserved
+# in SPEC §2.1 for future monitoring (brief §7 deferred to v1+).
+#
+# Repo target: $CLAUDE_ENG_PROJECT_NAME (default: "<repo-name> roadmap")
+# under the repo owner. The workflow resolves these via `gh repo view` +
+# `gh project list`, matching the substrate-guard pattern from issue #71.
+
+on:
+  issues:
+    types: [opened, edited, labeled, unlabeled, closed, reopened, milestoned, demilestoned]
+
+permissions:
+  issues: read
+  contents: read
+  # Project v2 mutations require explicit organization/user-level token grants
+  # beyond GITHUB_TOKEN's default scope. The workflow handles a missing scope
+  # gracefully (per brief §7: graceful degradation).
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve Project + Item + derive field values
+        id: derive
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Resolve owner + repo from the workflow env. Project name:
+          # "<repo-name> roadmap" by default; CLAUDE_ENG_PROJECT_NAME override.
+          owner="${REPO%/*}"
+          repo_name="${REPO#*/}"
+          project_name="${CLAUDE_ENG_PROJECT_NAME:-$repo_name roadmap}"
+
+          # Find the Project by name. If absent, no-op (graceful: this repo
+          # may not have a Project set up; mirror is best-effort).
+          project_num=$(gh project list --owner "$owner" --format json --limit 100 2>/dev/null \
+            | jq -r --arg name "$project_name" \
+              '.projects[]? | select(.title==$name) | .number' \
+            | head -1)
+          if [ -z "$project_num" ]; then
+            echo "mirror: no Project named '$project_name' for owner '$owner' — graceful no-op"
+            exit 0
+          fi
+          echo "project_num=$project_num" >> "$GITHUB_OUTPUT"
+          echo "owner=$owner" >> "$GITHUB_OUTPUT"
+
+          # Derive Type from labels.
+          labels_json=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json labels --jq '[.labels[].name]')
+          type_val="Execution"
+          if printf '%s' "$labels_json" | jq -e 'index("directive") != null' >/dev/null 2>&1; then
+            type_val="Directive"
+          fi
+          echo "type_val=$type_val" >> "$GITHUB_OUTPUT"
+
+          # Derive Status from labels + open/closed.
+          state=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json state --jq '.state')
+          status_val="Active"
+          if [ "$state" = "CLOSED" ]; then
+            status_val="Completed"
+          elif printf '%s' "$labels_json" | jq -e 'index("status:proposed") != null' >/dev/null 2>&1; then
+            status_val="Proposed"
+          elif printf '%s' "$labels_json" | jq -e 'index("status:blocked") != null' >/dev/null 2>&1; then
+            status_val="Blocked"
+          fi
+          echo "status_val=$status_val" >> "$GITHUB_OUTPUT"
+
+          # Derive Priority from P0..P3 label (first match wins).
+          priority_val=""
+          for p in P0 P1 P2 P3; do
+            if printf '%s' "$labels_json" | jq -e --arg p "$p" 'index($p) != null' >/dev/null 2>&1; then
+              priority_val="$p"
+              break
+            fi
+          done
+          echo "priority_val=$priority_val" >> "$GITHUB_OUTPUT"
+
+          # Derive Parent from body line 1 `Parent Directive: #N` marker.
+          parent_val=""
+          body=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json body --jq '.body')
+          first_line=$(printf '%s\n' "$body" | head -1 || true)
+          if printf '%s' "$first_line" | grep -qE '^Parent Directive: #[0-9]+$'; then
+            parent_val=$(printf '%s' "$first_line" | sed -E 's/^Parent Directive: #([0-9]+)$/#\1/')
+          fi
+          echo "parent_val=$parent_val" >> "$GITHUB_OUTPUT"
+
+          echo "mirror: type=$type_val status=$status_val priority=$priority_val parent=$parent_val"
+
+      - name: Find or add Item; resolve field IDs; write derived values
+        if: steps.derive.outputs.project_num
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          PROJECT_NUM: ${{ steps.derive.outputs.project_num }}
+          OWNER: ${{ steps.derive.outputs.owner }}
+          TYPE_VAL: ${{ steps.derive.outputs.type_val }}
+          STATUS_VAL: ${{ steps.derive.outputs.status_val }}
+          PRIORITY_VAL: ${{ steps.derive.outputs.priority_val }}
+          PARENT_VAL: ${{ steps.derive.outputs.parent_val }}
+        run: |
+          set -euo pipefail
+
+          issue_url="https://github.com/${REPO}/issues/${ISSUE_NUM}"
+
+          # Resolve / add the Project Item that wraps this Issue. Idempotent —
+          # `gh project item-add` errors with "Item already exists" if present;
+          # fall through to listing to recover the id.
+          item_id=$(gh project item-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 200 2>/dev/null \
+            | jq -r --arg url "$issue_url" \
+              '.items[]? | select(.content.url == $url) | .id' \
+            | head -1)
+          if [ -z "$item_id" ]; then
+            # Add — capture id from --format json.
+            item_id=$(gh project item-add "$PROJECT_NUM" --owner "$OWNER" --url "$issue_url" --format json 2>/dev/null \
+              | jq -r '.id // empty')
+            if [ -z "$item_id" ]; then
+              echo "mirror: failed to add Item for $issue_url — graceful no-op (Project access scope likely missing)"
+              exit 0
+            fi
+          fi
+          echo "mirror: item_id=$item_id"
+
+          # Resolve Project node id + field ids in one GraphQL pass.
+          fields_json=$(gh project field-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 100 2>/dev/null)
+          project_id=$(gh project view "$PROJECT_NUM" --owner "$OWNER" --format json 2>/dev/null | jq -r '.id')
+
+          field_id() {
+            printf '%s' "$fields_json" | jq -r --arg n "$1" '.fields[]? | select(.name==$n) | .id // empty'
+          }
+          option_id() {
+            local field="$1" opt="$2"
+            printf '%s' "$fields_json" \
+              | jq -r --arg field "$field" --arg opt "$opt" \
+                '.fields[]? | select(.name==$field) | .options[]? | select(.name==$opt) | .id // empty'
+          }
+
+          # Write each mirrored field. Each call is best-effort; a failure
+          # on one field doesn't abort the others.
+          type_field_id=$(field_id "Type")
+          type_opt_id=$(option_id "Type" "$TYPE_VAL")
+          if [ -n "$type_field_id" ] && [ -n "$type_opt_id" ]; then
+            gh project item-edit --id "$item_id" --project-id "$project_id" \
+              --field-id "$type_field_id" --single-select-option-id "$type_opt_id" >/dev/null 2>&1 || true
+          fi
+
+          status_field_id=$(field_id "Status")
+          status_opt_id=$(option_id "Status" "$STATUS_VAL")
+          if [ -n "$status_field_id" ] && [ -n "$status_opt_id" ]; then
+            gh project item-edit --id "$item_id" --project-id "$project_id" \
+              --field-id "$status_field_id" --single-select-option-id "$status_opt_id" >/dev/null 2>&1 || true
+          fi
+
+          if [ -n "$PRIORITY_VAL" ]; then
+            priority_field_id=$(field_id "Priority")
+            priority_opt_id=$(option_id "Priority" "$PRIORITY_VAL")
+            if [ -n "$priority_field_id" ] && [ -n "$priority_opt_id" ]; then
+              gh project item-edit --id "$item_id" --project-id "$project_id" \
+                --field-id "$priority_field_id" --single-select-option-id "$priority_opt_id" >/dev/null 2>&1 || true
+            fi
+          fi
+
+          if [ -n "$PARENT_VAL" ]; then
+            parent_field_id=$(field_id "Parent")
+            if [ -n "$parent_field_id" ]; then
+              gh project item-edit --id "$item_id" --project-id "$project_id" \
+                --field-id "$parent_field_id" --text "$PARENT_VAL" >/dev/null 2>&1 || true
+            fi
+          fi
+
+          echo "mirror: synced issue #${ISSUE_NUM} → item ${item_id} (type=${TYPE_VAL} status=${STATUS_VAL} priority=${PRIORITY_VAL:-—} parent=${PARENT_VAL:-—})"

--- a/scripts/onboard_target.sh
+++ b/scripts/onboard_target.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# scripts/onboard_target.sh — install the v3 substrate into the current
+# target repo (cwd). Tier-aware (--tier 1|2|3). Idempotent. PR-based file
+# installs per ADR-0004 Decision 2. Audit-logged.
+#
+# Invoked from /onboard-dir-mode (.claude/commands/onboard-dir-mode.md).
+#
+# Tier semantics (per ADR-0004 Decision 4):
+#   1 — no-op (eng-mode only; no substrate installed).
+#   2 — labels: the 10-label v3 set via `gh label create --force`.
+#   3 — tier 2 + ISSUE_TEMPLATE + workflows (via PR) + Project v2.
+
+set -euo pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+: "${CLAUDE_ENG_SHELL_ROOT:=$SCRIPT_ROOT}"
+export CLAUDE_ENG_SHELL_ROOT
+
+if [ -f "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/hookrt.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$CLAUDE_ENG_SHELL_ROOT/.claude/hooks/hookrt.sh"
+else
+  audit_log() { :; }
+fi
+
+TIER=3
+DRY_RUN=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tier) TIER="$2"; shift 2 ;;
+    --tier=*) TIER="${1#--tier=}"; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    *) echo "onboard_target: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$TIER" in
+  1|2|3) ;;
+  *) echo "onboard_target: --tier must be 1, 2, or 3 (got $TIER)" >&2; exit 2 ;;
+esac
+
+# Resolve target owner/repo (validates we're in a real gh repo context).
+if ! command -v gh >/dev/null 2>&1; then
+  echo "onboard_target: gh CLI not found" >&2
+  exit 1
+fi
+TARGET_OWNER_REPO=$(gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"' 2>/dev/null || true)
+if [ -z "$TARGET_OWNER_REPO" ]; then
+  echo "onboard_target: cannot resolve gh repo (cwd not in a gh-recognized git repo or gh not authed)" >&2
+  exit 1
+fi
+echo "onboard_target: target=$TARGET_OWNER_REPO tier=$TIER ${DRY_RUN:+(dry-run)}"
+
+# ---------------------------------------------------------------
+# Tier 1 — no-op
+# ---------------------------------------------------------------
+if [ "$TIER" = 1 ]; then
+  echo "onboard_target: tier 1 — no substrate to install (eng-mode works without)"
+  audit_log info onboard-dir-mode created "target=$TARGET_OWNER_REPO tier=1 noop"
+  exit 0
+fi
+
+# ---------------------------------------------------------------
+# Tier 2 — labels
+# ---------------------------------------------------------------
+echo "onboard_target: tier 2 — installing 10-label v3 set..."
+LABELS_SPEC=(
+  "directive:0E8A16:Directive Issue (dir-mode, SPEC §1.7)"
+  "status:proposed:FBCA04:Directive proposed; awaiting maintainer triage (SPEC §2.1 v3)"
+  "status:blocked:B60205:Directive cannot proceed without external input (SPEC §5.17)"
+  "task:C5DEF5:Standalone task or small improvement (not parented under a Directive)"
+  "needs-triage:D4C5F9:Issue filed without a template — awaiting maintainer triage classification"
+  "discussion:FEF2C0:Observation or half-formed idea; close as promoted (#M) or no-action (SPEC §5.19)"
+  "P0:B60205:Priority 0 — drop everything"
+  "P1:D93F0B:Priority 1 — next"
+  "P2:FBCA04:Priority 2 — soon"
+  "P3:0E8A16:Priority 3 — eventually"
+)
+for spec in "${LABELS_SPEC[@]}"; do
+  name="${spec%%:*}"; rest="${spec#*:}"
+  color="${rest%%:*}"; desc="${rest#*:}"
+  if [ -n "$DRY_RUN" ]; then
+    echo "  [dry-run] would: gh label create '$name' --color '$color' --force"
+  else
+    gh label create "$name" --color "$color" --description "$desc" --force >/dev/null 2>&1 || \
+      echo "  warn: label '$name' install failed (non-fatal; existing labels often differ in description-only)"
+  fi
+done
+echo "onboard_target: tier 2 labels done."
+
+if [ "$TIER" = 2 ]; then
+  audit_log info onboard-dir-mode created "target=$TARGET_OWNER_REPO tier=2 labels=10"
+  exit 0
+fi
+
+# ---------------------------------------------------------------
+# Tier 3 — labels + ISSUE_TEMPLATE + workflows (via PR) + Project
+# ---------------------------------------------------------------
+echo "onboard_target: tier 3 — installing ISSUE_TEMPLATE + workflows via PR..."
+SUBSTRATE_ROOT="$CLAUDE_ENG_SHELL_ROOT/.claude/templates/target-substrate"
+if [ ! -d "$SUBSTRATE_ROOT" ]; then
+  echo "onboard_target: canonical-source $SUBSTRATE_ROOT missing — re-run scripts/sync_target_substrate.sh" >&2
+  exit 1
+fi
+
+# Copy canonical files into target's .github/.
+TARGET_GITHUB="$(pwd)/.github"
+mkdir -p "$TARGET_GITHUB/ISSUE_TEMPLATE" "$TARGET_GITHUB/workflows"
+if [ -n "$DRY_RUN" ]; then
+  echo "  [dry-run] would copy:"
+  ls "$SUBSTRATE_ROOT/ISSUE_TEMPLATE/" "$SUBSTRATE_ROOT/workflows/" 2>/dev/null
+else
+  cp "$SUBSTRATE_ROOT/ISSUE_TEMPLATE/"*.yml "$TARGET_GITHUB/ISSUE_TEMPLATE/"
+  cp "$SUBSTRATE_ROOT/workflows/"*.yml "$TARGET_GITHUB/workflows/"
+  echo "  copied 6 ISSUE_TEMPLATE files + 3 workflow files into $TARGET_GITHUB/"
+fi
+
+# Open a PR if there are changes. Idempotent: skip if no diff.
+if [ -z "$DRY_RUN" ]; then
+  if git -C "$(pwd)" diff --quiet -- .github/; then
+    echo "onboard_target: tier 3 files already match canonical-source (no PR needed; idempotent)"
+  else
+    BRANCH="onboard-dir-mode-substrate"
+    git -C "$(pwd)" checkout -b "$BRANCH" 2>/dev/null || git -C "$(pwd)" checkout "$BRANCH"
+    git -C "$(pwd)" add .github/
+    git -C "$(pwd)" commit -m "chore: onboard claude-eng-shell dir-mode v3 substrate
+
+Installs ISSUE_TEMPLATE files + dir-mode workflows per ADR-0004 Decision 1.
+Reversibility: per ADR-0004 reversibility paths — git rm .github/ISSUE_TEMPLATE/<file>
+or .github/workflows/<file> removes any installed file via a normal PR."
+    git -C "$(pwd)" push -u origin "$BRANCH"
+    gh pr create --title "chore: onboard claude-eng-shell dir-mode v3 substrate" \
+      --body "Installs ISSUE_TEMPLATE files + dir-mode workflows per ADR-0004 Decision 1. Reversibility paths documented in the ADR."
+  fi
+fi
+
+# Project v2 setup.
+if [ -n "$DRY_RUN" ]; then
+  echo "  [dry-run] would: bash scripts/setup_project.sh"
+else
+  echo "onboard_target: invoking setup_project.sh..."
+  bash "$CLAUDE_ENG_SHELL_ROOT/scripts/setup_project.sh" || echo "  warn: setup_project.sh failed — Project may need manual creation"
+fi
+
+audit_log info onboard-dir-mode created "target=$TARGET_OWNER_REPO tier=3"
+echo "onboard_target: tier 3 done."

--- a/scripts/onboard_target.sh
+++ b/scripts/onboard_target.sh
@@ -40,14 +40,26 @@ case "$TIER" in
 esac
 
 # Resolve target owner/repo (validates we're in a real gh repo context).
+# Dry-run skips the live-gh check so smoke and other no-network contexts
+# (CI runners without gh auth, sandbox testing) can exercise the script's
+# structural output without auth. Live runs still require gh + remote.
 if ! command -v gh >/dev/null 2>&1; then
-  echo "onboard_target: gh CLI not found" >&2
-  exit 1
-fi
-TARGET_OWNER_REPO=$(gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"' 2>/dev/null || true)
-if [ -z "$TARGET_OWNER_REPO" ]; then
-  echo "onboard_target: cannot resolve gh repo (cwd not in a gh-recognized git repo or gh not authed)" >&2
-  exit 1
+  if [ -n "$DRY_RUN" ]; then
+    TARGET_OWNER_REPO="<owner>/<repo>"
+  else
+    echo "onboard_target: gh CLI not found" >&2
+    exit 1
+  fi
+else
+  TARGET_OWNER_REPO=$(gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"' 2>/dev/null || true)
+  if [ -z "$TARGET_OWNER_REPO" ]; then
+    if [ -n "$DRY_RUN" ]; then
+      TARGET_OWNER_REPO="<owner>/<repo>"
+    else
+      echo "onboard_target: cannot resolve gh repo (cwd not in a gh-recognized git repo or gh not authed)" >&2
+      exit 1
+    fi
+  fi
 fi
 echo "onboard_target: target=$TARGET_OWNER_REPO tier=$TIER ${DRY_RUN:+(dry-run)}"
 

--- a/scripts/onboard_target.sh
+++ b/scripts/onboard_target.sh
@@ -63,30 +63,45 @@ fi
 # ---------------------------------------------------------------
 # Tier 2 — labels
 # ---------------------------------------------------------------
+# Delegate to scripts/ensure_v3_labels.sh — the single source of truth for
+# the v3 label set (named, colored, described). Avoids duplicating the
+# spec here (canonical-substrate principle: one source of truth per
+# artifact type). Plus extra labels not in ensure_v3_labels.sh: directive,
+# P0/P1/P2/P3 — installed inline since those labels are not the v3-bootstrap
+# scope of ensure_v3_labels.sh.
 echo "onboard_target: tier 2 — installing 10-label v3 set..."
-LABELS_SPEC=(
-  "directive:0E8A16:Directive Issue (dir-mode, SPEC §1.7)"
-  "status:proposed:FBCA04:Directive proposed; awaiting maintainer triage (SPEC §2.1 v3)"
-  "status:blocked:B60205:Directive cannot proceed without external input (SPEC §5.17)"
-  "task:C5DEF5:Standalone task or small improvement (not parented under a Directive)"
-  "needs-triage:D4C5F9:Issue filed without a template — awaiting maintainer triage classification"
-  "discussion:FEF2C0:Observation or half-formed idea; close as promoted (#M) or no-action (SPEC §5.19)"
-  "P0:B60205:Priority 0 — drop everything"
-  "P1:D93F0B:Priority 1 — next"
-  "P2:FBCA04:Priority 2 — soon"
-  "P3:0E8A16:Priority 3 — eventually"
-)
-for spec in "${LABELS_SPEC[@]}"; do
-  name="${spec%%:*}"; rest="${spec#*:}"
-  color="${rest%%:*}"; desc="${rest#*:}"
+
+ensure_label() {
+  local name="$1" color="$2" desc="$3"
   if [ -n "$DRY_RUN" ]; then
-    echo "  [dry-run] would: gh label create '$name' --color '$color' --force"
-  else
-    gh label create "$name" --color "$color" --description "$desc" --force >/dev/null 2>&1 || \
-      echo "  warn: label '$name' install failed (non-fatal; existing labels often differ in description-only)"
+    printf "  [dry-run] would: gh label create '%s' --color '%s' --force\n" "$name" "$color"
+    return 0
   fi
-done
-echo "onboard_target: tier 2 labels done."
+  gh label create "$name" --color "$color" --description "$desc" --force >/dev/null 2>&1 || \
+    printf "  warn: label '%s' install failed (non-fatal; existing labels often differ in description-only)\n" "$name"
+}
+
+# v3-bootstrap labels (mirror of scripts/ensure_v3_labels.sh — call it
+# directly when not dry-run to inherit any future updates there).
+if [ -n "$DRY_RUN" ]; then
+  # Mirror the spec inline for dry-run visibility.
+  ensure_label "status:proposed" "FBCA04" "Directive proposed; awaiting maintainer triage (SPEC §2.1 v3)"
+  ensure_label "status:blocked"  "B60205" "Directive cannot proceed without external input (SPEC §5.17)"
+  ensure_label "task"            "C5DEF5" "Standalone task or small improvement (not parented under a Directive)"
+  ensure_label "needs-triage"    "D4C5F9" "Issue filed without a template — awaiting maintainer triage classification"
+  ensure_label "discussion"      "FEF2C0" "Observation or half-formed idea; close as promoted (#M) or no-action (SPEC §5.19)"
+else
+  bash "$CLAUDE_ENG_SHELL_ROOT/scripts/ensure_v3_labels.sh" 2>&1 | sed 's/^/  /'
+fi
+
+# Additional labels not in ensure_v3_labels.sh (directive + priorities).
+ensure_label "directive" "0E8A16" "Directive Issue (dir-mode, SPEC §1.7)"
+ensure_label "P0" "B60205" "Priority 0 — drop everything"
+ensure_label "P1" "D93F0B" "Priority 1 — next"
+ensure_label "P2" "FBCA04" "Priority 2 — soon"
+ensure_label "P3" "0E8A16" "Priority 3 — eventually"
+
+echo "onboard_target: tier 2 labels done (10 total: 5 from ensure_v3_labels.sh + 5 inline)."
 
 if [ "$TIER" = 2 ]; then
   audit_log info onboard-dir-mode created "target=$TARGET_OWNER_REPO tier=2 labels=10"

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -4932,6 +4932,26 @@ else
   ng "63f: /onboard-dir-mode missing ADR-0004 reference (#118)"
 fi
 
+# §63g: tier-2 dry-run produces label-create lines for BOTH status:proposed
+# AND status:blocked. Regression guard for the v0 parser bug (caught at
+# PR #119 code-review) where `:`-delimited parsing on `status:proposed:FBCA04...`
+# would split as name=status / color=proposed / desc=FBCA04:... silently
+# dropping the two `status:*` labels. The smoke §63d --tier 1 path didn't
+# exercise label parsing; §63g closes the gap.
+s63g_out=$("$SHELL_ROOT/scripts/onboard_target.sh" --tier 2 --dry-run 2>&1 || true)
+s63g_ok=1
+for required in "status:proposed" "status:blocked" "discussion" "task" "needs-triage"; do
+  if ! printf '%s' "$s63g_out" | grep -qE "gh label create '$required'"; then
+    s63g_ok=0
+    break
+  fi
+done
+if [ "$s63g_ok" = 1 ]; then
+  ok "63g: onboard_target --tier 2 --dry-run emits gh label create for all v3-bootstrap labels including status:proposed + status:blocked (#118)"
+else
+  ng "63g: onboard_target --tier 2 --dry-run missing one or more required labels (regression-guard for label-parser drift) (#118)"
+fi
+
 # ---------- restore registry ----------
 if [ -n "$ORIG_REG_BAK" ]; then
   mv "$ORIG_REG_BAK" "$ORIG_REG"

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -4859,6 +4859,79 @@ else
   ng "62f: /triage missing stale-discussion surface logic (#116)"
 fi
 
+# ---------- 63. target-substrate implementation: canonical dir + /onboard-dir-mode + preflight (#118) ----------
+# Issue #118 (final slice of Directive #107) ships the install machinery:
+# canonical-source directory, /onboard-dir-mode skill, scripts/onboard_target.sh,
+# and per-command graceful-degradation preflight references.
+
+# §63a: canonical-source directory has the 9 expected files.
+S63_SUB="$SHELL_ROOT/.claude/templates/target-substrate"
+s63a_count=0
+for f in ISSUE_TEMPLATE/config.yml ISSUE_TEMPLATE/directive-proposal.yml \
+         ISSUE_TEMPLATE/execution-under-directive.yml ISSUE_TEMPLATE/task.yml \
+         ISSUE_TEMPLATE/bug-report.yml ISSUE_TEMPLATE/discussion.yml \
+         workflows/auto-needs-triage.yml workflows/issues-to-project-mirror.yml \
+         workflows/dir-mode-post-merge.yml; do
+  [ -f "$S63_SUB/$f" ] && s63a_count=$((s63a_count + 1))
+done
+if [ "$s63a_count" = 9 ]; then
+  ok "63a: target-substrate canonical-source has 9 files (6 ISSUE_TEMPLATE + 3 workflows) (#118)"
+else
+  ng "63a: target-substrate canonical-source missing files: expected 9, found $s63a_count (#118)"
+fi
+
+# §63b: /onboard-dir-mode skill file exists with tiered procedure.
+if [ -f "$SHELL_ROOT/.claude/commands/onboard-dir-mode.md" ] \
+   && grep -q "Tier 1" "$SHELL_ROOT/.claude/commands/onboard-dir-mode.md" \
+   && grep -q "Tier 2" "$SHELL_ROOT/.claude/commands/onboard-dir-mode.md" \
+   && grep -q "Tier 3" "$SHELL_ROOT/.claude/commands/onboard-dir-mode.md"; then
+  ok "63b: /onboard-dir-mode skill names all 3 tiers (#118)"
+else
+  ng "63b: /onboard-dir-mode skill missing or lacks tier-aware procedure (#118)"
+fi
+
+# §63c: scripts/onboard_target.sh exists + executable + handles --tier flag.
+if [ -x "$SHELL_ROOT/scripts/onboard_target.sh" ] \
+   && grep -q -- "--tier" "$SHELL_ROOT/scripts/onboard_target.sh" \
+   && grep -q "gh label create" "$SHELL_ROOT/scripts/onboard_target.sh"; then
+  ok "63c: scripts/onboard_target.sh executable + tier-aware (#118)"
+else
+  ng "63c: scripts/onboard_target.sh missing or lacks tier handling (#118)"
+fi
+
+# §63d: scripts/onboard_target.sh --tier 1 --dry-run is a no-op (idempotent).
+s63d_rc=0
+"$SHELL_ROOT/scripts/onboard_target.sh" --tier 1 --dry-run >/dev/null 2>&1 || s63d_rc=$?
+# The script exits 1 if `gh repo view` cannot resolve (not in a gh repo context).
+# Smoke runs from the shell repo where gh is authed, so exit 0 expected. If
+# gh auth is missing, accept rc=1 as graceful-failure (per ADR-0004 fail-open).
+if [ "$s63d_rc" = 0 ] || [ "$s63d_rc" = 1 ]; then
+  ok "63d: onboard_target.sh --tier 1 --dry-run is non-destructive (rc=$s63d_rc; expected 0 or 1) (#118)"
+else
+  ng "63d: onboard_target.sh --tier 1 --dry-run unexpected rc=$s63d_rc (#118)"
+fi
+
+# §63e: each of the 7 dir-mode command procedure files contains a "step 0 preflight" reference.
+s63e_count=0
+for cmd in file-directive activate-directive complete-directive revise-directive \
+           block-directive list-directives link-directive; do
+  if grep -qE "Step 0.*preflight|step 0 preflight" "$SHELL_ROOT/.claude/commands/${cmd}.md"; then
+    s63e_count=$((s63e_count + 1))
+  fi
+done
+if [ "$s63e_count" = 7 ]; then
+  ok "63e: all 7 dir-mode commands name 'step 0 preflight' (#118)"
+else
+  ng "63e: 'step 0 preflight' missing in some dir-mode commands: $s63e_count/7 (#118)"
+fi
+
+# §63f: ADR-0004 reversibility paths referenced from /onboard-dir-mode.
+if grep -q "ADR-0004" "$SHELL_ROOT/.claude/commands/onboard-dir-mode.md"; then
+  ok "63f: /onboard-dir-mode references ADR-0004 reversibility framing (#118)"
+else
+  ng "63f: /onboard-dir-mode missing ADR-0004 reference (#118)"
+fi
+
 # ---------- restore registry ----------
 if [ -n "$ORIG_REG_BAK" ]; then
   mv "$ORIG_REG_BAK" "$ORIG_REG"


### PR DESCRIPTION
Closes #118

## Summary

Closes Directive #107. Implementation slice on top of #114's foundation. Ships the 5 deferred artifacts: canonical-source directory, `/onboard-dir-mode` skill, install script, per-command preflight references, smoke §63.

On merge, Directive #107's 8 success signals all satisfied; ready for `/complete-directive 107`.

## Plan

Big-slice approach per the issue body's "final Execution Issue" framing.

### Phase A — Doc(-as-code)
- [x] `.claude/templates/target-substrate/` — 9 canonical files (6 ISSUE_TEMPLATE + 3 workflows).
- [x] `.claude/commands/onboard-dir-mode.md` — tiered skill (Tier 1 no-op / Tier 2 labels / Tier 3 labels + PR-based file installs + Project).
- [x] 7 dir-mode command procedure files — Step 0 substrate preflight added (file-directive, activate-directive, complete-directive, revise-directive, block-directive, list-directives, link-directive).

### Phase B — Test
- [x] Smoke §63 — 6 assertions (canonical files / skill tiers / script tier-aware / dry-run safe / preflight in 7 commands / ADR-0004 ref). Baseline 350 → 356.

### Phase C — Code
- [x] `scripts/onboard_target.sh` — `--tier 1|2|3` + `--dry-run` flags. Label install via `gh label create --force`. File installs via git branch + `gh pr create` (never direct-push, per ADR-0004 Decision 2). Project via `setup_project.sh`.

## Test plan
- [x] Smoke 356/356 (baseline 350 + 6 new §63 assertions).
- [x] §63a — canonical-source has 9 files.
- [x] §63b — skill names all 3 tiers.
- [x] §63c — script tier-aware + executable + label-creation logic.
- [x] §63d — `--tier 1 --dry-run` is non-destructive (rc=0 or 1 graceful-fail).
- [x] §63e — all 7 dir-mode commands name Step 0 preflight.
- [x] §63f — skill references ADR-0004 reversibility framing.

## Docs touched
- 7 dir-mode command files (`.claude/commands/{file,activate,complete,revise,block,list,link}-directive*.md`) — Step 0 preflight insertion.
- `.claude/commands/onboard-dir-mode.md` (new).
- `.claude/templates/target-substrate/` (new directory, 9 canonical files).
- `scripts/onboard_target.sh` (new).
- `scripts/test/smoke.sh` §63 (new section).

## Notes for Directive #107 completion
- All 8 artifacts from #107's Objective are present.
- Bootstrap-label set is the 10-label v3 set per ADR-0004 (#107's body still says "8 labels" but SSOT is SPEC §1.7 + ADR-0004 — flagged in #109's completion comment for #107's housekeeping).
- Per-command graceful-degradation is documented + named in 7 procedure files. Actual runtime enforcement (shell exits with error if substrate missing) is the next iteration; the procedure-file references are the contract.

## Ship gate
- [x] Smoke green (356/356).
- [x] code-reviewer review.
- [x] doc-writer review.
- [x] `Closes #118` present.
