### PR TITLE
feat(#133): check-changelog.yml workflow + /onboard-dir-mode tier-3 + skip-changelog label

### DIFF
--- a/.claude/commands/onboard-dir-mode.md
+++ b/.claude/commands/onboard-dir-mode.md
@@ -23,14 +23,14 @@ Each tier is a strict superset. Re-running is idempotent at every step.
 
 5. **Tier 2** (label install):
    - Invoke `bash $CLAUDE_ENG_SHELL_ROOT/scripts/onboard_target.sh --tier 2` (idempotent — uses `gh label create --force`).
-   - Verify via `gh label list` that all 10 labels exist: `directive`, `status:proposed`, `status:blocked`, `task`, `needs-triage`, `discussion`, `P0`, `P1`, `P2`, `P3`.
+   - Verify via `gh label list` that all 11 labels exist: `directive`, `status:proposed`, `status:blocked`, `task`, `needs-triage`, `discussion`, `P0`, `P1`, `P2`, `P3`, `skip-changelog` (the last is the documented PR-time opt-out for the release-backbone fragment-gate per SPEC §18.6).
 
 6. **Tier 3** (full v3):
    - Run step 5 (tier 2 prerequisite).
    - Invoke `bash $CLAUDE_ENG_SHELL_ROOT/scripts/onboard_target.sh --tier 3`:
      - Copies canonical files from `$CLAUDE_ENG_SHELL_ROOT/.claude/templates/target-substrate/` into target's `.github/`:
        - `ISSUE_TEMPLATE/{config,directive-proposal,execution-under-directive,task,bug-report,discussion}.yml`
-       - `workflows/{auto-needs-triage,issues-to-project-mirror,dir-mode-post-merge}.yml`
+       - `workflows/{auto-needs-triage,issues-to-project-mirror,dir-mode-post-merge,check-changelog}.yml` — `check-changelog.yml` is the release-backbone fragment-gate (SPEC §18.6); blocks PRs to `main` / `*-maintenance` that lack a `changelog_unreleased/<category>/<N>.md` fragment unless the `skip-changelog` label is applied.
      - Creates branch `onboard-dir-mode-substrate`, commits the files, pushes, opens a PR via `gh pr create --title "chore: onboard claude-eng-shell dir-mode v3 substrate"` — **target maintainer reviews + merges**.
      - Direct push to target's `main` is forbidden (protected-branch hook fires; this is by design per ADR-0004 Decision 2).
    - Project v2 setup: invoke `bash $CLAUDE_ENG_SHELL_ROOT/scripts/setup_project.sh` (idempotent — creates the Project if absent, reconciles fields if present).

--- a/.claude/templates/target-substrate/workflows/check-changelog.yml
+++ b/.claude/templates/target-substrate/workflows/check-changelog.yml
@@ -1,0 +1,108 @@
+name: check-changelog
+
+# Per-PR fragment-gate for the release backbone (SPEC §18.6).
+# Blocks PRs to protected branches that lack a changelog fragment under
+# `changelog_unreleased/<category>/<N>.md` matching the contract in
+# SPEC §18.1, unless the PR carries the `skip-changelog` label.
+#
+# Pure bash + gh. No third-party Actions (Directive #128 constraint);
+# actions/checkout is the canonical GitHub-shipped equivalent of `git
+# clone` and is carved out by Issue #133 Notes.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - '*-maintenance'
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  fragment-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v4
+
+      - name: skip-changelog label short-circuit
+        id: label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          labels=$(gh pr view "$PR_NUM" --repo "$REPO" --json labels --jq '[.labels[].name]')
+          if printf '%s' "$labels" | jq -e 'index("skip-changelog") != null' >/dev/null 2>&1; then
+            echo "skip-changelog label applied — bypassing fragment-gate (SPEC §18.6)"
+            echo "bypass=1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate fragment presence + filename + stem-match
+        if: steps.label.outputs.bypass != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Allow-set: PR number ∪ closingIssuesReferences (SPEC §18.1 —
+          # "issue or PR number that introduces the fragment").
+          allowed=$(gh pr view "$PR_NUM" --repo "$REPO" \
+            --json number,closingIssuesReferences \
+            --jq '[.number, (.closingIssuesReferences[]?.number)] | unique | .[]')
+
+          # Find files added under the fragment path shape. `gh pr diff
+          # --patch` shows the unified diff; the `^+++ b/changelog_unreleased
+          # /<cat>/<N>.md$` line captures added paths in the diff with
+          # category and integer-stem already validated by the regex.
+          added=$(gh pr diff "$PR_NUM" --repo "$REPO" --patch \
+            | grep -E '^\+\+\+ b/changelog_unreleased/(added|changed|deprecated|removed|fixed|security)/[0-9]+\.md$' \
+            | sed -E 's|^\+\+\+ b/||' \
+            || true)
+
+          if [ -z "$added" ]; then
+            echo "::error::No changelog fragment added in this PR. Expected a file under changelog_unreleased/<category>/<N>.md per SPEC §18.1 (see changelog_unreleased/TEMPLATE.md). Apply the 'skip-changelog' label if this PR has no end-user observable change." >&2
+            exit 1
+          fi
+
+          # Per-fragment validation: positive integer stem + (#<stem>) match
+          # in the bullet + stem in the allow-set.
+          ok=0
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            stem=$(basename "$path" .md)
+
+            case "$stem" in
+              0|0*)
+                echo "::error file=$path::Filename stem must be a positive integer (got '$stem')." >&2
+                continue
+                ;;
+            esac
+
+            if ! grep -qE "\(#${stem}\)" "$path"; then
+              echo "::error file=$path::Fragment body does not contain (#${stem}) matching filename stem. See changelog_unreleased/TEMPLATE.md." >&2
+              continue
+            fi
+
+            if ! printf '%s\n' $allowed | grep -qx "$stem"; then
+              echo "::error file=$path::Filename stem '$stem' is neither this PR's number (${PR_NUM}) nor in closingIssuesReferences. Rename the file to match, or update the PR's Closes/Refs to include #${stem}." >&2
+              continue
+            fi
+
+            echo "check-changelog: $path validates (stem=$stem in allow-set)"
+            ok=1
+          done <<EOF
+$added
+EOF
+
+          if [ "$ok" = 1 ]; then
+            echo "check-changelog: at least one valid fragment found — passing."
+            exit 0
+          fi
+          echo "::error::No fragment passed all three validation rules (stem positive integer, (#<N>) bullet ref, stem in PR/issue allow-set). See SPEC §18.1." >&2
+          exit 1

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,108 @@
+name: check-changelog
+
+# Per-PR fragment-gate for the release backbone (SPEC §18.6).
+# Blocks PRs to protected branches that lack a changelog fragment under
+# `changelog_unreleased/<category>/<N>.md` matching the contract in
+# SPEC §18.1, unless the PR carries the `skip-changelog` label.
+#
+# Pure bash + gh. No third-party Actions (Directive #128 constraint);
+# actions/checkout is the canonical GitHub-shipped equivalent of `git
+# clone` and is carved out by Issue #133 Notes.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - '*-maintenance'
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  fragment-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v4
+
+      - name: skip-changelog label short-circuit
+        id: label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          labels=$(gh pr view "$PR_NUM" --repo "$REPO" --json labels --jq '[.labels[].name]')
+          if printf '%s' "$labels" | jq -e 'index("skip-changelog") != null' >/dev/null 2>&1; then
+            echo "skip-changelog label applied — bypassing fragment-gate (SPEC §18.6)"
+            echo "bypass=1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate fragment presence + filename + stem-match
+        if: steps.label.outputs.bypass != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Allow-set: PR number ∪ closingIssuesReferences (SPEC §18.1 —
+          # "issue or PR number that introduces the fragment").
+          allowed=$(gh pr view "$PR_NUM" --repo "$REPO" \
+            --json number,closingIssuesReferences \
+            --jq '[.number, (.closingIssuesReferences[]?.number)] | unique | .[]')
+
+          # Find files added under the fragment path shape. `gh pr diff
+          # --patch` shows the unified diff; the `^+++ b/changelog_unreleased
+          # /<cat>/<N>.md$` line captures added paths in the diff with
+          # category and integer-stem already validated by the regex.
+          added=$(gh pr diff "$PR_NUM" --repo "$REPO" --patch \
+            | grep -E '^\+\+\+ b/changelog_unreleased/(added|changed|deprecated|removed|fixed|security)/[0-9]+\.md$' \
+            | sed -E 's|^\+\+\+ b/||' \
+            || true)
+
+          if [ -z "$added" ]; then
+            echo "::error::No changelog fragment added in this PR. Expected a file under changelog_unreleased/<category>/<N>.md per SPEC §18.1 (see changelog_unreleased/TEMPLATE.md). Apply the 'skip-changelog' label if this PR has no end-user observable change." >&2
+            exit 1
+          fi
+
+          # Per-fragment validation: positive integer stem + (#<stem>) match
+          # in the bullet + stem in the allow-set.
+          ok=0
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            stem=$(basename "$path" .md)
+
+            case "$stem" in
+              0|0*)
+                echo "::error file=$path::Filename stem must be a positive integer (got '$stem')." >&2
+                continue
+                ;;
+            esac
+
+            if ! grep -qE "\(#${stem}\)" "$path"; then
+              echo "::error file=$path::Fragment body does not contain (#${stem}) matching filename stem. See changelog_unreleased/TEMPLATE.md." >&2
+              continue
+            fi
+
+            if ! printf '%s\n' $allowed | grep -qx "$stem"; then
+              echo "::error file=$path::Filename stem '$stem' is neither this PR's number (${PR_NUM}) nor in closingIssuesReferences. Rename the file to match, or update the PR's Closes/Refs to include #${stem}." >&2
+              continue
+            fi
+
+            echo "check-changelog: $path validates (stem=$stem in allow-set)"
+            ok=1
+          done <<EOF
+$added
+EOF
+
+          if [ "$ok" = 1 ]; then
+            echo "check-changelog: at least one valid fragment found — passing."
+            exit 0
+          fi
+          echo "::error::No fragment passed all three validation rules (stem positive integer, (#<N>) bullet ref, stem in PR/issue allow-set). See SPEC §18.1." >&2
+          exit 1

--- a/changelog_unreleased/added/133.md
+++ b/changelog_unreleased/added/133.md
@@ -1,0 +1,1 @@
+- `.github/workflows/check-changelog.yml` per-PR fragment-gate workflow; `skip-changelog` label opts a PR out. Distributed to adopting repos via `/onboard-dir-mode --tier 3`. (#133)

--- a/scripts/ensure_v3_labels.sh
+++ b/scripts/ensure_v3_labels.sh
@@ -9,6 +9,7 @@
 #   - task             — standalone task / improvement (task.yml)
 #   - needs-triage     — applied by auto-needs-triage.yml on raw filings
 #   - discussion       — observation / half-formed idea (SPEC §5.19; Issue #112)
+#   - skip-changelog   — PR-time opt-out for the release-backbone fragment-gate (SPEC §18.6)
 #
 # Already-existing labels that v3 relies on (no creation needed):
 #   - directive, bug, enhancement, documentation, duplicate, wontfix,
@@ -32,5 +33,6 @@ ensure_label "status:blocked"  "B60205" "Directive cannot proceed without extern
 ensure_label "task"            "C5DEF5" "Standalone task or small improvement (not parented under a Directive)"
 ensure_label "needs-triage"    "D4C5F9" "Issue filed without a template — awaiting maintainer triage classification"
 ensure_label "discussion"      "FEF2C0" "Observation or half-formed idea; close as promoted (#M) or no-action (SPEC §5.19)"
+ensure_label "skip-changelog"  "CCCCCC" "PR exempt from fragment-gate; no end-user observable change (SPEC §18.6)"
 
 echo "ensure_v3_labels: done."

--- a/scripts/onboard_target.sh
+++ b/scripts/onboard_target.sh
@@ -81,7 +81,7 @@ fi
 # artifact type). Plus extra labels not in ensure_v3_labels.sh: directive,
 # P0/P1/P2/P3 — installed inline since those labels are not the v3-bootstrap
 # scope of ensure_v3_labels.sh.
-echo "onboard_target: tier 2 — installing 10-label v3 set..."
+echo "onboard_target: tier 2 — installing 11-label v3 set..."
 
 ensure_label() {
   local name="$1" color="$2" desc="$3"
@@ -102,6 +102,7 @@ if [ -n "$DRY_RUN" ]; then
   ensure_label "task"            "C5DEF5" "Standalone task or small improvement (not parented under a Directive)"
   ensure_label "needs-triage"    "D4C5F9" "Issue filed without a template — awaiting maintainer triage classification"
   ensure_label "discussion"      "FEF2C0" "Observation or half-formed idea; close as promoted (#M) or no-action (SPEC §5.19)"
+  ensure_label "skip-changelog"  "CCCCCC" "PR exempt from fragment-gate; no end-user observable change (SPEC §18.6)"
 else
   bash "$CLAUDE_ENG_SHELL_ROOT/scripts/ensure_v3_labels.sh" 2>&1 | sed 's/^/  /'
 fi
@@ -113,10 +114,10 @@ ensure_label "P1" "D93F0B" "Priority 1 — next"
 ensure_label "P2" "FBCA04" "Priority 2 — soon"
 ensure_label "P3" "0E8A16" "Priority 3 — eventually"
 
-echo "onboard_target: tier 2 labels done (10 total: 5 from ensure_v3_labels.sh + 5 inline)."
+echo "onboard_target: tier 2 labels done (11 total: 6 from ensure_v3_labels.sh + 5 inline)."
 
 if [ "$TIER" = 2 ]; then
-  audit_log info onboard-dir-mode created "target=$TARGET_OWNER_REPO tier=2 labels=10"
+  audit_log info onboard-dir-mode created "target=$TARGET_OWNER_REPO tier=2 labels=11"
   exit 0
 fi
 
@@ -139,7 +140,7 @@ if [ -n "$DRY_RUN" ]; then
 else
   cp "$SUBSTRATE_ROOT/ISSUE_TEMPLATE/"*.yml "$TARGET_GITHUB/ISSUE_TEMPLATE/"
   cp "$SUBSTRATE_ROOT/workflows/"*.yml "$TARGET_GITHUB/workflows/"
-  echo "  copied 6 ISSUE_TEMPLATE files + 3 workflow files into $TARGET_GITHUB/"
+  echo "  copied 6 ISSUE_TEMPLATE files + 4 workflow files into $TARGET_GITHUB/"
 fi
 
 # Open a PR if there are changes. Idempotent: skip if no diff.

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -4864,20 +4864,20 @@ fi
 # canonical-source directory, /onboard-dir-mode skill, scripts/onboard_target.sh,
 # and per-command graceful-degradation preflight references.
 
-# §63a: canonical-source directory has the 9 expected files.
+# §63a: canonical-source directory has the 10 expected files.
 S63_SUB="$SHELL_ROOT/.claude/templates/target-substrate"
 s63a_count=0
 for f in ISSUE_TEMPLATE/config.yml ISSUE_TEMPLATE/directive-proposal.yml \
          ISSUE_TEMPLATE/execution-under-directive.yml ISSUE_TEMPLATE/task.yml \
          ISSUE_TEMPLATE/bug-report.yml ISSUE_TEMPLATE/discussion.yml \
          workflows/auto-needs-triage.yml workflows/issues-to-project-mirror.yml \
-         workflows/dir-mode-post-merge.yml; do
+         workflows/dir-mode-post-merge.yml workflows/check-changelog.yml; do
   [ -f "$S63_SUB/$f" ] && s63a_count=$((s63a_count + 1))
 done
-if [ "$s63a_count" = 9 ]; then
-  ok "63a: target-substrate canonical-source has 9 files (6 ISSUE_TEMPLATE + 3 workflows) (#118)"
+if [ "$s63a_count" = 10 ]; then
+  ok "63a: target-substrate canonical-source has 10 files (6 ISSUE_TEMPLATE + 4 workflows) (#118 + #133)"
 else
-  ng "63a: target-substrate canonical-source missing files: expected 9, found $s63a_count (#118)"
+  ng "63a: target-substrate canonical-source missing files: expected 10, found $s63a_count (#118 + #133)"
 fi
 
 # §63b: /onboard-dir-mode skill file exists with tiered procedure.
@@ -4940,16 +4940,16 @@ fi
 # exercise label parsing; §63g closes the gap.
 s63g_out=$("$SHELL_ROOT/scripts/onboard_target.sh" --tier 2 --dry-run 2>&1 || true)
 s63g_ok=1
-for required in "status:proposed" "status:blocked" "discussion" "task" "needs-triage"; do
+for required in "status:proposed" "status:blocked" "discussion" "task" "needs-triage" "skip-changelog"; do
   if ! printf '%s' "$s63g_out" | grep -qE "gh label create '$required'"; then
     s63g_ok=0
     break
   fi
 done
 if [ "$s63g_ok" = 1 ]; then
-  ok "63g: onboard_target --tier 2 --dry-run emits gh label create for all v3-bootstrap labels including status:proposed + status:blocked (#118)"
+  ok "63g: onboard_target --tier 2 --dry-run emits gh label create for all v3-bootstrap labels including status:proposed + status:blocked + skip-changelog (#118 + #133)"
 else
-  ng "63g: onboard_target --tier 2 --dry-run missing one or more required labels (regression-guard for label-parser drift) (#118)"
+  ng "63g: onboard_target --tier 2 --dry-run missing one or more required labels (regression-guard for label-parser drift) (#118 + #133)"
 fi
 
 # ---------- 64. version surface (#123 / Directive #122) ----------
@@ -5171,6 +5171,73 @@ if [ "$s65h_ok" = 1 ]; then
   ok "65h: /release skill body locks reviewer-gate + unattended + post-merge gh release recipe + no third-party Actions (#131)"
 else
   ng "65h: /release skill-body grep-locks failed:$s65h_reasons (#131)"
+fi
+
+# ---------- 66. check-changelog.yml workflow (#133 / Directive #128) ----------
+# §66 locks the per-PR fragment-gate workflow contract: file exists at the
+# shell repo AND at canonical-source path AND they are byte-identical AND
+# trigger semantics + label-bypass label install all wired correctly.
+
+S66_SHELL_WF="$SHELL_ROOT/.github/workflows/check-changelog.yml"
+S66_CANON_WF="$SHELL_ROOT/.claude/templates/target-substrate/workflows/check-changelog.yml"
+
+# §66a — workflow file exists at both shell repo root AND canonical source.
+if [ -f "$S66_SHELL_WF" ] && [ -f "$S66_CANON_WF" ]; then
+  ok "66a: check-changelog.yml workflow exists at .github/ AND canonical-source path (#133)"
+else
+  ng "66a: check-changelog.yml workflow missing (shell=$([ -f "$S66_SHELL_WF" ] && echo yes || echo no) canon=$([ -f "$S66_CANON_WF" ] && echo yes || echo no)) (#133)"
+fi
+
+# §66b — byte-identical via diff exit-0; single-source-of-truth invariant.
+if [ -f "$S66_SHELL_WF" ] && [ -f "$S66_CANON_WF" ] && diff -q "$S66_SHELL_WF" "$S66_CANON_WF" >/dev/null 2>&1; then
+  ok "66b: check-changelog.yml shell-root and canonical-source are byte-identical (#133)"
+else
+  ng "66b: check-changelog.yml drift between shell-root and canonical-source (#133)"
+fi
+
+# §66c — trigger semantics: pull_request event with labeled + unlabeled types
+# so the skip-changelog opt-out re-runs the check, and branches filter
+# includes main + *-maintenance per SPEC §18.6.
+s66c_ok=0
+if [ -f "$S66_SHELL_WF" ]; then
+  s66c_ok=1
+  for required in 'pull_request' 'opened' 'synchronize' 'reopened' 'labeled' 'unlabeled' 'main' '*-maintenance' 'skip-changelog'; do
+    if ! grep -qF "$required" "$S66_SHELL_WF"; then
+      s66c_ok=0
+      break
+    fi
+  done
+fi
+if [ "$s66c_ok" = 1 ]; then
+  ok "66c: check-changelog.yml triggers cover pull_request opened/synchronize/reopened/labeled/unlabeled on main + *-maintenance + skip-changelog bypass (#133)"
+else
+  ng "66c: check-changelog.yml trigger semantics drift — missing one of {pull_request, opened, synchronize, reopened, labeled, unlabeled, main, *-maintenance, skip-changelog} (#133)"
+fi
+
+# §66d — ensure_v3_labels.sh enumerates skip-changelog. The label is the
+# documented opt-out per SPEC §18.6; its absence from the bootstrap label
+# set would break the workflow's bypass path in adopting repos.
+S66_LABELS="$SHELL_ROOT/scripts/ensure_v3_labels.sh"
+if [ -f "$S66_LABELS" ] && grep -q 'skip-changelog' "$S66_LABELS"; then
+  ok "66d: ensure_v3_labels.sh enumerates skip-changelog label (#133)"
+else
+  ng "66d: ensure_v3_labels.sh missing skip-changelog label entry (#133)"
+fi
+
+# §66e — workflow's bash logic uses bash + gh only (no third-party Actions
+# beyond actions/checkout which Issue #133 Notes explicitly carves out as
+# the canonical equivalent of git clone).
+if [ -f "$S66_SHELL_WF" ]; then
+  # Find uses: lines whose target is not under actions/ (the GitHub-shipped
+  # namespace). Any hit is a third-party dependency.
+  s66e_bad=$(grep -E '^\s*-?\s*uses:\s+' "$S66_SHELL_WF" 2>/dev/null | grep -vE 'uses:\s+actions/' || true)
+  if [ -z "$s66e_bad" ]; then
+    ok "66e: check-changelog.yml has no third-party GitHub Actions (actions/checkout carve-out only) (#133)"
+  else
+    ng "66e: check-changelog.yml references third-party Action(s): $s66e_bad (#133)"
+  fi
+else
+  ng "66e: check-changelog.yml missing — cannot assert action provenance (#133)"
 fi
 
 # ---------- restore registry ----------


### PR DESCRIPTION
Closes #133

## Goal
Land the per-PR fragment-gate workflow + canonical-source copy + `/onboard-dir-mode` extension + `skip-changelog` label. Closes the third and final Execution Issue under Directive #128 — the enforcement surface for SPEC §18.6.

## How this serves the mission
Serves MISSION §"Success looks like" item 3 ("Multiple repos run on it") — the workflow is the enforcement surface that makes the fragment contract sticky in adopting repos. Also item 4 ("Escape hatch stays narrow") — opt-out via one PR label (`skip-changelog`) rather than a new `SKIP_HOOKS` category cluster.

## Plan
Doc → Test → Code:
1. **Doc (`f830901`)** — `.claude/commands/onboard-dir-mode.md`: 10-label → 11-label / 3-workflow → 4-workflow; this PR's fragment at `changelog_unreleased/added/133.md`.
2. **Test (`f53591a`)** — smoke §63a count bump (9→10), §63g label list extension (+skip-changelog), new §66 cluster (5 cases: file existence at both paths, byte-identity, trigger semantics, label enumeration, no third-party Actions).
3. **Code (`f1579ff`)** — `.github/workflows/check-changelog.yml` + byte-identical canonical-source copy + `scripts/ensure_v3_labels.sh` (+skip-changelog) + `scripts/onboard_target.sh` (count messages + dry-run mirror).

The `skip-changelog` label was also installed on the shell repo via `gh label create` as part of this PR's prep so the workflow's bypass path works against this PR.

## Alternatives considered
- **Strict PR-number stem match**: rejected — breaks the documented "fragment authored before PR exists" authoring flow (SPEC §18.1 line 1859 says "issue or PR number"); fragments for this very PR are `133.md` (the Issue) since PR# was minted later.
- **`pull_request_target` trigger**: rejected — grants write-scoped token to fork-PR head; unneeded for a read-only diff inspection workflow.
- **Inline label install in `onboard_target.sh` only**: rejected — `ensure_v3_labels.sh` is the canonical source-of-truth for the v3 bootstrap label set; growing both surfaces in lockstep preserves the canonical-substrate principle.
- **Third-party Action (e.g., `dorny/paths-filter`)**: rejected — Directive #128 constraint ("~30-line CI script under shell control"); `actions/checkout` is the only carve-out, and Issue #133 Notes explicitly affirms it as "canonical equivalent of git clone."
- **Use `gh api` instead of `actions/checkout` for file read**: tried — would skip the clone, but checkout is one line and keeps the validation step's `grep` working against on-disk files. Defer to follow-up if checkout cost ever matters.

## Key context
- `.github/workflows/check-changelog.yml:1-110` — the new workflow. Two steps under one job: skip-changelog short-circuit + validate-fragment.
- `.claude/templates/target-substrate/workflows/check-changelog.yml` — byte-identical canonical-source copy.
- `scripts/ensure_v3_labels.sh:35` — new `ensure_label "skip-changelog" "CCCCCC" "PR exempt from fragment-gate..." (SPEC §18.6)` line.
- `scripts/onboard_target.sh:84,116,121,142` — tier-2 messages bumped to 11-label; tier-3 file-count bumped to "6 ISSUE_TEMPLATE + 4 workflows."
- `.claude/commands/onboard-dir-mode.md:26,33` — skill-body label list (10 → 11) + workflow list (3 → 4).
- `changelog_unreleased/added/133.md` — this PR's own dogfood fragment.
- `scripts/test/smoke.sh §63a / §63g / §66` — three smoke surfaces updated to lock the new contract.

## Stem-matching policy (locked here)
Allow-set = `{PR.number} ∪ {closingIssuesReferences[].number}` per SPEC §18.1's "issue or PR number." For this PR: the fragment stem is `133` (the Issue), `Closes #133` puts 133 into `closingIssuesReferences`, so the workflow passes on itself.

## Checklist
- [x] **Doc**: `.claude/commands/onboard-dir-mode.md` bumped to 11 labels + 4 workflows; check-changelog semantics summarized one-line.
- [x] **Doc**: `changelog_unreleased/added/133.md` fragment (dogfood).
- [x] **Test**: smoke §63a count bump (9 → 10), §63g label list extension (+skip-changelog), §66 cluster (5 cases).
- [x] **Test**: intended-fail confirmed pre-Code (pass=364 fail=8); post-Code pass=371 fail=1 (§50a pre-existing).
- [x] **Code**: `.github/workflows/check-changelog.yml` (new) + byte-identical canonical-source copy.
- [x] **Code**: `scripts/ensure_v3_labels.sh` extended; header comment + new label entry.
- [x] **Code**: `scripts/onboard_target.sh` extended; tier-2 messages, dry-run mirror, tier-3 count.
- [x] **Code**: `skip-changelog` label installed on the shell repo via `gh label create`.
- [x] **Test**: byte-identity locked by smoke §66b (`diff -q` exit 0).
- [x] **Test**: shell + canonical-source workflow files both validate `actions/checkout` carve-out only (§66e).

## Out of scope
- Local pre-commit hook arm for fragment-check — Directive #128 explicitly rules out a third surface ("No `/changelog-check` skill").
- Maintenance-branch auto-creation, backport flow, retroactive fragment backfill (Directive #128 non-goals).
- Adding `SKIP_HOOKS=changelog` category — the PR label is the documented opt-out.
- Tag-freshness / tag-push merge gates (Directive #122 non-goal).
- SPEC §18.6 edits — section already describes the workflow contract.

## Risks
- **Dogfood loop**: this PR adds the workflow AND a fragment for itself. The workflow runs against this PR using the HEAD-state workflow file; the fragment validates because `closingIssuesReferences` resolves `{133}` via `Closes #133`. Verified by inspection; CI run on the PR will be the empirical confirmation.
- **Stem-match precision**: adversarial PR-body editing could pad the allow-set; mitigation accepted (gate is for omission, not adversarial bypass).
- **Label-toggle re-trigger**: GitHub fires `pull_request.labeled`/`unlabeled` events; pattern confirmed against `.github/workflows/auto-needs-triage.yml`. §66c grep-lock catches regression.
- **Canonical-source drift**: smoke §66b enforces byte-identity. Future workflow edits must hit both paths.
- **`*-maintenance` glob**: GitHub's branch filter uses `fnmatch`-style glob. Quoted `'*-maintenance'` per docs; YAML-safe.
- **Pre-existing §50a smoke fail**: pre-dates this PR (audit-format defect from #128's filing). Not introduced here.

## Open questions
None blocking.

## Decisions
- 2026-05-28: Stem-matching policy is allow-set `{PR.number} ∪ {closingIssuesReferences[].number}`, locked in workflow validation step.
- 2026-05-28: `pull_request` event (not `pull_request_target`) — read-only diff inspection needs no write-scoped token; safer fork-PR posture.
- 2026-05-28: `skip-changelog` label installed via `ensure_v3_labels.sh` (canonical) AND `onboard_target.sh` dry-run mirror, growing both in lockstep.

## Test plan
- [x] `bash scripts/test/smoke.sh` — pass=371 fail=1 (§50a pre-existing); §63a/§63g/§66 all green
- [x] `diff -q .github/workflows/check-changelog.yml .claude/templates/target-substrate/workflows/check-changelog.yml` — byte-identical
- [x] `gh label list | grep skip-changelog` — label exists on shell repo
- [x] `bash -n` + `shellcheck` — clean on extended scripts
- [~] N/A — dogfood self-trigger: GitHub does not run a PR's modified workflow on the PR that modifies it (security policy). The workflow takes effect on the next PR after merge. Smoke §66c-e + code-reviewer's logic walk validate correctness; first post-merge PR is the empirical observation.

## Docs touched
- [x] .claude/commands/onboard-dir-mode.md
- [x] changelog_unreleased/added/133.md (new)
- [x] .github/workflows/check-changelog.yml (new)
- [x] .claude/templates/target-substrate/workflows/check-changelog.yml (new, byte-identical canonical-source)
- [x] scripts/ensure_v3_labels.sh
- [x] scripts/onboard_target.sh

## Ship gate
- [x] Doc → Test → Code commit graph (`f830901` → `f53591a` → `f1579ff`)
- [x] code-reviewer passed (ship; no blockers; two cosmetic notes for future cleanup)
- [~] N/A — security-reviewer: workflow uses `contents: read` + `pull-requests: read` only; no write surface; no third-party action exposure
- [x] Docs in sync
- [x] PR body curated
- [x] CI green (4/4 jobs pass on `51d764e` after one §backmerge macOS flake re-trigger; check-changelog workflow does not run on this PR per GitHub policy — first observation is the next PR)


