### PR TITLE
docs(#149): drop v0/v1+ framing from .claude/CLAUDE.md mode-switching line

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,7 @@ issue → branch → draft PR → checklist commits → ready PR → merge. Ever
 
 Default autonomy ceiling stops at PR-ready (`attended` mode). See SPEC §5.7.1 for the `unattended` opt-in.
 
-**Dir-mode** (SPEC §1.7) extends the same pattern one level up: `MISSION.md` → Directive Issue → Execution Issue. Same generate → review → gated → audit shape; reviewer is `directive-reviewer` (§4.9). Mode switching is manual in v0; orchestration is v1+ (§0.4). Dir-mode commands live in §5.10–§5.14.
+**Dir-mode** (SPEC §1.7) extends the same pattern one level up: `MISSION.md` → Directive Issue → Execution Issue. Same generate → review → gated → audit shape; reviewer is `directive-reviewer` (§4.9). Workflow selection between eng-mode and dir-mode is manual; an automatic selector is a deferred capability (SPEC §0.4). Dir-mode commands live in §5.10–§5.18.
 
 ## Work order: Doc → Test → Code
 1. **Doc** — Write the behavior/contract to be changed into the SSOT (MISSION, README, CLAUDE.md, ARCHITECTURE, ADR) first.


### PR DESCRIPTION
Refs #149

## Goal
Tail-of-Directive #149 ride-along — strip the last `v0/v1+` qualifier from `.claude/CLAUDE.md` line 10 (Directive #149 success signal #7).

## Why this is here, not a separate Issue
Directive #149's Objective explicitly named `.claude/CLAUDE.md` in scope; cleaves 1-5 missed this single-line fix. Filing as a tail ride-along on the Directive avoids new-Issue protocol overhead for one line. `Refs #149` (not `Closes`) because #149 closes via `/complete-directive` after this lands.

## What
Replace `Mode switching is manual in v0; orchestration is v1+ (§0.4).` with current-state framing: `Workflow selection between eng-mode and dir-mode is manual; an automatic selector is a deferred capability (SPEC §0.4).` Also bumped `§5.10-§5.14` → `§5.10-§5.18` to cover the full dir-mode command range (§5.15-§5.18 added post-#149-filing).

## Test plan
- [x] `grep -n 'in v0\|v1+' .claude/CLAUDE.md` returns empty.
- [x] SPEC §0.4 cross-reference still resolves (Deferred capabilities section).
- [x] Smoke pass=373 fail=0 (no behavior change).

## Ship gate
- [x] No code/hook/skill changes
- [x] No new dependencies
- [x] Docs in sync (no other file references this line)