### PR TITLE
docs(#143): SPEC + CLAUDE.md post-v3 terminology consistency

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,7 @@ issue → branch → draft PR → checklist commits → ready PR → merge. Ever
 
 Default autonomy ceiling stops at PR-ready (`attended` mode). See SPEC §5.7.1 for the `unattended` opt-in.
 
-**Dir-mode** (SPEC §1.7) extends the same pattern one level up: Final Goal → Directive → Execution Issue. Same generate → review → gated → audit shape; reviewer is `directive-reviewer` (§4.9). Mode switching is manual in v0; orchestration is v1+ (§0.4). Dir-mode commands live in §5.10–§5.14.
+**Dir-mode** (SPEC §1.7) extends the same pattern one level up: `MISSION.md` → Directive Issue → Execution Issue. Same generate → review → gated → audit shape; reviewer is `directive-reviewer` (§4.9). Mode switching is manual in v0; orchestration is v1+ (§0.4). Dir-mode commands live in §5.10–§5.14.
 
 ## Work order: Doc → Test → Code
 1. **Doc** — Write the behavior/contract to be changed into the SSOT (MISSION, README, CLAUDE.md, ARCHITECTURE, ADR) first.

--- a/SPEC.md
+++ b/SPEC.md
@@ -123,7 +123,7 @@ An operating shell for Claude Code that runs on top of the standard GitHub workf
 The shell covers two layers of the same workflow:
 
 - **Engineering execution** — issue → branch → draft PR → checklist commits → ready PR → merge. Per the GitHub-standard flow.
-- **Directing maintenance** — Final Goal → Directive → Execution Issue, where a Directive is a medium-term directional context that scopes several issues without being directly executable.
+- **Directing maintenance** — `MISSION.md` → Directive Issue → Execution Issue, where a Directive is a medium-term directional context that scopes several issues without being directly executable.
 
 Both layers use the same generate → review → mode-based-approval → audit pattern (§1.5). See §1.7 for the eng-mode / dir-mode split, §2.1 for the Directive lifecycle, §4.9 for the dir-mode reviewer.
 
@@ -157,7 +157,7 @@ The directional layer (§1.7, §2.1, §4.9, §5.10–§5.17) ships in v0 as a th
 - Auto-detection of Directive completion based on success-signal evaluation.
 - Auto-revision of Directives based on engineering outcomes.
 - Directive dependency graph or visualization.
-- Multi-Final-Goal support.
+- Multi-MISSION support (multiple canonical-direction docs per shell instance).
 - External Director-tool integration interface (e.g., webhook receivers).
 - Stop conditions / kill switches / budget controls (deferred with the orchestrator).
 - `roadmap-reviewer` subagent (optional v1+; deferred unless v0 operating experience surfaces real friction).
@@ -278,14 +278,14 @@ The shell operates in two **modes**, distinguished by the *type of artifact* bei
 | Mode | Artifact type | Generate-subagent(s) | Review-subagent | Approval rule |
 |------|---------------|----------------------|------------------|---------------|
 | **eng-mode** | Execution Issue, PR, Commit | `planner`, `doc-writer`, `test-writer`, `explorer` | `code-reviewer`, `security-reviewer`, `issue-reviewer`, `plan-reviewer` | attended: human / unattended: reviewer verdict (§1.5) |
-| **dir-mode** | Directive (Draft Item or Issue), Final Goal | `planner`, `doc-writer`, `explorer` | `directive-reviewer` (§4.9) | attended: human / unattended: `directive-reviewer` verdict |
+| **dir-mode** | Directive Issue | `planner`, `doc-writer`, `explorer` | `directive-reviewer` (§4.9) | attended: human / unattended: `directive-reviewer` verdict |
 
 **Hierarchy of artifacts** that the two modes act on:
 
 ```
-Final Goal           ← human-defined long-term anchor
+MISSION.md           ← human-defined long-term anchor (doc-as-code)
   ↓
-Directive            ← directing context, revisable, medium-term (dir-mode)
+Directive Issue      ← directing context, revisable, medium-term (dir-mode)
   ↓
 Execution Issue      ← concrete unit of work (eng-mode)
   ↓
@@ -831,7 +831,7 @@ The dir-mode workflow (§1.7) uses one new reviewer subagent in v0. A second is 
 
 #### 4.9.2 roadmap-reviewer (v1+, deferred)
 
-Cross-Directive coherence check — Goal alignment, Directive sequencing, drift detection. Not required for v0 (§0.4). Will be designed once v0 operating experience surfaces the friction.
+Cross-Directive coherence check — MISSION alignment, Directive sequencing, drift detection. Not required for v0 (§0.4). Will be designed once v0 operating experience surfaces the friction.
 
 #### 4.9.3 Session-restart caveat for new reviewer subagents
 


### PR DESCRIPTION
Closes #143

## Goal

Bring SPEC.md and `.claude/CLAUDE.md` into post-v3 terminology compliance — completing the cleanup sweep started by PR #138 (README) and PR #142 (MISSION). 5 line edits in SPEC + 1 line edit in CLAUDE.md align the dir-mode artifact vocabulary with MISSION line 4's canonical contract.

## How this serves the mission

References MISSION line 4: *"this document supersedes the v0/v1 Goal-as-Item artifact."* That clause is the project-wide post-v3 terminology contract. `directive-reviewer` reads both MISSION and SPEC when judging Directives; a SPEC/MISSION terminology drift weakens the reviewer's textual ground. After this PR, all four canonical-direction surfaces (MISSION, README, SPEC, CLAUDE.md) speak one vocabulary.

## Plan

Six mechanical line edits in two files. No semantic or behavioral change. SPEC TOC unaffected (no heading touched).

- **SPEC.md §0.1 (L126)** — dir-mode hierarchy in "What this is" → post-v3 names
- **SPEC.md §0.4 (L160)** — "Multi-Final-Goal support" → "Multi-MISSION support (multiple canonical-direction docs per shell instance)"
- **SPEC.md §1.7 (L281)** — modes table dir-mode artifact column: drop "(Draft Item or Issue), Final Goal" → "Directive Issue"
- **SPEC.md §1.7 (L286)** — hierarchy diagram top: "Final Goal" → "MISSION.md (doc-as-code)"; "Directive" → "Directive Issue"
- **SPEC.md §4.9.2 (L834)** — roadmap-reviewer (v1+ deferred): "Goal alignment" → "MISSION alignment"
- **.claude/CLAUDE.md (L10)** — dir-mode pattern intro: post-v3 names (mirror of MISSION:23 fix from PR #142)

## Alternatives considered

- **Split into per-file PRs (SPEC-only + CLAUDE.md-only)** — rejected: the 6 edits share one terminology contract (MISSION.md line 4); splitting fragments the audit trail and doubles review/merge overhead for a 12-line diff.
- **Defer the v1+ borderline polish (§0.4 line 160, §4.9.2 line 834)** — rejected: both surfaces are read TODAY by anyone navigating SPEC; even though they describe v1+ features, leaving stale terminology creates conflicting precedents for readers comparing MISSION vs SPEC.
- **Batch into a larger SPEC review pass** — rejected: Issue #143 is scoped narrowly to terminology consistency; bundling speculative edits would block the cleanup behind an undefined review.
- **Leave §1.7 modes-table parenthetical "(Draft Item or Issue)" intact to preserve v0 history** — rejected: SPEC §1.7 is normative spec, not changelog. v0 history lives in git log, CHANGELOG, and superseded ADRs. Normative tables must reflect current state or they mislead.

## Key context

- `MISSION.md:4` — canonical post-v3 terminology contract.
- `SPEC.md:126,160,281,286,834` — the 5 edit sites.
- `.claude/CLAUDE.md:10` — the 6th edit site, mirror of MISSION:23 fix from PR #142.
- PR #142 — sibling MISSION self-correction; shape precedent.
- PR #138 — README post-v3 rewrite (already merged).
- ADR-0003 Decision 6 — establishes MISSION.md as post-v3 canonical direction.

## Checklist

- [x] **Doc**: SPEC.md §0.1 line 126 uses post-v3 names (`MISSION.md → Directive Issue → Execution Issue`) (AC #2) — code-reviewer verified
- [x] **Doc**: SPEC.md §0.4 line 160 reworded — "Multi-MISSION support" (AC #5) — code-reviewer verified
- [x] **Doc**: SPEC.md §1.7 modes table line 281 — "Directive Issue" only (AC #3) — code-reviewer verified
- [x] **Doc**: SPEC.md §1.7 hierarchy diagram line 286 — `MISSION.md (doc-as-code)` top, "Directive Issue" second level, line-break preservation confirmed (AC #4) — code-reviewer verified
- [x] **Doc**: SPEC.md §4.9.2 line 834 — "MISSION alignment" (AC #6) — code-reviewer verified
- [x] **Doc**: `.claude/CLAUDE.md` line 10 uses post-v3 names (AC #7) — code-reviewer verified
- [x] **Doc**: `grep -nE "Final Goal|Goal →" SPEC.md .claude/CLAUDE.md` returns no matches (AC #1) — code-reviewer ran and confirmed empty
- [x] **Doc**: no changes to README.md, MISSION.md, or any ADR (AC #8) — `git diff --name-only main..HEAD` shows only `SPEC.md` + `.claude/CLAUDE.md`
- [x] **Doc**: CHANGELOG.md, MISSION.md footer/header, ADR-0001/0002/0003 historical references preserved (AC #9) — code-reviewer verified
- [~] **Test**: N/A — pure-prose docs, mechanical terminology fix, Doc-only collapse
- [~] **Code**: N/A — pure-prose docs change

## Out of scope

- README.md — already post-v3 per PR #138
- MISSION.md — already post-v3 per PR #142
- ADRs (0001, 0002, 0003) — body content is frozen historical record
- CHANGELOG.md — release notes are append-only historical record
- SPEC.md PR-body template row at L1582 (`## Goal` section header) — template prose, not the artifact
- Vocabulary alignment between MISSION's `## The mechanism` P2/P3 (deferred from PR #140)

## Risks

- **§1.7 line 286 hierarchy diagram is a multi-line code block** — line-break and indentation preservation verified by code-reviewer.
- **§1.7 modes-table change drops "Final Goal" from artifact-type column entirely** — correct per post-v3 (MISSION.md is doc-as-code direction, not a dir-mode artifact). Explicitly called out in Decisions.
- **§0.4 L160 and §4.9.2 L834 polish v1+-adjacent wording** — when v1+ orchestration is designed, those sentences may need revisiting. Mitigation: pure renames, no re-architecting.
- **No code / hook / compat / perf / data / security impact** — pure prose.

## Open questions

None.

## Decisions

- §1.7 modes table dir-mode artifact column reflects post-v3 only: just "Directive Issue." MISSION.md is the canonical direction Directives reference, not a dir-mode artifact. Pre-v3 "Draft Item" form fully retired (ADR-0003 Decision 6).
- 3-level hierarchy used in §0.1 to match README's framing of dir-mode scope; §1.7 diagram extends to PR / merge.

## Test plan

- [x] `grep -nE "Final Goal|Goal →" SPEC.md .claude/CLAUDE.md` returns empty — code-reviewer confirmed
- [x] `git diff --name-only main..HEAD` shows only `SPEC.md` + `.claude/CLAUDE.md` — confirmed
- [x] `./scripts/test/smoke.sh` passes — pass=373 fail=0
- [x] `./scripts/build_toc.sh --check` passes — TOC-OK
- [x] Visual inspection of `SPEC.md` line 286 hierarchy diagram — line-break preservation confirmed by code-reviewer

## Docs touched

- [x] SPEC.md
- [x] .claude/CLAUDE.md
- [~] README.md — N/A (already post-v3 per PR #138)
- [~] MISSION.md — N/A (already post-v3 per PR #142)

## Ship gate

- [x] All tests pass (smoke 373/0, build_toc clean)
- [x] code-reviewer passed (VERDICT: ship; all 11 ACs verified)
- [~] security-reviewer — N/A, no auth/input/deps/crypto changes
- [~] Docs in sync — N/A by construction
- [x] PR body curated
- [x] CI green — 4/4 SUCCESS (bash -n + smoke, ubuntu + macos)