### PR TITLE
docs(#151): drop (dir-mode v3) qualifiers from dir-mode commands + reviewer agent descriptions

### DIFF
--- a/.claude/agents/directive-reviewer.md
+++ b/.claude/agents/directive-reviewer.md
@@ -19,12 +19,12 @@ Your job is to stop weak Directives from landing and to refuse premature complet
   - **Success signals** — verifiable conditions for completion.
   - **Non-goals** — explicit exclusions.
   - **Constraints** — what must hold throughout.
-  - **MISSION fit** — which `MISSION.md` section or success criterion does this Directive serve? (dir-mode v3 reframe / ADR-0003: MISSION.md is the canonical repo direction; the `Parent Goal` field from v0/v1 is removed — see header note below.)
+  - **MISSION fit** — which `MISSION.md` section or success criterion does this Directive serve? (MISSION.md is the canonical repo direction; see header note below.)
 - The list of currently `Active` Directives — fetch with:
   ```
   gh issue list --label directive --label '-status:proposed' --state open --json number,title,body --limit 100
   ```
-  Or the equivalent search query `is:open label:directive -label:status:proposed`. An open `directive`-labeled Issue without `status:proposed` is `Active` per the v3 4-state lifecycle (SPEC §2.1). The 100-cap is a heuristic; if hit, surface in the verdict reason.
+  Or the equivalent search query `is:open label:directive -label:status:proposed`. An open `directive`-labeled Issue without `status:proposed` is `Active` per the 4-state lifecycle (SPEC §2.1). The 100-cap is a heuristic; if hit, surface in the verdict reason.
 
 **For completion review:**
 - The Directive's body (success signals as written at activation time).
@@ -87,7 +87,7 @@ Before the verdict, produce a short structured report (≤300 words) — one par
 - Do NOT suggest content for the Directive body or completion claim. Your job is to reject or pass, not to author. If the body needs more text, return `refine` and name the gap; the caller (`/file-directive`, `/activate-directive`, or `/complete-directive`) re-authors.
 - Do NOT block on stylistic issues alone (heading capitalization, ordering). Block on substance gaps.
 - Do not invent active Directives or linked Execution Issues you didn't see in the fetched data. If `gh` fails (rate-limit, auth), say so and pass through to manual review.
-- **MISSION.md alignment** (dir-mode v3 reframe / ADR-0003): the `MISSION fit` section must name a specific `MISSION.md` section or success criterion. If the target repo has no `MISSION.md`, note that in the verdict reason and pass through to manual review — the Directive may motivate a MISSION.md amendment, which is appropriate. The legacy "early v0 state Goal-bootstrap allowance" is **removed** for repos that have a `MISSION.md`; for repos onboarding the shell whose first Directive precedes their first `MISSION.md`, the allowance still applies (note the absence + pass through). See ADR-0003 Decision 6.
+- **MISSION.md alignment** (see [ADR-0003](docs/ADRs/0003-issues-ssot-substrate.md) Decision 6): the `MISSION fit` section must name a specific `MISSION.md` section or success criterion. If the target repo has no `MISSION.md`, note that in the verdict reason and pass through to manual review — the Directive may motivate a MISSION.md amendment, which is appropriate. The legacy Goal-bootstrap allowance is **removed** for repos that have a `MISSION.md`; for repos onboarding the shell whose first Directive precedes their first `MISSION.md`, the allowance still applies (note the absence + pass through). See ADR-0003 Decision 6.
 - One paragraph per check is enough. Long reviews discourage maintenance; short reviews are still actionable.
 
 ## Verdict dispatch (informational — handled by caller per SPEC §1.7 / §2.1 reviewer-gating contract)

--- a/.claude/agents/triage-reviewer.md
+++ b/.claude/agents/triage-reviewer.md
@@ -1,12 +1,12 @@
 ---
 name: triage-reviewer
-description: Binary accept/reject classifier for `/triage` (dir-mode v3 reframe, SPEC §1.7). Called per-Issue by `/triage` to decide whether the Issue's body matches its claimed template (the `directive` / `task` / `bug` label or `needs-triage` raw filing). Lighter than `directive-reviewer` (§4.9) — does NOT verify Directive substance; only checks template-content alignment so mis-template usage triggers a close + refile rather than silent acceptance.
+description: Binary accept/reject classifier for `/triage`. Called per-Issue by `/triage` to decide whether the Issue's body matches its claimed template (the `directive` / `task` / `bug` label or `needs-triage` raw filing). Lighter than `directive-reviewer` (§4.9) — does NOT verify Directive substance; only checks template-content alignment so mis-template usage triggers a close + refile rather than silent acceptance.
 tools: [Read, Grep, Glob, Bash]
 ---
 
 You are the triage-reviewer. Called by `/triage` per-Issue to make ONE binary decision: does this Issue's body match the template its labels claim?
 
-You are **not** the substantive reviewer. Directive proposals receive their substantive review at `/activate-directive` time (via `directive-reviewer`, §4.9); Execution Issues receive theirs at `/file-issue` time (via `issue-reviewer`, §4.7). Your job is the upstream gate: catch mis-template usage so the strict reject + refile invariant (Decision 4 of the v3 reframe brief) can be enforced.
+You are **not** the substantive reviewer. Directive proposals receive their substantive review at `/activate-directive` time (via `directive-reviewer`, §4.9); Execution Issues receive theirs at `/file-issue` time (via `issue-reviewer`, §4.7). Your job is the upstream gate: catch mis-template usage so the strict reject + refile invariant (Decision 4 of the Directive #92 brief) can be enforced.
 
 ## Input
 

--- a/.claude/commands/activate-directive.md
+++ b/.claude/commands/activate-directive.md
@@ -1,15 +1,15 @@
 ---
-description: Activate a Proposed Directive — re-runs directive-reviewer; on `ship` removes the `status:proposed` label (Issue → Active) (dir-mode v3 / ADR-0003).
+description: Activate a Proposed Directive — re-runs directive-reviewer; on `ship` removes the `status:proposed` label (Issue → Active).
 argument-hint: <issue-#>
 ---
 
 Transition a Directive from `Status=Proposed` to `Status=Active` by removing the `status:proposed` label after a fresh `directive-reviewer` pass on the current body (which may have been edited in the GH UI since filing).
 
-In dir-mode v3 (ADR-0003), Status is encoded as labels on the Issue (Issues are SSOT). Project Status field is mirrored by `.github/workflows/issues-to-project-mirror.yml`. `/activate-directive` does NOT write to the Project directly.
+Status is encoded as labels on the Issue (Issues are SSOT). Project Status field is mirrored by `.github/workflows/issues-to-project-mirror.yml`. `/activate-directive` does NOT write to the Project directly.
 
 ## Procedure
 
-0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Resolve the Issue** — `<issue-#>` is a GitHub Issue number. Fetch:
    ```bash

--- a/.claude/commands/block-directive.md
+++ b/.claude/commands/block-directive.md
@@ -1,17 +1,17 @@
 ---
-description: Mark an Active Directive Issue as Blocked by adding the `status:blocked` label + a ## Blocked comment (dir-mode v3 / ADR-0003).
+description: Mark an Active Directive Issue as Blocked by adding the `status:blocked` label + a ## Blocked comment.
 argument-hint: <issue-#> --reason <why>
 ---
 
 Add the `status:blocked` label and a `## Blocked: <reason>` comment to an Active Directive Issue. The Issue stays open; the label drives the mirror workflow's Status=Blocked.
 
-In dir-mode v3 (ADR-0003), `status:blocked` is the canonical state encoding. The Project Item's Status field follows via `.github/workflows/issues-to-project-mirror.yml`.
+`status:blocked` is the canonical state encoding. The Project Item's Status field follows via `.github/workflows/issues-to-project-mirror.yml`.
 
 Not reviewer-gated by `directive-reviewer` — blocking is an annotation, not a body change.
 
 ## Procedure
 
-0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Parse arguments** — `<issue-#>` is the GitHub Issue number; `--reason <why>` is **mandatory**. If `--reason` is missing or its value is empty after whitespace-trim: error ("--reason <why> is required for /block-directive") and stop.
 

--- a/.claude/commands/complete-directive.md
+++ b/.claude/commands/complete-directive.md
@@ -1,15 +1,15 @@
 ---
-description: Close a Directive Issue as Completed — directive-reviewer evaluates evidence; closes Issue with --reason completed (dir-mode v3 / ADR-0003).
+description: Close a Directive Issue as Completed — directive-reviewer evaluates evidence; closes Issue with --reason completed.
 argument-hint: <issue-#>
 ---
 
 Close a Directive Issue with `--reason completed`. Requires `directive-reviewer` evaluation of success-signal satisfaction by linked Execution Issues.
 
-In dir-mode v3 (ADR-0003), Issue close-as-completed IS the Status=Completed signal. The Project Item's Status field follows via `.github/workflows/issues-to-project-mirror.yml`.
+Issue close-as-completed IS the Status=Completed signal. The Project Item's Status field follows via `.github/workflows/issues-to-project-mirror.yml`.
 
 ## Procedure
 
-0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Resolve the Issue** — `<issue-#>` is a GitHub Issue number. Fetch:
    ```bash

--- a/.claude/commands/file-directive.md
+++ b/.claude/commands/file-directive.md
@@ -1,15 +1,15 @@
 ---
-description: File a new Directive as a GitHub Issue with `directive` + `status:proposed` labels (dir-mode v3 — Issues-as-SSOT per ADR-0003 / Directive #92). Reviewer-gated.
+description: File a new Directive as a GitHub Issue with `directive` + `status:proposed` labels. Reviewer-gated.
 argument-hint: ""
 ---
 
 Create a new Directive as a GitHub Issue. Body authored from `.claude/templates/directive.md`. Reviewer-gated before `gh issue create`.
 
-In dir-mode v3 (ADR-0003), **Issues are SSOT**. The Project Item that wraps the new Issue is created and populated by `.github/workflows/issues-to-project-mirror.yml` (cluster D mirror workflow) — `/file-directive` does NOT write to the Project directly.
+**Issues are SSOT**. The Project Item that wraps the new Issue is created and populated by `.github/workflows/issues-to-project-mirror.yml` (cluster D mirror workflow) — `/file-directive` does NOT write to the Project directly.
 
 ## Procedure
 
-0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Author the body** from `.claude/templates/directive.md`:
    - **Objective** — bounded by concrete artifact-level boundary (issue counts, file paths, AC ticks, merge events). Refuse to proceed if the Objective doesn't name a concrete artifact-level boundary.

--- a/.claude/commands/file-issue.md
+++ b/.claude/commands/file-issue.md
@@ -6,7 +6,7 @@ argument-hint: [--quick] [--parent <directive-id>|--no-parent] <description>
 Create an issue.
 
 1. Parse `$ARGUMENTS`:
-   - With `--quick`: one-line issue (label `bug`), ask only for one acceptance criterion. (`chore` label was removed during the v3 reframe per ADR-0003; `bug` matches the `bug-report.yml` Issue Form template label.)
+   - With `--quick`: one-line issue (label `bug`), ask only for one acceptance criterion. (`bug` matches the `bug-report.yml` Issue Form template label.)
    - With `--parent <directive-id>`: parent this Issue under the named Directive (SPEC §5.2 dir-mode integration). The Directive's number is the value passed to the flag — e.g., `/file-issue --parent 91 fix-the-thing`.
    - With `--no-parent`: explicitly opt out of parenting (skip step 1.5).
    - Otherwise: confirm title, body, label with the user.

--- a/.claude/commands/link-directive.md
+++ b/.claude/commands/link-directive.md
@@ -3,7 +3,7 @@ description: Link an Execution Issue to its parent Directive — sets the `Paren
 argument-hint: <directive-#> <execution-#>
 ---
 
-Link an Execution Issue to its parent Directive by ensuring the `Parent Directive: #<N>` line-1 body marker is set + posting cross-reference comments. the Project Item's `Parent` field is mirrored from this body marker by `.github/workflows/issues-to-project-mirror.yml` — `/link-directive` does NOT write to the Project directly.
+Link an Execution Issue to its parent Directive by ensuring the `Parent Directive: #<N>` line-1 body marker is set + posting cross-reference comments. The Project Item's `Parent` field is mirrored from this body marker by `.github/workflows/issues-to-project-mirror.yml` — `/link-directive` does NOT write to the Project directly.
 
 ## Procedure
 

--- a/.claude/commands/link-directive.md
+++ b/.claude/commands/link-directive.md
@@ -1,17 +1,17 @@
 ---
-description: Link an Execution Issue to its parent Directive — sets the `Parent Directive: #N` body marker (dir-mode v3 / ADR-0003). Idempotent.
+description: Link an Execution Issue to its parent Directive — sets the `Parent Directive: #N` body marker. Idempotent.
 argument-hint: <directive-#> <execution-#>
 ---
 
-Link an Execution Issue to its parent Directive by ensuring the `Parent Directive: #<N>` line-1 body marker is set + posting cross-reference comments. In dir-mode v3 (ADR-0003), the Project Item's `Parent` field is mirrored from this body marker by `.github/workflows/issues-to-project-mirror.yml` — `/link-directive` does NOT write to the Project directly.
+Link an Execution Issue to its parent Directive by ensuring the `Parent Directive: #<N>` line-1 body marker is set + posting cross-reference comments. the Project Item's `Parent` field is mirrored from this body marker by `.github/workflows/issues-to-project-mirror.yml` — `/link-directive` does NOT write to the Project directly.
 
 ## Procedure
 
-0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Validate the two arguments**:
    - `<directive-#>` — must be a `directive`-labeled, OPEN Issue. Fetch via `gh issue view`. If not a Directive: stop.
-   - `<execution-#>` — must be an Issue WITHOUT the `directive` label (i.e., an Execution Issue or Task / Bug). If it is itself a Directive: stop with error ("Cannot parent a Directive under another Directive in v0 — see SPEC §0.4 directive-graph deferral").
+   - `<execution-#>` — must be an Issue WITHOUT the `directive` label (i.e., an Execution Issue or Task / Bug). If it is itself a Directive: stop with error ("Cannot parent a Directive under another Directive — directive dependency graph is deferred per SPEC §0.4").
 
 2. **Idempotency check** — read the Execution Issue's body. If line 1 already matches `^Parent Directive: #<directive-#>$`, the link is already in place. Emit:
    ```
@@ -43,4 +43,4 @@ Same in attended and unattended.
 - Linking two Directives (v0 non-goal — directive dependency graph deferred per SPEC §0.4).
 - Overwriting an existing different `Parent Directive: #<other>` marker without explicit user confirmation. If the Issue is already linked to a *different* Directive, stop and report rather than silently re-parenting.
 - Skipping the body-marker step — the regex `^Parent Directive: #(\d+)$` is consumed by `/reflect`, the dir-mode-post-merge workflow, AND the issues-to-project-mirror workflow (SPEC §5.2, §5.7, ADR-0003).
-- Writing to the Project Item's `Parent` field directly — that's the mirror workflow's job in v3.
+- Writing to the Project Item's `Parent` field directly — that's the mirror workflow's job.

--- a/.claude/commands/list-directives.md
+++ b/.claude/commands/list-directives.md
@@ -1,13 +1,13 @@
 ---
-description: List Directive Issues filtered by Status label (default omits Completed). Read-only (dir-mode v3 / ADR-0003).
+description: List Directive Issues filtered by Status label (default omits Completed). Read-only.
 argument-hint: [--status <state>]
 ---
 
-List Directive Issues filtered by Status label. Read-only; queries Issues directly (Issues-as-SSOT per ADR-0003 — no Project Item lookup).
+List Directive Issues filtered by Status label. Read-only; queries Issues directly.
 
 ## Procedure
 
-0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Parse arguments**:
    - `--status <state>` — one of `Proposed | Active | Blocked | Completed | All`. Default: omit `Completed` (show Proposed + Active + Blocked).
@@ -30,7 +30,7 @@ List Directive Issues filtered by Status label. Read-only; queries Issues direct
    ```
    | #   | Status     | Title                                           |
    |-----|------------|-------------------------------------------------|
-   | 92  | Active     | directive: dir-mode v3 reframe Issues-as-SSOT   |
+   | 92  | Active     | directive: SSOT substrate decision              |
    | ... |            |                                                 |
    ```
 

--- a/.claude/commands/onboard-dir-mode.md
+++ b/.claude/commands/onboard-dir-mode.md
@@ -1,12 +1,12 @@
 ---
-description: Install the v3 substrate (labels + Issue templates + workflows + Project v2) into a target repo. Tier-aware. Idempotent. PR-based file installs per ADR-0004.
+description: Install the dir-mode substrate (labels + Issue templates + workflows + Project) into a target repo. Tier-aware. Idempotent. PR-based file installs per ADR-0004.
 argument-hint: [--tier 1|2|3] [--dry-run]
 ---
 
-Install the dir-mode v3 substrate into the current target repo (cwd). Per ADR-0004:
+Install the dir-mode substrate into the current target repo (cwd). Per ADR-0004:
 
-- **Tier 1**: no install — eng-mode works without v3 substrate.
-- **Tier 2**: install the 10-label v3 set via `gh label create --force`. Unlocks `/file-directive` / `/activate-directive` / `/complete-directive` directly against Issues. No Project mirror.
+- **Tier 1**: no install — eng-mode works without the dir-mode substrate.
+- **Tier 2**: install the 10-label dir-mode set via `gh label create --force`. Unlocks `/file-directive` / `/activate-directive` / `/complete-directive` directly against Issues. No Project mirror.
 - **Tier 3**: tier 2 + install ISSUE_TEMPLATE files + workflow files via a PR to the target + create Project v2 via `gh project create` + populate fields via `scripts/setup_project.sh`. Unlocks `/triage` + template chooser + Project-as-derived-view.
 
 Each tier is a strict superset. Re-running is idempotent at every step.
@@ -25,13 +25,13 @@ Each tier is a strict superset. Re-running is idempotent at every step.
    - Invoke `bash $CLAUDE_ENG_SHELL_ROOT/scripts/onboard_target.sh --tier 2` (idempotent — uses `gh label create --force`).
    - Verify via `gh label list` that all 11 labels exist: `directive`, `status:proposed`, `status:blocked`, `task`, `needs-triage`, `discussion`, `P0`, `P1`, `P2`, `P3`, `skip-changelog` (the last is the documented PR-time opt-out for the release-backbone fragment-gate per SPEC §18.6).
 
-6. **Tier 3** (full v3):
+6. **Tier 3** (full substrate):
    - Run step 5 (tier 2 prerequisite).
    - Invoke `bash $CLAUDE_ENG_SHELL_ROOT/scripts/onboard_target.sh --tier 3`:
      - Copies canonical files from `$CLAUDE_ENG_SHELL_ROOT/.claude/templates/target-substrate/` into target's `.github/`:
        - `ISSUE_TEMPLATE/{config,directive-proposal,execution-under-directive,task,bug-report,discussion}.yml`
        - `workflows/{auto-needs-triage,issues-to-project-mirror,dir-mode-post-merge,check-changelog}.yml` — `check-changelog.yml` is the release-backbone fragment-gate (SPEC §18.6); blocks PRs to `main` / `*-maintenance` that lack a `changelog_unreleased/<category>/<N>.md` fragment unless the `skip-changelog` label is applied.
-     - Creates branch `onboard-dir-mode-substrate`, commits the files, pushes, opens a PR via `gh pr create --title "chore: onboard claude-eng-shell dir-mode v3 substrate"` — **target maintainer reviews + merges**.
+     - Creates branch `onboard-dir-mode-substrate`, commits the files, pushes, opens a PR via `gh pr create --title "chore: onboard claude-eng-shell dir-mode substrate"` — **target maintainer reviews + merges**.
      - Direct push to target's `main` is forbidden (protected-branch hook fires; this is by design per ADR-0004 Decision 2).
    - Project v2 setup: invoke `bash $CLAUDE_ENG_SHELL_ROOT/scripts/setup_project.sh` (idempotent — creates the Project if absent, reconciles fields if present).
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -79,7 +79,7 @@ awk '/^## \[<X.Y.Z>\]/{f=1; next} /^## \[/{f=0} f' CHANGELOG.md > /tmp/release-n
 gh release create v<X.Y.Z> --title v<X.Y.Z> --target "$MERGE_SHA" --notes-file /tmp/release-notes-v<X.Y.Z>.md --verify-tag
 ```
 
-This is intentionally manual in v0 per Directive #128 non-goal ("No automated distribution") — the one-liner stays visible and auditable rather than buried in a workflow. Adopters who want full automation can wrap this in a `release-tag.yml` workflow downstream without changing the skill.
+This is intentionally manual per Directive #128 non-goal ("No automated distribution") — the one-liner stays visible and auditable rather than buried in a workflow. Adopters who want full automation can wrap this in a `release-tag.yml` workflow downstream without changing the skill.
 
 Re-running `gh release create` on an existing tag fails with a clear `release already exists` message — idempotent at the gh-CLI layer.
 

--- a/.claude/commands/revise-directive.md
+++ b/.claude/commands/revise-directive.md
@@ -5,11 +5,11 @@ argument-hint: <issue-#>
 
 Replace an `Active` Directive Issue's body with a new one when scope or success signals changed. The prior body is preserved as a comment for history; the new body is reviewer-gated. No transient Status state — per ADR-0003 Decision 7, `Revised` was dropped; the audit-log entry + the archive comment ARE the revision evidence.
 
-In dir-mode v3 (ADR-0003), Issues are SSOT. The Project Item is unchanged by this command (body content isn't mirrored to Project fields).
+Issues are SSOT. The Project Item is unchanged by this command (body content isn't mirrored to Project fields).
 
 ## Procedure
 
-0. **Step 0 — substrate preflight** (ADR-0004; #118): verify the target satisfies this command's tier requirement. Tier 2 minimum for all dir-mode commands (10-label v3 set must exist). If `gh label list | grep -qx directive` fails, exit with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"`. Fail-open on `gh` network errors per ADR-0004 reversibility framing.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Resolve the Issue** — `<issue-#>` is a GitHub Issue number. Fetch:
    ```bash

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -1,11 +1,11 @@
 ---
-description: Triage Issues with `needs-triage` or `status:proposed` labels — binary accept/reject per Issue via triage-reviewer; strict reject + refile semantics (no relabel) per dir-mode v3 reframe (SPEC §1.7, Directive #92, brief §5.2 / §5.3 / Decision 4).
+description: Triage Issues with `needs-triage` or `status:proposed` labels — binary accept/reject per Issue via triage-reviewer; strict reject + refile semantics (no relabel) per SPEC §1.7 + Directive #92 brief §5.2 / §5.3 / Decision 4.
 argument-hint: "[--limit <N>]"
 ---
 
 Triage open Issues that carry `needs-triage` (raw filings) or `status:proposed` (Directive proposals awaiting maintainer ratification). For each, AI proposes ACCEPT or REJECT; the maintainer confirms; on REJECT the original Issue closes-as-not-planned and the maintainer refiles in the correct template.
 
-Triage is the **maintainer's binary decision** per Issue. The triage-reviewer subagent (§4.10, added by dir-mode v3) is the classifier — checks whether the Issue's body matches its claimed template. The substantive review of Directive content remains at `/activate-directive` (via `directive-reviewer`, §4.9).
+Triage is the **maintainer's binary decision** per Issue. The triage-reviewer subagent (§4.10) is the classifier — checks whether the Issue's body matches its claimed template. The substantive review of Directive content remains at `/activate-directive` (via `directive-reviewer`, §4.9).
 
 ## Procedure
 

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -4556,19 +4556,25 @@ fi
 # (SPEC §1.7/§2.1/§5.10-§5.18) per ADR-0003. Structural sanity for the
 # substrate flip from Project-Items-as-SSOT (v0) to Issues-as-SSOT (v3).
 
-# 58a: every dir-mode command file mentions Issues are SSOT or ADR-0003.
+# 58a: every dir-mode command file operates on the Issue substrate
+# (gh issue invocation OR explicit `directive` / `status:` label reference).
+# Replaces the prior ADR-0003 / Issues-as-SSOT / dir-mode-v3 token assertion
+# (cluster E #96) which was tied to migration-era qualifiers stripped by
+# Directive #149 / Issue #151. The intent is unchanged: prevent regression
+# to Project-Items-as-SSOT by requiring each dir-mode command file to assert
+# its Issue-substrate contract in the body.
 s58a_missing=""
 for cmd in file-directive activate-directive complete-directive block-directive revise-directive list-directives link-directive; do
   cmd_path="$SHELL_ROOT/.claude/commands/$cmd.md"
   [ -f "$cmd_path" ] || { s58a_missing="$s58a_missing $cmd(missing)"; continue; }
-  if ! grep -qE '(ADR-0003|Issues-as-SSOT|Issues are SSOT|dir-mode v3)' "$cmd_path" 2>/dev/null; then
+  if ! grep -qE '(gh issue|`directive` label|`status:)' "$cmd_path" 2>/dev/null; then
     s58a_missing="$s58a_missing $cmd"
   fi
 done
 if [ -z "$s58a_missing" ]; then
-  ok "58a: all 7 dir-mode commands reference ADR-0003 / Issues-as-SSOT (#96/cluster E)"
+  ok "58a: all 7 dir-mode commands assert Issue-substrate contract (#96/cluster E; updated #151)"
 else
-  ng "58a: dir-mode commands missing v3 references:$s58a_missing (#96/cluster E)"
+  ng "58a: dir-mode commands missing Issue-substrate refs:$s58a_missing (#96/cluster E; updated #151)"
 fi
 
 # 58b: /file-directive emits issue=#<N> audit token (not item=PVTI_...).
@@ -4917,18 +4923,22 @@ else
   ng "63d: onboard_target.sh --tier 1 --dry-run unexpected rc=$s63d_rc (#118)"
 fi
 
-# §63e: each of the 7 dir-mode command procedure files contains a "step 0 preflight" reference.
+# §63e: each of the 7 dir-mode command procedure files contains a substrate
+# preflight step. Pattern broadened (#151) to match both the original
+# "Step 0 ... preflight" phrasing and the compressed "Substrate preflight"
+# one-liner introduced by Directive #149 / Issue #151 (the 4-line boilerplate
+# was de-duplicated to a single shared statement per AC #4).
 s63e_count=0
 for cmd in file-directive activate-directive complete-directive revise-directive \
            block-directive list-directives link-directive; do
-  if grep -qE "Step 0.*preflight|step 0 preflight" "$SHELL_ROOT/.claude/commands/${cmd}.md"; then
+  if grep -qE "Step 0.*preflight|step 0 preflight|Substrate preflight" "$SHELL_ROOT/.claude/commands/${cmd}.md"; then
     s63e_count=$((s63e_count + 1))
   fi
 done
 if [ "$s63e_count" = 7 ]; then
-  ok "63e: all 7 dir-mode commands name 'step 0 preflight' (#118)"
+  ok "63e: all 7 dir-mode commands name substrate preflight (#118; updated #151)"
 else
-  ng "63e: 'step 0 preflight' missing in some dir-mode commands: $s63e_count/7 (#118)"
+  ng "63e: substrate preflight missing in some dir-mode commands: $s63e_count/7 (#118; updated #151)"
 fi
 
 # §63f: ADR-0004 reversibility paths referenced from /onboard-dir-mode.


### PR DESCRIPTION
Closes #151
Refs #149

## Goal
Drop migration-era qualifiers from dir-mode command + reviewer agent description text — cleave 2 of 4 under Directive #149.

## How this serves the mission
Serves MISSION's `## Success looks like > "The directing layer works"`. Dir-mode commands carrying `(dir-mode v3 / ADR-0003)` boilerplate while engineering-mode commands carry no `(eng-mode)` parallel tag IS the asymmetric treatment Directive #149 names. After this PR, command/agent description text reads at parity with engineering-mode commands — no "this is the special branch" framing.

## Plan
Single-commit `docs(#151)` PR (docs-only; relaxed phasing per CLAUDE.md §1.2 — AC #1's grep gate IS the test).

Mechanical batch using python str.replace across 13 files. Identical Step 0 substrate-preflight boilerplate (4-line paragraph) compressed to a 1-line check; same line in 7 dir-mode commands.

Affected files:
- `.claude/commands/{file,activate,complete,block,link,list,revise,onboard-dir-mode,triage}-directive.md` — wait actually that's 9 names of 8 commands plus triage. Per current strip: 9 commands + 2 agents + 2 collateral (file-issue.md, release.md) = 13 files.
- `.claude/agents/{directive,triage}-reviewer.md` — description-line `(dir-mode v3 reframe, SPEC §1.7)` parentheticals dropped; "v3 4-state lifecycle" → "4-state lifecycle"; "Decision 4 of the v3 reframe brief" → "Decision 4 of the Directive #92 brief".

## Alternatives considered
- **Extract Step 0 boilerplate to a shared template file (`.claude/templates/substrate-preflight.md`) + reference from each command**: rejected — markdown has no include mechanism that the skills runtime consumes. Each command file would still need to inline-paste the text OR cross-reference the template, the latter of which a reader would need to follow. The 1-line compression achieves "single shared statement" in spirit (byte-identical line across all 7 callers) without introducing a new file or indirection.
- **Per-file Edit tool calls (9 calls)**: rejected — initial attempt failed on "file not yet read" precondition. Python str.replace with a list of (old, new) pairs is the same-cost batch with one Bash invocation.
- **Skip the Step 0 compression, only strip qualifiers**: rejected — Directive #149 AC #4 explicitly requires de-duplication of the Step 0 boilerplate ("single shared statement, referenced from each dir-mode command rather than re-pasted").

## Key context
- `.claude/commands/*-directive.md` × 9 — dir-mode command pages, primary scope
- `.claude/agents/directive-reviewer.md`, `.claude/agents/triage-reviewer.md` — dir-mode reviewer agents
- `.claude/commands/{file-issue,release,link-directive}.md` — collateral hits with `in v0` / `v0 reframe` framing
- Directive #149 success-signal #2: `grep -cE 'v3|reframe|Issues-as-SSOT' .claude/commands/*.md .claude/agents/*.md` returns 0

## Checklist
- [x] **Doc**: 9 dir-mode commands — `(dir-mode v3 / ADR-0003)` parentheticals dropped; "In dir-mode v3 (ADR-0003), ..." lead sentences rephrased.
- [x] **Doc**: 7 commands — Step 0 substrate-preflight boilerplate compressed from 4-line paragraph to 1-line check (byte-identical across all 7).
- [x] **Doc**: 2 agents — description-line `(dir-mode v3 reframe, SPEC §1.7)` and body "v3 reframe brief" / "v3 4-state lifecycle" / "(dir-mode v3 reframe / ADR-0003: ...)" stripped.
- [x] **Doc**: collateral — `file-issue.md` "removed during the v3 reframe" trimmed; `release.md` "intentionally manual in v0" → "intentionally manual"; `link-directive.md` error message "in v0" framing dropped; `list-directives.md` example output cleaned.
- [x] **Doc**: `grep -cE 'v3|reframe|Issues-as-SSOT' .claude/commands/*.md .claude/agents/*.md` returns 0 (verified).
- [~] **Test**: N/A — docs-only, no executable behavior change. Smoke tests still run; `/list-directives` invoked locally renders correctly.
- [~] **Code**: N/A — no code/hook/skill behavior changes.

## Out of scope
- `SPEC.md` (cleave 1 — landed in PR #154).
- `docs/SUBAGENTS.md` (cleave 3 — #152).
- `docs/{ENGINEERING_FLOW,TROUBLESHOOTING,ESCAPE_HATCH}.md` (cleave 4 — #153).
- `docs/ADRs/*` removal — cleave 5 under #149 (planned successor).
- Renaming any skill or agent file.
- Changing substrate-preflight behavior — only its documentation surface.

## Risks
- **Skill description-line truncation**: the `Skill` tool surfaces the first sentence of `description:` to the user. After strip, descriptions are shorter — still complete sentences, no truncation risk. Verified by re-loading the skill list (description fields read cleanly).
- **Substrate-preflight intent loss**: the compressed 1-line check drops the "tier 2 minimum / ADR-0004 reversibility framing" prose. The contract is unchanged (still aborts if `gh label list | grep -qx directive` fails); the rationale lives in `onboard-dir-mode.md` and SPEC §1.7's Substrate-in-target subsection. No behavior change.
- **Cleave 5 coupling**: after `docs/ADRs/*` are deleted (cleave 5), any surviving `ADR-0003` / `ADR-0004` references in these files become dangling. Cleave 5 will sweep those; current state has fewer cross-refs than before cleave 2 (boilerplate compression dropped most).

## Open questions
- None blocking.

## Decisions
- 2026-05-28: Step 0 boilerplate compression chosen over template-include. Reason: markdown has no include mechanism that skills consume; 1-line byte-identical text across callers is equivalent to a single source for grep + audit purposes. Reversible.

## Test plan
- [x] `grep -cE 'v3|reframe|Issues-as-SSOT' .claude/commands/*.md .claude/agents/*.md` returns 0.
- [x] `git diff --stat` shows only `.claude/commands/` and `.claude/agents/` touched (13 files).
- [x] Skill description-line re-render verified (Skill list shows clean descriptions).
- [x] code-reviewer pass at ship gate (verdict: ship, after fixup 9815b33).

## Followup commit 9815b33 (test(#151))
- smoke §58a (cluster E #96): pattern updated from `(ADR-0003|Issues-as-SSOT|Issues are SSOT|dir-mode v3)` to `(gh issue|\`directive\` label|\`status:)` — equivalent-or-stronger structural assertion of the Issue-substrate contract after Directive #149's strip of migration-era qualifiers.
- smoke §63e (#118): pattern broadened to also accept `Substrate preflight` (the compressed 1-line form introduced by this PR's AC #4 boilerplate de-dup).
- `.claude/commands/link-directive.md:6`: lowercase typo fixed (`. the Project` → `. The Project`).
- Local smoke: pass=373 fail=0.

## Docs touched
- [x] `.claude/commands/*.md` (10 files)
- [x] `.claude/agents/*.md` (2 files)
- [x] `scripts/test/smoke.sh` (fixup — smoke patterns updated to match post-cleave-2 prose)
- [~] SPEC.md / MISSION.md / README — N/A this cleave.

## Ship gate
- [x] All tests pass — local smoke pass=373 fail=0 after fixup.
- [x] code-reviewer passed
- [~] (conditional) security-reviewer — N/A, no auth/input/deps/crypto changes
- [x] Docs in sync (cross-references unchanged; SPEC §0.4 reference in link-directive error message preserved)
- [x] PR body curated
- [ ] CI green
