### PR TITLE
fix(#189): restore dir-mode substrate preflight grep (cut -f1)

### DIFF
--- a/.claude/commands/block-directive.md
+++ b/.claude/commands/block-directive.md
@@ -11,7 +11,7 @@ Not reviewer-gated by `activation-reviewer` — blocking is an annotation, not a
 
 ## Procedure
 
-0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | cut -f1 | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Parse arguments** — `<issue-#>` is the GitHub Issue number; `--reason <why>` is **mandatory**. If `--reason` is missing or its value is empty after whitespace-trim: error ("--reason <why> is required for /block-directive") and stop.
 

--- a/.claude/commands/complete-directive.md
+++ b/.claude/commands/complete-directive.md
@@ -9,7 +9,7 @@ Issue close-as-completed IS the Status=Completed signal. The Project Item's Stat
 
 ## Procedure
 
-0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | cut -f1 | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Resolve the Issue** — `<issue-#>` is a GitHub Issue number. Fetch:
    ```bash

--- a/.claude/commands/file-directive.md
+++ b/.claude/commands/file-directive.md
@@ -9,7 +9,7 @@ Create a new Directive as a GitHub Issue. Body authored from `.claude/templates/
 
 ## Procedure
 
-0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | cut -f1 | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Author the body** from `.claude/templates/directive.md`:
    - **Objective** — bounded by concrete artifact-level boundary (issue counts, file paths, AC ticks, merge events). Refuse to proceed if the Objective doesn't name a concrete artifact-level boundary.

--- a/.claude/commands/link-directive.md
+++ b/.claude/commands/link-directive.md
@@ -7,7 +7,7 @@ Link an Execution Issue to its parent Directive by ensuring the `Parent Directiv
 
 ## Procedure
 
-0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | cut -f1 | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Validate the two arguments**:
    - `<directive-#>` — must be a `directive`-labeled, OPEN Issue. Fetch via `gh issue view`. If not a Directive: stop.

--- a/.claude/commands/list-directives.md
+++ b/.claude/commands/list-directives.md
@@ -7,7 +7,7 @@ List Directive Issues filtered by Status label. Read-only; queries Issues direct
 
 ## Procedure
 
-0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | cut -f1 | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Parse arguments**:
    - `--status <state>` — one of `Proposed | Active | Blocked | Completed | All`. Default: omit `Completed` (show Proposed + Active + Blocked).

--- a/.claude/commands/revise-directive.md
+++ b/.claude/commands/revise-directive.md
@@ -9,7 +9,7 @@ Issues are SSOT. The Project Item is unchanged by this command (body content isn
 
 ## Procedure
 
-0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | grep -qx directive` fails. Fail-open on `gh` network errors.
+0. **Substrate preflight**: abort with `"target lacks dir-mode substrate; run /onboard-dir-mode --tier 2 first"` if `gh label list | cut -f1 | grep -qx directive` fails. Fail-open on `gh` network errors.
 
 1. **Resolve the Issue** — `<issue-#>` is a GitHub Issue number. Fetch:
    ```bash

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -5106,6 +5106,28 @@ else
   ng "63g: onboard_target --tier 2 --dry-run missing one or more required labels (regression-guard for label-parser drift) (#118 + #133)"
 fi
 
+# §63h: substrate-preflight grep CORRECTNESS (#189). §63e asserts the preflight
+# is PRESENT; this asserts its grep can actually match. `gh label list` is
+# tab-separated (name<TAB>desc<TAB>color), so `grep -qx directive` (whole-line-
+# exact) never matches → the guard silently falls open (a no-op that never
+# guards). The correct form pipes through `cut -f1` first, as /activate and
+# /file-directive step-3 already do. Two-part guard: (a) no command file retains
+# the whole-line form (AC#1 predicate verbatim); (b) the 6 directive-gated
+# commands use the `cut -f1` form.
+s63h_stale=$(grep -rlF 'gh label list | grep -qx' "$SHELL_ROOT/.claude/commands/" 2>/dev/null || true)
+s63h_cut=0
+for cmd in file-directive complete-directive revise-directive \
+           block-directive list-directives link-directive; do
+  if grep -qF 'gh label list | cut -f1 | grep -qx directive' "$SHELL_ROOT/.claude/commands/${cmd}.md"; then
+    s63h_cut=$((s63h_cut + 1))
+  fi
+done
+if [ -z "$s63h_stale" ] && [ "$s63h_cut" = 6 ]; then
+  ok "63h: substrate-preflight grep uses cut -f1 in all 6 directive-gated commands; no whole-line form remains (#189)"
+else
+  ng "63h: substrate-preflight grep regression — whole-line form in [$(printf '%s' "${s63h_stale:-none}" | tr '\n' ' ')], cut-form count $s63h_cut/6 (#189)"
+fi
+
 # ---------- 64. version surface (#123 / Directive #122) ----------
 # 64a — VERSION file is exactly one non-empty line (semver 0.x format
 # locked by Directive #122 constraint #1; no comments, no trailing


### PR DESCRIPTION
Closes #189

## Goal
Restore the dir-mode substrate preflight in the 6 directive-gated command files — its `gh label list | grep -qx directive` check never matches (tab-separated output), so the guard silently falls open and never aborts on a bare tier-1 target.

## How this serves the mission
SSOT/guardrail integrity. A preflight that can never fire is false assurance — worse than none. Restoring it makes the dir-mode substrate contract (SPEC §1.7 graceful-degradation principle) actually enforced, per the "every matcher reaches a decided state, no silent fall-through" enforcement philosophy in CLAUDE.md.

## Plan
Single mechanical root cause, empirically confirmed: `gh label list` emits tab-separated rows (`name<TAB>desc<TAB>color`), so whole-line-exact `grep -qx directive` never matches → the preflight's fail branch always fires the fall-open path. Insert `cut -f1` before `grep -qx`, mirroring the already-correct form in `/activate` (step 0) and `/file-directive` (step 3). All 6 broken lines are byte-identical → uniform edit.

This is a `fix`: Doc phase relaxed. `Docs: n/a — behavior-restoring fix; the 6 command files are their own procedure-SSOT and the edit IS the doc fix; SPEC carries no gh-label-list literal (grep-confirmed); CLAUDE.md unaffected.` The fix's reproduce-first anchor is the failing §63h smoke assertion.

## Alternatives considered
- `--json name --jq` form instead of `cut -f1`: rejected — `cut -f1` is the established repo idiom (`/activate`, `/file-directive` step 3); matching it minimizes diff + reviewer load. AC permits either; consistency wins.
- Extract a shared preflight helper to dedupe the 6 identical lines: rejected — out of scope for a `fix`; the lines are Markdown procedure prose, not sourced shell, so no clean dedup target. File a separate `refactor` if wanted.
- New §67 smoke section for the assertion: rejected — §63 already owns the preflight family (§63e = presence); §63h co-locates the correctness check and avoids renumbering.

## Key context
- 6 byte-identical broken lines at step 0: `file-directive.md:12`, `complete-directive.md:12`, `revise-directive.md:12`, `block-directive.md:14`, `list-directives.md:10`, `link-directive.md:10`.
- Correct reference form: `.claude/commands/activate.md` step 0; `file-directive.md` step 3 (`cut -f1`).
- Smoke §63 preflight family: `scripts/test/smoke.sh:5006+`; §63e = presence; §63h added = correctness.

## Checklist
- [x] **Doc**: n/a — behavior-restoring fix (reason in Plan above); no doc commit.
- [x] **Test**: §63h in `scripts/test/smoke.sh` — (a) no whole-line form remains across `.claude/commands/` (AC#1 predicate); (b) all 6 directive-gated commands use the `cut -f1` form. Confirmed FAILS against pre-fix files (cut-form 0/6).
- [x] **Code**: applied `cut -f1` to the step-0 preflight line in all 6 files; full smoke suite green (382 pass, 0 fail) incl. §63h; `grep -rl 'gh label list | grep -qx' .claude/commands/` returns nothing.

## Out of scope
- Changing the preflight's fail-open-on-`gh`-error semantics.
- Modifying §63e (presence assertion stays; correctness is additive).
- Deduping the 6 identical preflight lines (separate `refactor`).
- Any SPEC / CLAUDE.md edit (neither carries the broken pattern).

## Risks
- Compatibility: none — the fix makes a never-matching guard match correctly. On a repo with the `directive` label the preflight now passes; on one without it, it now correctly aborts with the existing `/onboard-dir-mode --tier 2` message. Network-error fail-open path untouched.
- Security/data/perf: none.

## Open questions
None.

## Test plan
- [x] Full smoke suite green (382 pass / 0 fail), including §63h and §63e.
- [x] `grep -rl 'gh label list | grep -qx' .claude/commands/` returns nothing.
- [x] Empirical: `gh label list | cut -f1 | grep -qx directive` matches on this repo; old form does not.

## Docs touched
- [x] n/a — see Plan (behavior-restoring fix; no SSOT outside edited command files).

## Ship gate
- [x] All tests pass (smoke 382/0 local; CI bash -n + smoke green on macos + ubuntu)
- [x] code-reviewer passed (verdict: clean, no blockers)
- [x] Docs in sync (n/a — behavior-restoring; no SSOT carries the literal, reviewer-confirmed)
- [x] PR body curated
- [x] CI green
