### PR TITLE
docs(#137): rewrite README + add MISSION mechanism section

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -7,6 +7,10 @@
 
 claude-eng-shell is the engineering scaffold a single Claude Code agent (or human + Claude pair) lives inside to do work on a GitHub-standard repository. It captures the procedural discipline of senior engineering — issue → branch → draft PR → reviewed commits → ready merge — and renders it as hooks, slash commands, subagents, and audit trails that an AI agent cannot drift past without leaving evidence.
 
+## The mechanism
+
+The mechanism behind this discipline is **context narrowing.** An AI agent's output quality is bounded by the size and relevance of its working context; free-form sessions accumulate noise and drift, and degrade as their windows fill with material irrelevant to the next decision. Every shell mechanism — Doc → Test → Code phasing, subagent isolation, GitHub artifacts as durable memory, hooks-as-environment, reviewers judging from artifacts not conversations — pushes the active context at any moment toward "as small and relevant as possible." Design choices that *grow* context (long-running conversations, shared subagent windows, reviewers primed by discussion, single-shot do-the-whole-task prompts) work against the mechanism even when they look quality-improving in isolation. Directives should be evaluated against this principle, not just against abstract quality — a proposal that improves quality but bloats context is regression, not progress.
+
 ## Success looks like
 
 Twelve months out, the shell's success is best summarized as **a Claude Code session running in `unattended` mode against a real engineering issue produces a merged PR whose quality matches what a careful senior engineer would have produced in the same hours.** That requires:

--- a/README.md
+++ b/README.md
@@ -1,15 +1,34 @@
 # claude-eng-shell
 
-An operating shell for [Claude Code](https://docs.claude.com/claude-code) that runs on top of the standard GitHub workflow. See [SPEC.md](SPEC.md) for the full specification — start from the **Table of contents** at the top of that file and `Read --offset --limit` into the section you care about rather than loading all ~1,300 lines.
+**An opinionated workflow shell for [Claude Code](https://docs.claude.com/claude-code).** It wraps a Claude Code session in the engineering discipline a senior human would apply on a GitHub repository — issue → branch → draft PR → reviewed commits → ready merge — and renders that discipline as hooks, slash commands, subagents, and an audit trail. The point is to let an AI drive end-to-end engineering work without drifting past the checks a careful human would not skip.
 
-## Core ideas
+- **[MISSION.md](MISSION.md)** — what success looks like twelve months out, who this is for, and what is explicitly not a goal.
+- **[SPEC.md](SPEC.md)** — the single self-contained specification (~1,300 lines). Start from the **Table of contents** at the top and read individual sections with `Read --offset --limit` rather than loading the whole file.
 
-- **GitHub-standard backbone** — every change rides issue → branch → draft PR → checklist commits → ready PR → merge. Default base is `main`; topic-branch / experimental work picks an alternate via `/work-on --base <branch>` (SPEC §10.5).
-- **Doc → Test → Code work order** — strict for `feat`/`docs`/contract changes; relaxed for `fix`/`refactor`/`perf` per SPEC §1.2.
-- **Active SSOT maintenance** — docs change alongside code; merged PR bodies are durable cross-session memory via SessionStart.
-- **Two operating modes** — **eng-mode** handles engineering execution (issue → PR → merge); **dir-mode** handles directing maintenance (Final Goal → Directive → Execution Issue). Same workflow pattern (generate → review → gated approval → audit), different artifact types and reviewer. Manual mode switching in v0 — orchestration is v1+ (SPEC §0.4 / §1.7 / §2.1).
-- **Ten subagents** — `explorer`, `planner`, `doc-writer`, `test-writer`, `code-reviewer`, `security-reviewer`, `issue-reviewer`, `plan-reviewer`, `directive-reviewer`, `triage-reviewer`. The six reviewers (`code-`, `security-`, `issue-`, `plan-`, `directive-`, `triage-`) substitute for human-confirm checkpoints in `unattended` mode.
-- **Hooks enforce discipline** — protected branches, force push, backmerges (`git merge main` on a feature branch), secret exposure, malformed commits, sensitive files, paths outside the registry, `gh pr merge` when a linked issue has unchecked AC and no `## AC closeout` comment (`/ship` step 7.6 invokes `scripts/ac_closeout.sh` to satisfy by construction). Every block is escapable via `SKIP_HOOKS=<category> SKIP_REASON='<why>'` and audit-logged at `.claude/audit/audit.jsonl`. Secret-scan hits emit `<file>:<line>: <pattern-id>` markers and honor a `.shellsecretignore` allow-list at the target-repo root (SPEC §6.1 / §7 — the structural tuning mechanism for repeated false positives, preferred over normalizing `SKIP_HOOKS=secret`). SessionStart warns when a workspace was injected but launched via plain `claude` instead of `claude-eng` (otherwise every hook would silently no-op — see SPEC §6.5(c)).
+## Why this shape
+
+A small but load-bearing observation drives the design: **an AI agent's output quality is bounded by the size and relevance of its working context.** A free-form session reads files opportunistically, accumulates conversational digressions, and asks the model to hold the whole task in one window. As that window fills with material that isn't relevant to the next decision, performance degrades — drift, hallucinated invariants, half-finished implementations, lost preconditions.
+
+So the shell does not try to give the agent better instructions for "do the whole task." It instead splits one task into a sequence of **narrow, well-scoped phases**, and pushes everything that doesn't belong in the current phase *out* of the active context. Engineering discipline is the lever; context discipline is the effect:
+
+- **Doc → Test → Code splits the job into three short-context steps.** The doc phase reads the SSOT (MISSION, SPEC, CLAUDE.md). The test phase reads the contract just written + the test rig. The code phase reads the failing test + the relevant implementation. None of the three has to hold the others in working memory, and each phase's output (a doc commit, a failing-test commit, a passing-test commit) is the input the next phase needs — nothing more.
+- **Subagents run in isolated context windows.** `planner`, `doc-writer`, `test-writer`, and the `*-reviewer` family each spawn with a fresh context, do their job, and return a summary. Exploration burn, planning detours, and review reasoning never pollute the main session. The main agent reads a verdict, not a transcript.
+- **GitHub artifacts are the durable memory.** Branch state, draft-PR body, AC checkboxes, merged commit history, audit log — these survive across sessions. A resumed session reads its position from the repo, not from a long conversation transcript that may not exist anymore. SessionStart re-injects only the slice relevant to where the work currently sits.
+- **Hooks enforce the rules so the agent doesn't have to remember them.** Protected-branch commits, secrets in the diff, malformed commit messages, AC-unticked merges — the environment refuses, with an audit-logged escape hatch for the cases that warrant one. The agent's context stays focused on the work, not on policing itself against every rule in the SPEC.
+- **Reviewers judge from the artifact, not the conversation.** `code-reviewer`, `security-reviewer`, `directive-reviewer`, and their peers see the diff + PR body + MISSION — not the discussion that produced them. Arguments that sounded convincing fifty messages ago carry no weight at the gate. This isolation is the point: a fresh reader catches what a primed one cannot.
+
+Put together: the shell's mechanisms are not independent good-engineering practices stacked on each other. They are all aimed at the same lever — keeping the slice of context the model is reasoning over at any given moment as small and relevant as possible.
+
+This is why the shell is structured around a hierarchy of artifacts (`MISSION.md` → Directive Issue → Execution Issue → PR → commits) rather than a long-running conversation. Each level is a context boundary. Each level has its own reviewer. Each level's output is what the next level reads.
+
+## How the loop runs
+
+Two operating layers, both following the same generate → review → gated approval → audit pattern:
+
+- **eng-mode** — engineering execution. `/file-issue` → `/work-on <N>` (creates branch + draft PR) → Doc → Test → Code commits → `/ship` (runs reviewers, ticks AC, marks ready) → merge.
+- **dir-mode** — directing maintenance. `/file-directive` → `/activate-directive` → `/file-issue --parent <N>` to spin out Execution Issues → `/complete-directive` when success signals are met. Manual mode switching in v0; the orchestrator that auto-switches is v1+ (SPEC §0.4).
+
+In `unattended` mode the reviewer subagents substitute for the human approvals at each checkpoint; in `attended` mode (default) the agent stops at PR-ready and waits for a human review.
 
 ## Install
 
@@ -19,30 +38,13 @@ cd claude-eng-shell
 ./scripts/bootstrap.sh
 ```
 
-`bootstrap.sh` only checks dependencies — `git`, `gh`, `jq` are required; `python3` is recommended (used by several helpers; missing python falls back to less-precise behavior). It never modifies `~/.zshrc` or any other user-global file. Add the binary to PATH or alias it yourself:
+`bootstrap.sh` only checks dependencies — `git`, `gh`, `jq` are required; `python3` is recommended (used by several helpers; missing python falls back to less-precise behavior). It never modifies `~/.zshrc` or any other user-global file. Add the binary to `PATH` or alias it yourself:
 
 ```bash
 export PATH="$PWD/bin:$PATH"
 # or
 alias claude-eng="$PWD/bin/claude-eng"
 ```
-
-### Versioning
-
-The shell version is stored in the top-level `VERSION` file as a single line of [semver](https://semver.org) 0.x — `MAJOR.MINOR.PATCH` with `MAJOR=0` throughout v0. Tags follow `v` + semver (e.g., `v0.2.0`).
-
-```bash
-claude-eng --version       # → prints the VERSION-file contents (or `git describe` fallback)
-```
-
-`--version` is short-circuited before registry resolution and the scope guard, so it works from any cwd including unregistered paths.
-
-**v0 conventions** (locked by Directive #122):
-- Format is semver 0.x. Per [SemVer 2.0 §4](https://semver.org/#spec-item-4), 0.x carries no compatibility guarantees — bumps within 0.x are informational signals, not contracts.
-- Bumping out of 0.x (to `1.0.0`) is reserved for the first non-self adopter dogfooding. No hook / CI / onboard enforces semver bump semantics at v0.
-- Tags are pushed manually by the maintainer after a meaningful milestone merges to `main` (no per-PR cadence).
-
-For change-authors: per-PR changelog fragments go under `changelog_unreleased/<category>/<N>.md` — see [`changelog_unreleased/TEMPLATE.md`](changelog_unreleased/TEMPLATE.md) and SPEC §18 (Release backbone) for the contract. [`CHANGELOG.md`](CHANGELOG.md) at repo root holds the consolidated history.
 
 ## Quick start
 
@@ -70,13 +72,13 @@ External paths register too:
 For **dir-mode** (SPEC §1.7), bootstrap the GitHub Project v2 substrate from inside a registered target repo:
 
 ```bash
-./scripts/setup_project.sh         # idempotent — creates "<repo-name> roadmap" with
-                                    # 6 fields and links to the repo. On re-run,
-                                    # reconciles SINGLE_SELECT options additively
-                                    # (preserves user-added options). The Iteration
-                                    # field is user-added via the GH UI (gh CLI lacks
-                                    # the ITERATION data-type). Schema locked by
-                                    # docs/ADRs/0002-…
+./scripts/setup_project.sh   # idempotent — creates "<repo-name> roadmap" with
+                             # 6 fields and links to the repo. On re-run,
+                             # reconciles SINGLE_SELECT options additively
+                             # (preserves user-added options). The Iteration
+                             # field is user-added via the GH UI (gh CLI lacks
+                             # the ITERATION data-type). Schema locked by
+                             # docs/ADRs/0002-…
 ```
 
 ## Operating modes
@@ -87,6 +89,40 @@ For **dir-mode** (SPEC §1.7), bootstrap the GitHub Project v2 substrate from in
 | `unattended` | continues to merge (clean) or park (hard blocker) | overnight runs, batched fixes |
 
 Set per-target with `echo unattended > .claude/state/mode`. Override per-invocation with `/ship --mode=unattended`. See SPEC §5.7.1 for the full resolution priority and blocker classification.
+
+## What the hooks actually enforce
+
+- Protected-branch direct commit/push, force push, `--amend` after push, `--no-verify`
+- Secret patterns in the staged diff (emits `file:line: <id>` markers; path allow-list via `.shellsecretignore` at the target-repo root)
+- Edits to `.env`, `*.pem`, `credentials*`
+- Edit/Write outside the registered scope, and `rm -rf`/`mv -f`/`cp -f` against out-of-registry paths
+- `gh pr merge` when a linked issue has unchecked AC and no `## AC closeout` marker comment (`/ship` step 7.6 invokes `scripts/ac_closeout.sh` to satisfy by construction)
+- Branch creation against a Directive Issue (Directives are not directly executable — must be turned into Execution Issues first via `/file-issue --parent`)
+- `gh issue close` without `--reason completed` on a trusted-filer Issue; `--remove-label directive` from any filer
+
+Every block is escapable via `SKIP_HOOKS=<category> SKIP_REASON='<why>' <command>` and audit-logged at `.claude/audit/audit.jsonl`. SessionStart surfaces silent-no-op states (workspace injected but launched via plain `claude` instead of `claude-eng`, or `hookrt.sh` missing) — otherwise the hooks would evaporate without warning. See SPEC §6.1 / §6.5 / §7 for the full enforcement surface and the structural tuning mechanisms for repeated false positives.
+
+## Subagents
+
+Ten in total: `explorer`, `planner`, `doc-writer`, `test-writer`, `code-reviewer`, `security-reviewer`, `issue-reviewer`, `plan-reviewer`, `directive-reviewer`, `triage-reviewer`. The six reviewers (`code-`, `security-`, `issue-`, `plan-`, `directive-`, `triage-`) substitute for human-confirm checkpoints in `unattended` mode. See [docs/SUBAGENTS.md](docs/SUBAGENTS.md) for when to use each.
+
+## Versioning
+
+The shell version is stored in the top-level `VERSION` file as a single line of [semver](https://semver.org) 0.x — `MAJOR.MINOR.PATCH` with `MAJOR=0` throughout v0. Tags follow `v` + semver (e.g., `v0.2.0`).
+
+```bash
+claude-eng --version       # → prints VERSION-file contents (or `git describe` fallback)
+```
+
+`--version` is short-circuited before registry resolution and the scope guard, so it works from any cwd including unregistered paths.
+
+**v0 conventions** (locked by Directive #122):
+
+- Format is semver 0.x. Per [SemVer 2.0 §4](https://semver.org/#spec-item-4), 0.x carries no compatibility guarantees — bumps within 0.x are informational signals, not contracts.
+- Bumping out of 0.x (to `1.0.0`) is reserved for the first non-self adopter dogfooding. No hook / CI / onboard enforces semver bump semantics at v0.
+- Tags are pushed manually by the maintainer after a meaningful milestone merges to `main` (no per-PR cadence).
+
+For change-authors: per-PR changelog fragments go under `changelog_unreleased/<category>/<N>.md` — see [`changelog_unreleased/TEMPLATE.md`](changelog_unreleased/TEMPLATE.md) and SPEC §18 (Release backbone) for the contract. [`CHANGELOG.md`](CHANGELOG.md) at repo root holds the consolidated history.
 
 ## Configuration toggles
 
@@ -110,11 +146,13 @@ All optional. Per-target state files live under `.claude/state/` (gitignored); e
 
 ## Docs
 
+- [MISSION.md](MISSION.md) — long-term direction and success criteria.
 - [SPEC.md](SPEC.md) — the single self-contained specification (SSOT). Start from the TOC at the top.
 - [docs/ENGINEERING_FLOW.md](docs/ENGINEERING_FLOW.md) — step-by-step engineering flow.
 - [docs/SUBAGENTS.md](docs/SUBAGENTS.md) — subagent usage guide.
 - [docs/ESCAPE_HATCH.md](docs/ESCAPE_HATCH.md) — bypassing hooks safely.
 - [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) — common blocks and fixes.
+- [docs/ADRs/](docs/ADRs/) — architecture decision records for irreversible structural choices.
 
 ## Verify
 


### PR DESCRIPTION
Closes #137

## Goal

Rewrite README.md to make claude-eng-shell legible to a cold reader (what it IS, links to MISSION + SPEC, philosophy of context narrowing) and add a `## The mechanism` section to MISSION.md that canonizes context narrowing as the mechanism `directive-reviewer` can cite when rejecting context-bloating Directives.

## How this serves the mission

References MISSION `## What this exists for`: the shell's purpose is to render senior-engineering discipline so AI agents produce quality output. That paragraph names hooks/agents/audits as enforcement but stops short of naming *why* the discipline produces quality. Without that mechanism in MISSION, future Directives can pass "MISSION fit" on outcome alone ("improves quality") without honoring the lever ("preserves context narrowing"), opening a path for inefficient flows to land under reviewer gates. This PR closes the gap on both sides — the README's "Why this shape" section explains the mechanism for readers, and MISSION's new `## The mechanism` section canonizes it for reviewers.

## Plan

Two coupled docs edits in one PR:

- **README rewrite** — lead with what claude-eng-shell IS, link MISSION + SPEC prominently in the opening list, add a `## Why this shape` section that names context narrowing as the lever and walks through five mechanisms (Doc → Test → Code phasing, subagent isolation, GitHub artifacts as memory, hooks-as-environment, artifact-only reviewers). Reorganize reference material under the conceptual frame. Fix the closing artifact-hierarchy sentence to use post-v3 names (`MISSION.md → Directive Issue → Execution Issue → PR → commits`, matching ADR-0003).
- **MISSION addition** — new `## The mechanism` section between `## What this exists for` and `## Success looks like`. Names context narrowing, enumerates the design choices that serve it, identifies the failure mode (proposals that grow context count as regression even when quality-improving in isolation), and adds the operative clause: *"Directives should be evaluated against this principle, not just against abstract quality."*

## Alternatives considered

- **Two separate PRs (README rewrite + MISSION amendment)** — rejected: the README's "Why this shape" section IS the prose elaboration of MISSION's new clause. Split-merging leaves either MISSION canonizing a principle the README doesn't explain, or the README arguing a philosophy with no MISSION clause for `directive-reviewer` to cite. Editorial coupling, not just convenience.
- **New ADR (`0004-context-narrowing.md`) instead of a MISSION section** — rejected: ADRs lock irreversible structural decisions with rejected alternatives. Context narrowing is a *purpose* statement (the mechanism the shell exists to serve), not a structural choice; belongs in MISSION. Deferrable per Issue body.
- **Philosophy on README only, leave MISSION untouched** — rejected: `directive-reviewer` reads MISSION, not README, when judging MISSION fit. README-only means no canonical citation for the reviewer that needs it most.
- **Add the clause to SPEC.md instead of MISSION.md** — rejected: SPEC describes *how the shell works*; MISSION describes *what it exists to do*. Purpose statement, not specification clause. Also explicitly out of scope per Issue body.
- **Defer the README rewrite, ship MISSION addition alone** — rejected: README has never linked MISSION and has never carried a philosophy section. Shipping the MISSION clause alone leaves the most-visited entry point still misaligned with the new canonical direction.

## Key context

- `MISSION.md:6-8` — pre-existing `## What this exists for` paragraph that names enforcement (hooks/agents/audits) but not the underlying mechanism.
- `MISSION.md:10-12` — new `## The mechanism` section (this PR).
- `README.md:1-22` — new opening + `## Why this shape` (this PR).
- `docs/ADRs/0003-issues-ssot-substrate.md` — Decision 6 establishes MISSION.md as the post-v3 canonical direction; the README's artifact-hierarchy sentence was updated to match.
- `.claude/CLAUDE.md` "Work order" relaxation rule — `docs` change where "the change IS the doc" collapses Doc → Test → Code to Doc-only by construction.

## Checklist

- [x] **Doc**: README opens with a clear one-paragraph "what claude-eng-shell IS" framing and links MISSION.md in the first list (AC #1) — verified at README.md:3-5
- [x] **Doc**: README contains a `## Why this shape` section that names context narrowing and enumerates the five mechanisms (AC #2) — verified at README.md:9-22
- [x] **Doc**: README artifact hierarchy uses post-v3 names — `MISSION.md`, not "Final Goal" (AC #3) — verified at README.md:22
- [x] **Doc**: MISSION.md gains `## The mechanism` between `## What this exists for` and `## Success looks like` (AC #4) — verified at MISSION.md:10-12
- [x] **Doc**: The mechanism section explicitly states Directives should be evaluated against context narrowing, not abstract quality (AC #5) — verified at MISSION.md:12
- [x] **Doc**: All reference material from the prior README preserved — install, quick start, dir-mode bootstrap, operating modes, hooks, subagents, versioning, config table, docs index, verify (AC #6) — verified by diff-walk against `main`
- [x] **Doc**: All linked paths in the new README resolve (AC #7) — verified on disk
- [~] **Test**: N/A — pure prose docs change, no code path to test (CLAUDE.md `docs` relaxation: the change IS the doc)
- [~] **Code**: N/A — pure prose docs change

## Out of scope

- Changes to `SPEC.md` and `.claude/CLAUDE.md` — they remain consistent with the new MISSION clause; revising them would expand scope beyond a docs-clarification PR.
- New ADR locking context-narrowing as an architectural principle — deferrable per Issue body; MISSION clause is sufficient for `directive-reviewer` to cite.
- Updates to `docs/SUBAGENTS.md`, `docs/ENGINEERING_FLOW.md`, or other secondary docs to cross-link the new MISSION section — separate doc-maintenance Issue if needed.
- Smoke assertion that grep-validates README link targets — no existing prose-docs smoke coverage; separate Directive territory.

## Risks

- **Slight recursion**: MISSION's `## What this exists for` and `## The mechanism` both speak to purpose. Mitigation: the new section is scoped distinctly (*how the discipline produces quality*) vs the existing paragraph (*what discipline is rendered*).
- **Drift risk between README "Why this shape" and MISSION `## The mechanism`** — two prose locations articulate the same principle. Future edits should treat MISSION as SSOT and README as exposition; nothing enforces this beyond reviewer attention. Acceptable trade-off given that a single location loses either entry-point exposition or reviewer-citable canonical clause.
- **`directive-reviewer` behavioral change without an SPEC update** — the new MISSION clause gives the reviewer a basis to reject context-growing Directives. SPEC §4.9 doesn't explicitly instruct this lens yet. Mitigation: reviewers read MISSION by construction; if practice warrants the explicit instruction, a follow-up Directive can add it to SPEC.
- **Reference-material preservation is by inspection, not by test** (AC #6) — relies on diff review. Mitigation: AC closeout requires explicit tick.
- **Link rot in the new README** (AC #7) — manual link-walk in the test plan; smoke does not grep-validate README links today.

## Open questions

None blocking.

## Decisions

- MISSION.md is the canonical home for the context-narrowing principle (not README, ADR, or SPEC). Reasoning in `## Alternatives considered` above. This decision is reversible — a future Directive can promote the principle to an ADR if reviewer behavior in practice warrants the stronger artifact.

## Test plan

Pure-prose docs PR. The Doc → Test → Code phasing collapses to Doc-only by construction per CLAUDE.md relaxation. Acceptance is diff review against AC #1–#7.

- [x] Read README diff against AC #1, #2, #3, #6, #7 — code-reviewer confirmed
- [x] Read MISSION diff against AC #4, #5 — code-reviewer confirmed
- [x] `./scripts/test/smoke.sh` passes — pass=373 fail=0
- [x] `./scripts/build_toc.sh --check` passes — clean
- [x] Manually walk every link in the new README to confirm resolution — code-reviewer verified all link targets on disk

## Docs touched

- [x] README.md
- [x] MISSION.md
- [~] SPEC.md — N/A, intentionally out of scope
- [~] CLAUDE.md — N/A, intentionally out of scope

## Ship gate

- [x] All tests pass (smoke 373/0, build_toc --check clean)
- [x] code-reviewer passed (VERDICT: ship)
- [~] security-reviewer — N/A, no auth/input/deps/crypto changes
- [~] Docs in sync — N/A by construction (the PR IS docs; SPEC + CLAUDE.md explicitly out of scope)
- [x] PR body curated
- [x] CI green — 4/4 checks SUCCESS (bash -n + smoke, ubuntu + macos)
