### PR TITLE
docs(#147): README expansion — dir-mode walkthrough + topic-branch + more commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,49 @@ External paths register too:
 # or: claude-eng ~/code/<repo>   ← unregistered path prompts to register
 ```
 
+### Dir-mode: Directive-scoped work
+
+A **Directive** is a medium-term directional context that scopes one or more Execution Issues (SPEC §1.7, §2.1). Use one when the work crosses 2-3 PRs or needs a coherent "why are we doing this" anchor — a refactor, a migration, a feature with subsystems. For one-off changes, regular `/file-issue` is enough.
+
+**Single-Directive flow (most common):**
+
+```bash
+# Inside the session:
+> /file-directive               # author Directive; status:proposed, reviewer-gated
+> /activate-directive <N>       # Proposed → Active (removes status:proposed)
+> /file-issue --parent <N> <description>   # spawn Execution Issue parented under Directive #N
+> /work-on <execution-#>        # eng-mode from here on
+> /ship
+# ... repeat /file-issue --parent / /work-on / /ship per Execution Issue ...
+> /complete-directive <N>       # reviewer evaluates closed-Execution-Issue evidence
+```
+
+**Multi-PR Directive with topic-branch isolation (SPEC §10.5):**
+
+When the work spans several PRs and you want isolation from `main` until consolidation:
+
+```bash
+# Create the topic branch from main (the shell does NOT auto-create it):
+$ git checkout main && git pull
+$ git checkout -b feature/directive-<N> && git push -u origin feature/directive-<N>
+
+# Inside the session, for each Execution Issue under the Directive:
+> /file-issue --parent <N> <description>
+> /work-on <execution-#> --base feature/directive-<N>   # sub-task PR; uses Refs #<execution-#>
+> /ship
+
+# When all Execution Issues are done, consolidate to main:
+$ gh pr create --base main --head feature/directive-<N> \
+    --title "..." --body "Closes #<exec-1>"$'\n'"Closes #<exec-2>..."
+
+# Then close the Directive:
+> /complete-directive <N>
+```
+
+The Directive Issue itself is never branched — the `directive-protect` hook blocks `git checkout -b` against a Directive Issue. The Directive scopes the work; the Execution Issues do the work.
+
+### Dir-mode substrate (Project v2)
+
 For **dir-mode** (SPEC §1.7), bootstrap the GitHub Project v2 substrate from inside a registered target repo:
 
 ```bash
@@ -105,6 +148,20 @@ Every block is escapable via `SKIP_HOOKS=<category> SKIP_REASON='<why>' <command
 ## Subagents
 
 Ten in total: `explorer`, `planner`, `doc-writer`, `test-writer`, `code-reviewer`, `security-reviewer`, `issue-reviewer`, `plan-reviewer`, `directive-reviewer`, `triage-reviewer`. The six reviewers (`code-`, `security-`, `issue-`, `plan-`, `directive-`, `triage-`) substitute for human-confirm checkpoints in `unattended` mode. See [docs/SUBAGENTS.md](docs/SUBAGENTS.md) for when to use each.
+
+## More commands
+
+The full command surface is documented in SPEC §5; the most-used ones beyond `/file-issue` / `/work-on` / `/ship` / dir-mode:
+
+- `/discuss <observation>` — friction-free filing for "weird but not a bug" observations (SPEC §5.19). Bypasses the rationale-triad gate; close as promoted (concrete Issue filed) or no-action.
+- `/audit [--last <N>] [--category <cat>]` — query the audit log for recent blocks, escapes, warns. Use when debugging a hook that fired unexpectedly.
+- `/status` — one-shot summary of current branch / issue / PR / phase state.
+- `/release <X.Y.Z>` — cut a versioned release (consolidates per-PR changelog fragments; SPEC §18).
+- `/onboard-dir-mode` — install the v3 dir-mode substrate (labels, Issue templates, workflows, Project v2) into a target repo. Tier-aware, idempotent.
+- `/loop <interval> <command>` and `/schedule` — automation modes for recurring tasks (overnight watchers, scheduled remote agents).
+- `/verify` — run the app to confirm a change works in real behavior (not just tests). Use before reporting a UI / behavior change as done.
+
+If a hook blocked you, start with [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) and [docs/ESCAPE_HATCH.md](docs/ESCAPE_HATCH.md).
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,12 @@ $ git checkout -b feature/directive-<N> && git push -u origin feature/directive-
 > /ship
 
 # When all Execution Issues are done, consolidate to main:
-$ gh pr create --base main --head feature/directive-<N> \
-    --title "..." --body "Closes #<exec-1>"$'\n'"Closes #<exec-2>..."
+$ gh pr create --base main --head feature/directive-<N> --title "..." --body "$(cat <<'EOF'
+Closes #<exec-1>
+Closes #<exec-2>
+...
+EOF
+)"
 
 # Then close the Directive:
 > /complete-directive <N>
@@ -154,12 +158,10 @@ Ten in total: `explorer`, `planner`, `doc-writer`, `test-writer`, `code-reviewer
 The full command surface is documented in SPEC §5; the most-used ones beyond `/file-issue` / `/work-on` / `/ship` / dir-mode:
 
 - `/discuss <observation>` — friction-free filing for "weird but not a bug" observations (SPEC §5.19). Bypasses the rationale-triad gate; close as promoted (concrete Issue filed) or no-action.
-- `/audit [--last <N>] [--category <cat>]` — query the audit log for recent blocks, escapes, warns. Use when debugging a hook that fired unexpectedly.
+- `/audit [<filter>]` — query the audit log for recent blocks, escapes, warns. Filter is a substring match against the log (e.g., `/audit force-push`, `/audit escape`). Use when debugging a hook that fired unexpectedly.
 - `/status` — one-shot summary of current branch / issue / PR / phase state.
 - `/release <X.Y.Z>` — cut a versioned release (consolidates per-PR changelog fragments; SPEC §18).
-- `/onboard-dir-mode` — install the v3 dir-mode substrate (labels, Issue templates, workflows, Project v2) into a target repo. Tier-aware, idempotent.
-- `/loop <interval> <command>` and `/schedule` — automation modes for recurring tasks (overnight watchers, scheduled remote agents).
-- `/verify` — run the app to confirm a change works in real behavior (not just tests). Use before reporting a UI / behavior change as done.
+- `/onboard-dir-mode [--tier 1|2|3] [--dry-run]` — install the v3 dir-mode substrate (labels, Issue templates, workflows, Project v2) into a target repo. Tier-aware, idempotent.
 
 If a hook blocked you, start with [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) and [docs/ESCAPE_HATCH.md](docs/ESCAPE_HATCH.md).
 


### PR DESCRIPTION
Closes #147

## Goal

Three additive expansions to `README.md` to close coverage gaps surfaced by post-PR-#146 README audit: a worked dir-mode walkthrough, the topic-branch × Directive variant, and a `## More commands` section indexing useful shell commands that weren't visible in README before.

## How this serves the mission

References MISSION `## Success looks like`: *"The directing layer works. A team that picks up claude-eng-shell uses the dir-mode hierarchy (`MISSION.md` → Directive Issue → Execution Issue) to plan two or three weeks of work."* The README is the primary entry point for that audience. Pre-this-PR, `## How the loop runs` named dir-mode in one line but never showed the workflow. PR #146 made the topic-branch × Directive pattern discoverable in SPEC; this PR brings the same discoverability to README. Closes the README/SPEC asymmetry for the dir-mode success criterion.

## Plan

Three additive blocks, all in `README.md`:

- **`### Dir-mode: Directive-scoped work` subsection** inside `## Quick start`, between External-paths and dir-mode-substrate blocks. Opens with "when to use a Directive" and gives Single-Directive flow + Multi-PR topic-branch variant code blocks.
- **Single-Directive flow** shows: `/file-directive` → `/activate-directive` → `/file-issue --parent <N>` → `/work-on <execution-#>` → `/ship` → repeat → `/complete-directive`.
- **Multi-PR Directive with topic-branch isolation** shows: manual `git checkout -b feature/directive-<N>` from main, per-Execution-Issue `/work-on --base feature/directive-<N>` producing `Refs` sub-PRs, consolidator `gh pr create` with `Closes` lines, then `/complete-directive`. Notes the directive-protect hook blocks branching against a Directive Issue itself.
- **`## More commands` section** between `## Subagents` and `## Versioning`, naming five shell commands beyond the core flow: `/discuss`, `/audit`, `/status`, `/release`, `/onboard-dir-mode`. Includes pointer to `docs/TROUBLESHOOTING.md` + `docs/ESCAPE_HATCH.md` for hook-block recovery.

Total: 65 additive lines, 6 changed during code-reviewer fix pass. Single file.

## Alternatives considered

- **Split into 2 PRs (Quick-start expansion vs `## More commands`)** — rejected: doubles review overhead for a single-file change; the two blocks share dir-mode framing.
- **Expand `docs/ENGINEERING_FLOW.md` instead of README** — rejected: the gap is at the README level. New readers don't reach ENGINEERING_FLOW.md before forming a mental model.
- **Restructure `## How the loop runs` to carry the worked examples** — rejected: that section is concept-shaped (Doc → Test → Code + operating modes); grafting worked examples muddles its purpose. Quick start is the right home.
- **Defer until first non-self adopter feedback** — rejected: the dir-mode reframe completed 2 days ago, PR #146 just landed the topic-branch × Directive clarification, and README still describes only eng-mode.

## Key context

- `README.md` — target file.
- `SPEC.md §10.5` (topic-branch / multi-PR) — normative source the walkthrough cross-references; expanded in PR #146.
- `SPEC.md §5.10–§5.18` (dir-mode commands) and `§5.19` (`/discuss`) — normative source for `## More commands`.
- `MISSION.md ## Success looks like` — the "directing layer works" criterion this PR serves.
- `.claude/commands/audit.md` / `onboard-dir-mode.md` — verified by code-reviewer that README's argument-hint matches actual skill spec.
- PR #146 — predecessor that documented topic-branch × Directive in SPEC.

## Code-reviewer iteration

First-pass code-reviewer returned `block` with one blocker + three nits. All addressed in fix commit `6ad565b`:

- **B1 (blocker)**: dropped `/loop`, `/schedule`, `/verify` from `## More commands` — they are Claude Code-level skills, not part of the shell's command surface (SPEC §5). Including them under "the full command surface is documented in SPEC §5" was misleading. Issue #147 AC #6 was updated to reflect the corrected list, and a new AC #7 added for command-syntax accuracy.
- **N1**: `/audit [--last <N>] [--category <cat>]` was invented flags. Fixed to `/audit [<filter>]` per `.claude/commands/audit.md`.
- **N2**: `gh pr create ... --body "Closes #<exec-1>"$'\n'"..."` used confusing ANSI-C quoting. Rewrote with heredoc `--body "$(cat <<'EOF' ... EOF)"` per repo convention.
- **N3**: `/onboard-dir-mode` was missing argument-hint. Added `[--tier 1|2|3] [--dry-run]`.

Re-review verdict: `ship`.

## Checklist

- [x] **Doc**: `## Quick start` gains `### Dir-mode: Directive-scoped work` subsection between External-paths and dir-mode-substrate blocks (AC #1) — verified at README.md:72
- [x] **Doc**: Single-Directive flow code block with full lifecycle (AC #2) — verified at README.md:74-87
- [x] **Doc**: Multi-PR Directive with topic-branch isolation code block (AC #3) — verified at README.md:89-113
- [x] **Doc**: subsection notes directive-protect hook (AC #4) — verified at README.md:115
- [x] **Doc**: new `## More commands` section between `## Subagents` and `## Versioning` (AC #5) — verified at README.md:156
- [x] **Doc**: names `/discuss`, `/audit`, `/status`, `/release`, `/onboard-dir-mode` (AC #6, tightened from earlier draft) — verified at README.md:159-164
- [x] **Doc**: command syntax matches actual skill argument-hints (AC #7) — `/audit [<filter>]` + `/onboard-dir-mode [--tier 1|2|3] [--dry-run]` verified against command files
- [x] **Doc**: points to `docs/TROUBLESHOOTING.md` + `docs/ESCAPE_HATCH.md` (AC #8) — verified at README.md:166
- [x] **Doc**: no changes to MISSION.md, SPEC.md, CLAUDE.md, or any ADR (AC #9) — `git diff --name-only main..HEAD` shows only README.md
- [x] **Doc**: `git diff --name-only main..HEAD` shows only `README.md` (AC #10) — confirmed
- [~] **Test**: N/A — pure-prose docs change, Doc-only collapse (CLAUDE.md relaxation)
- [~] **Code**: N/A — pure-prose docs change

## Out of scope

- "Things go wrong" worked examples — pointer to TROUBLESHOOTING.md is sufficient
- Cross-repo adoption walkthrough — MISSION covers this
- `## How the loop runs` rewrite
- Subagent walkthrough — that's docs/SUBAGENTS.md
- Sample-session terminal transcript — future doc
- Lifecycle ASCII diagram — prose is sufficient
- Claude Code-level skills (`/loop`, `/schedule`, `/verify`) — not part of the shell's command surface (dropped per B1)

## Risks

- **Quick-start concentration**: section grew to ~85 lines covering eng-mode + dir-mode. If it gets longer, splitting into `## Quick start (eng mode)` + `## Quick start (dir mode)` becomes the natural refactor. Tracked here.
- **README/SPEC drift**: README summarizes; SPEC §10.5 and §5.10–§5.18 are normative. Mitigation: every cross-reference names its SPEC section by number for grep-ability.
- **`## More commands` maintenance surface**: now-active second update site for command syntax. Mitigation: entries are one-liners pointing at SPEC sections; the code-reviewer iteration caught the initial sync gap.
- **No code / hook / compat / perf / data / security impact** — pure prose.

## Open questions

None blocking.

## Decisions

- Dir-mode walkthrough goes in Quick start (not in `## How the loop runs` or `docs/ENGINEERING_FLOW.md`). Quick start is where readers go for "here's what you actually do."
- Single-Directive and multi-PR-topic-branch shown as one subsection with two code blocks. The multi-PR pattern is a variation, not a separate concept.
- `## More commands` only includes shell commands (not Claude Code-level skills). Section framing says "the full command surface is documented in SPEC §5"; mixing in non-shell skills would contradict the framing.

## Test plan

- [x] `grep -n "### Dir-mode: Directive-scoped work" README.md` returns 1 line — confirmed
- [x] `grep -n "Multi-PR Directive with topic-branch isolation" README.md` returns 1 line — confirmed
- [x] `grep -n "## More commands" README.md` returns 1 line — confirmed
- [x] `git diff --name-only main..HEAD` shows only `README.md` — confirmed
- [x] `./scripts/test/smoke.sh` passes — pass=373 fail=0
- [x] `./scripts/build_toc.sh --check` passes — SPEC TOC unaffected

## Docs touched

- [x] README.md (3 additive blocks)
- [~] MISSION.md — N/A, intentionally out of scope
- [~] SPEC.md — N/A, intentionally out of scope
- [~] CLAUDE.md — N/A, intentionally out of scope

## Ship gate

- [x] All tests pass (smoke 373/0, build_toc clean)
- [x] code-reviewer passed (re-review after fix: VERDICT: ship; first-pass block fully addressed)
- [~] security-reviewer — N/A, no auth/input/deps/crypto changes
- [~] Docs in sync — N/A by construction
- [x] PR body curated
- [x] CI green — 4/4 SUCCESS (bash -n + smoke, ubuntu + macos)