### PR TITLE
docs(#152): SUBAGENTS.md — expand to 10 subagents, restructure to per-agent ### sections

### DIFF
--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -47,7 +47,7 @@ Phase B. Translates the Phase A doc into a failing test, confirms the failure is
 
 ## Reviewers
 
-Reviewers never author content. Each emits a `VERDICT:` line — exactly one of `ship`, `refine: <one-line>`, `block: <reason>` — which the caller dispatches per SPEC §1.5 operating-mode coupling. In `attended` mode the verdict surfaces to the user; in `unattended` mode it gates directly.
+Reviewers never author content. Each emits a `VERDICT:` line whose values vary per reviewer — most use `ship` / `refine: <one-line>` / `block: <reason>`; `code-reviewer` uses `ship` / `ship after fix` / `block (blocker)` (SPEC §4.5); `triage-reviewer` uses `ACCEPT` / `REJECT — refile as <template>` (SPEC §4.10). Per SPEC §1.5 operating-mode coupling: in `attended` mode the verdict surfaces to the user; in `unattended` mode it gates directly.
 
 ### code-reviewer
 
@@ -55,7 +55,7 @@ Pre-commit / pre-PR review. Auto-invoked by `/review` and `/ship`.
 
 - **When**: at the ship gate before `gh pr ready`, and any time `/review` runs.
 - **Input**: diff + PR body + MISSION + issue body. No chat context — the reviewer is deliberately uninformed by the conversation that produced the diff, so its verdict comes from the artifacts alone.
-- **Output**: `ship` / `refine` / `block` with `path:line` anchors on findings.
+- **Output**: `ship` / `ship after fix` / `block (blocker)` with `path:line` anchors on findings.
 - **Spec**: SPEC §4.5.
 
 ### security-reviewer
@@ -92,7 +92,7 @@ Quality check on a proposed Directive body (`/file-directive`, `/activate-direct
 - **When**: every Directive transition that mutates body content or asserts completion. Annotation-only `/block-directive` does not run this reviewer (no body change).
 - **Input**: proposed body or evidence + list of currently Active Directives + MISSION.
 - **Output**: `ship` / `refine` / `block`. Five checks: schema completeness, success-signal verifiability, scope clarity, non-goal clarity, Active-Directive conflict. Completion review adds an evidence-sufficiency check.
-- **Spec**: SPEC §4.9.
+- **Spec**: SPEC §4.9.1.
 
 ### triage-reviewer
 

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -1,26 +1,124 @@
 # Subagents
 
-Full specs in [SPEC.md §4](../SPEC.md).
+Full specs in [SPEC.md §4](../SPEC.md). This page is the practitioner's index — what each subagent does, when to call it, what it expects as input, and what comes back. Subagents protect the main session's context by running specialised work in isolated windows; the main assistant integrates the result.
 
-| Agent | When | Input | Output |
-|-------|------|-------|--------|
-| `planner` | Before code edits. Required for 3+ file changes, migrations, API changes | User request, issue body, MISSION, target CLAUDE.md | Plan + Doc/Test/Code-ordered checklist (markdown for PR body) |
-| `explorer` | Wide read-only exploration. Protects main context | Search question | Definition + up to 5 references, summarized |
-| `doc-writer` | Phase A. When external surface changes | Intent of change | Identifies affected SSOT + patches. Stub proposal only if absent |
-| `test-writer` | Phase B. Right after Phase A | doc/spec | Failing test (intentional failure confirmed) |
-| `code-reviewer` | Before commit/PR. Auto-called by `/review` and `/ship` | diff + PR body + MISSION + issue body (no chat context) | ship / ship after fix / block + `path:line` |
-| `security-reviewer` | Auth/input/deps/crypto changes | diff | High/Medium/Low/Info + risk + remediation |
+Subagents fall into three roles. **Explorers** read the codebase. **Builders** produce new artifacts (plans, docs, tests). **Reviewers** judge artifacts and emit a `ship` / `refine` / `block` verdict (SPEC §1.5 operating-mode coupling — in `unattended` runs the verdict gates directly, replacing the human checkpoint).
 
-## Call policy
+## Explorers
 
-You don't need to call all six on a single PR. Don't re-run something the main assistant already explored in `explorer`. No call-count limits or tracking.
+### explorer
 
-## How to call (from within Claude Code)
+Wide read-only exploration of the codebase. Protects the main context window from large search results.
+
+- **When**: looking for a definition, mapping all callers of a symbol, surveying a feature's surface across many files, or any "where is X" / "who depends on Y" question.
+- **Input**: a focused search question — "where is `is_directive_issue` defined and who calls it?", "what hook matchers fire on `gh pr merge`?"
+- **Output**: definition pointer + up to 5 reference sites with `path:line` anchors, summarized. No edits.
+- **Don't**: re-run searches the main assistant already did (SPEC §1.5).
+- **Spec**: SPEC §4.2.
+
+## Builders
+
+### planner
+
+Produces the implementation plan + Doc/Test/Code-ordered checklist that becomes the PR body. **Required** for 3+ file changes, migrations, API/schema changes.
+
+- **When**: invoked by `/work-on` before any edits. Skippable for typo / one-line fix per CLAUDE.md §1.2 relaxation rules.
+- **Input**: issue body, target `MISSION.md`, target `CLAUDE.md`, resolved base branch.
+- **Output**: plan markdown with mandatory `## Alternatives considered` and `## Target base` sections. The checklist is what the PR body's `## Checklist` consumes.
+- **Spec**: SPEC §4.1.
+
+### doc-writer
+
+Phase A. Translates intent into SSOT changes (MISSION, README, CLAUDE.md, ARCHITECTURE, ADR, API docs).
+
+- **When**: invoked when external surface changes — features, contracts, schemas. Skipped for `refactor` with unchanged external behavior.
+- **Input**: intent of the change + identified SSOT targets.
+- **Output**: patches to existing SSOTs. Proposes a stub for absent docs only with user confirmation (does not invent new SSOT files autonomously).
+- **Spec**: SPEC §4.3.
+
+### test-writer
+
+Phase B. Translates the Phase A doc into a failing test, confirms the failure is the intended picture, then hands off to the main assistant for Phase C.
+
+- **When**: right after Phase A on `feat`, `docs`, and external-contract changes. `fix` runs reproduce-first instead (the bug repro plays the spec role).
+- **Input**: the Phase A doc/spec.
+- **Output**: a test that fails with the expected message; the failure is confirmed before commit.
+- **Spec**: SPEC §4.4.
+
+## Reviewers
+
+Reviewers never author content. Each emits a `VERDICT:` line — exactly one of `ship`, `refine: <one-line>`, `block: <reason>` — which the caller dispatches per SPEC §1.5 operating-mode coupling. In `attended` mode the verdict surfaces to the user; in `unattended` mode it gates directly.
+
+### code-reviewer
+
+Pre-commit / pre-PR review. Auto-invoked by `/review` and `/ship`.
+
+- **When**: at the ship gate before `gh pr ready`, and any time `/review` runs.
+- **Input**: diff + PR body + MISSION + issue body. No chat context — the reviewer is deliberately uninformed by the conversation that produced the diff, so its verdict comes from the artifacts alone.
+- **Output**: `ship` / `refine` / `block` with `path:line` anchors on findings.
+- **Spec**: SPEC §4.5.
+
+### security-reviewer
+
+Auto-invoked when the diff touches an auth, input-validation, dependency, crypto, or new-IO-boundary surface.
+
+- **When**: any PR whose diff matches security-relevant patterns; not called for prose-only changes.
+- **Input**: diff (no chat context).
+- **Output**: findings classified High / Medium / Low / Info with risk explanation and remediation.
+- **Spec**: SPEC §4.6.
+
+### issue-reviewer
+
+Rationale check on a proposed Issue body before `gh issue create`. Filed Issues that fail the rationale triad never reach the queue.
+
+- **When**: every `/file-issue` invocation. The `--quick` form still runs the rationale check in compressed form.
+- **Input**: proposed Issue body, MISSION, snapshot of open Issues.
+- **Output**: `ship` / `refine: <one-line>` / `block: <reason>` — verifies (a) MISSION fit, (b) why-now, (c) existing-coverage.
+- **Spec**: SPEC §4.7.
+
+### plan-reviewer
+
+Approach + alternatives check on `planner` output. The reviewer enforces that the chosen approach beats the alternatives the planner surfaced — a plan with a thin `## Alternatives considered` section gets a `refine`.
+
+- **When**: after `planner` runs in `/work-on`, before the user (attended) or the harness (unattended) approves the plan.
+- **Input**: planner output + issue body + MISSION.
+- **Output**: `ship` / `refine` / `block` — `ship` in `unattended` mode substitutes for human plan approval.
+- **Spec**: SPEC §4.8.
+
+### directive-reviewer
+
+Quality check on a proposed Directive body (`/file-directive`, `/activate-directive`, `/revise-directive`) or a completion claim (`/complete-directive`).
+
+- **When**: every Directive transition that mutates body content or asserts completion. Annotation-only `/block-directive` does not run this reviewer (no body change).
+- **Input**: proposed body or evidence + list of currently Active Directives + MISSION.
+- **Output**: `ship` / `refine` / `block`. Five checks: schema completeness, success-signal verifiability, scope clarity, non-goal clarity, Active-Directive conflict. Completion review adds an evidence-sufficiency check.
+- **Spec**: SPEC §4.9.
+
+### triage-reviewer
+
+Binary classifier for `/triage` — per-Issue template-content match check.
+
+- **When**: every Issue under `/triage`'s queue (Issues carrying `needs-triage` or `status:proposed`).
+- **Input**: Issue body + labels + `authorAssociation` passed in the invocation. No `gh` calls; no cross-Issue duplicate scan.
+- **Output**: `ACCEPT` (template-content match) or `REJECT — refile as <template>: <reason>` (mis-template usage). Intentionally lighter than `directive-reviewer`; substantive Directive review still happens at `/activate-directive`.
+- **Spec**: SPEC §4.10.
+
+## Calling subagents
+
+From within Claude Code, name the subagent in conversation or rely on the skill's auto-invocation:
 
 ```
 > have planner take this change
 > review the PR with code-reviewer
-> run security-reviewer on the auth changes
+> file the directive proposal (will route through directive-reviewer)
 ```
 
-Or use `/review`, `/ship` for automatic invocation.
+`/work-on`, `/ship`, `/file-issue`, `/file-directive`, `/activate-directive`, `/complete-directive`, `/revise-directive`, and `/triage` invoke their reviewers automatically.
+
+## Session-restart caveat
+
+Claude Code enumerates available `subagent_type` values **at session start** by scanning `.claude/agents/*.md`. A reviewer added mid-session falls back to `general-purpose` routing until the next session restart — the agent file is necessary but not sufficient. The fallback is functionally complete (the agent's prompt instructs `general-purpose` to behave as the new reviewer); restart at session end is canonical. See SPEC §4.9.3.
+
+## Parallel invocation
+
+Independent investigations that can run in parallel should be invoked together — multiple Agent calls in a single message. The harness runs them concurrently and integrates results when all return. Reviewers with no dependency on each other (e.g., `code-reviewer` + `doc-writer` SSOT sync on the same PR) batch cleanly.


### PR DESCRIPTION
Closes #152
Refs #149

## Goal
Expand `docs/SUBAGENTS.md` from a 6-row table to a 10-section per-agent doc, restructured under function-based group headers — cleave 3 of 4 under Directive #149.

## How this serves the mission
Serves MISSION's `## Success looks like > "The directing layer works"`. The canonical reviewer doc currently lists 6 of 10 subagents and omits `issue-reviewer`, `plan-reviewer`, `directive-reviewer`, `triage-reviewer`. A new adopter looking up "what reviewers does this shell have?" sees only the eng-mode set and concludes dir-mode reviewers are second-class. After this PR, all 10 are at parity indent under three function-based group headers (Explorers / Builders / Reviewers) — no `(dir-mode)` parenthetical scoping.

## Plan
Single-commit `docs(#152)` PR (docs-only; relaxed phasing per CLAUDE.md §1.2 — AC verifiers are mechanical).

Rewrite, not edit-in-place: the 27-line table format doesn't accommodate the depth required (1-line role + behavior summary + invocation + SPEC cross-ref per agent). The full rewrite was the lower-effort path.

## Alternatives considered
- **Keep the table format, add 4 rows**: rejected — the table's columns (Agent / When / Input / Output) constrain the per-agent depth. AC #4 requires "equivalent depth: 1-line role + 2–3 line behavior summary + invocation context + cross-ref" which can't fit a table cell. The table also can't carry the verdict-protocol explanation that `## Reviewers` needs.
- **One ### per agent without group headers**: rejected — AC #6 explicitly requires `## ` group headers (Explorers / Builders / Reviewers). The grouping signals what function each subagent serves and reinforces the "dir-mode reviewers are reviewers, not a special branch" framing.
- **Defer the rewrite, just add 4 missing rows as table entries**: rejected — same as alt 1, AC depth requirement isn't met. Also doesn't address Directive #149's signal: "directive-reviewer and triage-reviewer sit at the same indent level as code-reviewer."

## Key context
- `docs/SUBAGENTS.md` — target file (sole modification)
- `README.md` §Subagents — lists all 10 (this doc catches up)
- `.claude/CLAUDE.md` §Subagents table — also lists all 10
- `.claude/agents/*.md` — the 10 agent files that define each subagent
- SPEC §4.1–§4.10 — full specs each ### section cross-references

## Checklist
- [x] **Doc**: 10 `### <agent-name>` sections — `explorer`, `planner`, `doc-writer`, `test-writer`, `code-reviewer`, `security-reviewer`, `issue-reviewer`, `plan-reviewer`, `directive-reviewer`, `triage-reviewer`.
- [x] **Doc**: each section has 1-line role + behavior summary + invocation context + SPEC §4.x cross-ref.
- [x] **Doc**: `## ` group headers — `## Explorers`, `## Builders`, `## Reviewers`.
- [x] **Doc**: no `(dir-mode)` / `(v3)` parenthetical scoping in any `### ` title.
- [x] **Doc**: `grep -cE '^### ' docs/SUBAGENTS.md` returns 10 (verified).
- [x] **Doc**: session-restart caveat (SPEC §4.9.3) included as the foot section.
- [x] **Doc**: parallel-invocation note added — practical guidance for the main assistant.
- [~] **Test**: N/A — docs-only.
- [~] **Code**: N/A — no agent behavior changes.

## Out of scope
- `SPEC.md` reviewer sections (cleave 1 — landed).
- `.claude/agents/*.md` description text (cleave 2 — landed).
- `docs/{ENGINEERING_FLOW,TROUBLESHOOTING,ESCAPE_HATCH}.md` — cleave 4 (#153).
- ADR removal — cleave 5 (planned).
- Adding new subagents not currently in `.claude/agents/`.

## Risks
- **Stale grep on the old table format**: any external doc that searches for the table's column headers (`| Agent |`) would no longer find them. Mitigation: `grep -rn '| Agent | When' .` returned no inbound refs.
- **SPEC §4 reorg**: if SPEC §4 ever renumbers, the §4.x cross-refs in this doc go stale. Acceptable risk — §4 numbering has been stable for months, and cleave 5 will surface any cross-reference drift in its sweep.

## Open questions
- None blocking.

## Decisions
- 2026-05-28: full rewrite chosen over table-extension. Reason: AC depth requirement and parity-indent requirement both unsatisfiable in table format. Reversible — the file is small.

## Test plan
- [x] `grep -cE '^### ' docs/SUBAGENTS.md` returns 10 (verified post-rewrite).
- [x] All 10 agent names present and at parity indent.
- [x] No `(dir-mode)` / `(v3)` qualifier in any heading.
- [x] `## ` group headers present (Explorers / Builders / Reviewers).
- [x] code-reviewer pass at ship gate (verdict: ship after fixup e04807c).

## Followup commit e04807c
- Reviewer-surfaced: preamble universalized `ship/refine/block` across all reviewers, but `code-reviewer` uses `ship / ship after fix / block (blocker)` (SPEC §4.5) and `triage-reviewer` uses `ACCEPT / REJECT` (SPEC §4.10). Preamble rephrased to acknowledge the variation; code-reviewer Output line corrected; directive-reviewer cross-ref sharpened from §4.9 (umbrella) to §4.9.1 (the specific subsection).

## Docs touched
- [x] `docs/SUBAGENTS.md` (the rewrite + fixup)
- [~] SPEC.md / README.md / CLAUDE.md — N/A; this doc catches up to them.

## Ship gate
- [x] All tests pass — docs-only; smoke is structural-only, no SUBAGENTS.md assertion.
- [x] code-reviewer passed
- [~] (conditional) security-reviewer — N/A
- [x] Docs in sync (`docs/SUBAGENTS.md` now matches README.md §Subagents + SPEC §4)
- [x] PR body curated
- [ ] CI green
