### PR TITLE
docs(#120): post-v3 drift sweep — README counts + MISSION dedupe

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -12,7 +12,7 @@ claude-eng-shell is the engineering scaffold a single Claude Code agent (or huma
 Twelve months out, the shell's success is best summarized as **a Claude Code session running in `unattended` mode against a real engineering issue produces a merged PR whose quality matches what a careful senior engineer would have produced in the same hours.** That requires:
 
 - **The flow holds in unattended runs.** Clean execution end-to-end (issue → branch → Doc → Test → Code → /ship → merge) is the dominant path, not the exception. Hard blockers (incompatible plan, secret detected, AC unticked) surface as audit-logged `parked` states rather than silent regressions.
-- **The directing layer works.** A team that picks up claude-eng-shell uses the dir-mode hierarchy (Goal → Directive → Execution Issue) to plan two or three weeks of work, ship it under reviewer gates, and reach the Directive's success signals without revising the shell. This Goal Item is the first concrete example.
+- **The directing layer works.** A team that picks up claude-eng-shell uses the dir-mode hierarchy (Goal → Directive → Execution Issue) to plan two or three weeks of work, ship it under reviewer gates, and reach the Directive's success signals without revising the shell. claude-eng-shell itself is the first concrete example.
 - **Multiple repos run on it.** At least two unrelated upstream repos — beyond claude-eng-shell itself — adopt the shell as their canonical Claude Code workflow. Each contributes friction back into the SPEC.
 - **The escape hatch stays narrow.** Audit-log queries (`/audit`) show that bypasses (`SKIP_HOOKS=...`) cluster in the small set of legitimate cases the SPEC names — not as a normalized routing around inconvenient gates.
 - **The v1+ orchestrator lands.** Automatic mode-switching between eng-mode and dir-mode, kill-switches, and budget controls (SPEC §0.4) ship after v0 operating experience surfaces the right design for them.
@@ -41,9 +41,6 @@ Secondary users include teams adopting AI-assisted engineering more broadly, who
 - **Future users**: any engineer adopting claude-eng-shell as their Claude Code workflow.
 - **AI agents**: the shell is the operating environment Claude Code reads from; the SPEC is the contract Claude Code is held to.
 
-## Last reviewed: 2026-05-25
-
-
 ---
 
-*Last reviewed: 2026-05-26. Updated by Directive #92 cluster I migration (transcribed from PVTI #84, the v0/v1 Goal Item that this MISSION.md supersedes).*
+*Last reviewed: 2026-05-26. Updated by Directive #92 cluster I migration (transcribed from PVTI #84, the v0/v1 Goal-as-Item artifact that this MISSION.md supersedes).*

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An operating shell for [Claude Code](https://docs.claude.com/claude-code) that r
 - **Doc → Test → Code work order** — strict for `feat`/`docs`/contract changes; relaxed for `fix`/`refactor`/`perf` per SPEC §1.2.
 - **Active SSOT maintenance** — docs change alongside code; merged PR bodies are durable cross-session memory via SessionStart.
 - **Two operating modes** — **eng-mode** handles engineering execution (issue → PR → merge); **dir-mode** handles directing maintenance (Final Goal → Directive → Execution Issue). Same workflow pattern (generate → review → gated approval → audit), different artifact types and reviewer. Manual mode switching in v0 — orchestration is v1+ (SPEC §0.4 / §1.7 / §2.1).
-- **Nine subagents** — `explorer`, `planner`, `doc-writer`, `test-writer`, `code-reviewer`, `security-reviewer`, `issue-reviewer`, `plan-reviewer`, `directive-reviewer`. The five reviewers (`code-`, `security-`, `issue-`, `plan-`, `directive-`) substitute for human-confirm checkpoints in `unattended` mode.
+- **Ten subagents** — `explorer`, `planner`, `doc-writer`, `test-writer`, `code-reviewer`, `security-reviewer`, `issue-reviewer`, `plan-reviewer`, `directive-reviewer`, `triage-reviewer`. The six reviewers (`code-`, `security-`, `issue-`, `plan-`, `directive-`, `triage-`) substitute for human-confirm checkpoints in `unattended` mode.
 - **Hooks enforce discipline** — protected branches, force push, backmerges (`git merge main` on a feature branch), secret exposure, malformed commits, sensitive files, paths outside the registry, `gh pr merge` when a linked issue has unchecked AC and no `## AC closeout` comment (`/ship` step 7.6 invokes `scripts/ac_closeout.sh` to satisfy by construction). Every block is escapable via `SKIP_HOOKS=<category> SKIP_REASON='<why>'` and audit-logged at `.claude/audit/audit.jsonl`. Secret-scan hits emit `<file>:<line>: <pattern-id>` markers and honor a `.shellsecretignore` allow-list at the target-repo root (SPEC §6.1 / §7 — the structural tuning mechanism for repeated false positives, preferred over normalizing `SKIP_HOOKS=secret`). SessionStart warns when a workspace was injected but launched via plain `claude` instead of `claude-eng` (otherwise every hook would silently no-op — see SPEC §6.5(c)).
 
 ## Install
@@ -102,6 +102,6 @@ All optional. Per-target state files live under `.claude/state/` (gitignored); e
 ## Verify
 
 ```bash
-./scripts/test/smoke.sh           # ~280 assertions across hooks, helpers, slash commands
+./scripts/test/smoke.sh           # ~350+ assertions across hooks, helpers, slash commands
 ./scripts/build_toc.sh --check    # SPEC.md TOC freshness
 ```


### PR DESCRIPTION
## Summary

Four small post-v3 drift items in canonical top-level docs surfaced by 2026-05-26 review. Pure text alignment, no behavior change.

Closes #120

## Plan

Single `docs(#120):` commit, two files. Doc → Test → Code does not apply — the change IS the doc; the existing smoke (357 assertions) is the regression check (SPEC §1.2 relaxation). Mirrors precedent set by Issue #73.

### Alternatives considered
- Four separate commits per AC item — rejected: no independent rollback value; obscures the unifying "post-v3 drift sweep" rationale.
- Bundle with a broader doc audit (ENGINEERING_FLOW / SUBAGENTS / ESCAPE_HATCH / SPEC) — rejected: out of scope per Issue body; deserves its own Issue if pursued.

## Changes

| File:line | Was | Now |
|---|---|---|
| README.md:11 | "Nine subagents" + 5 reviewers | "Ten subagents" + 6 reviewers (adds `triage-reviewer`) |
| README.md:105 | `~280 assertions` | `~350+ assertions` (rounded for drift resistance) |
| MISSION.md:44 | duplicate `## Last reviewed: 2026-05-25` H2 | removed (line 49 italic footer is canonical) |
| MISSION.md:15 | "This Goal Item is the first concrete example." | "claude-eng-shell itself is the first concrete example." |
| MISSION.md:46 | "...the v0/v1 Goal Item that this MISSION.md supersedes" | "...the v0/v1 Goal-as-Item artifact that this MISSION.md supersedes" (matches line 4 canonical phrasing) |

## Test plan

- [x] `grep -c 'Last reviewed' MISSION.md` → 1
- [x] `grep -c 'Goal Item' MISSION.md` → 0 (canonical "Goal-as-Item" preserved on lines 4 + 46)
- [x] `ls .claude/agents/*.md | wc -l` → 10 (matches README:11)
- [x] `scripts/test/smoke.sh` → `pass=357 fail=0`
- [x] No anchor links to `#last-reviewed` anywhere in `*.md` (pre-checked before delete)

## Docs

n/a — this PR IS the docs change.