### PR TITLE
chore: allow gh pr merge in shared shell permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(gh pr merge:*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/changelog_unreleased/changed/200.md
+++ b/changelog_unreleased/changed/200.md
@@ -1,0 +1,1 @@
+- The distributed `.claude/settings.json` now grants a `permissions.allow` rule for `gh pr merge`, so `/ship`'s merge step clears the harness auto-mode authorization gate without a per-merge prompt. Adopting repos inherit this grant; scope it down via `settings.local.json` if a narrower blast radius is wanted. (#200)


### PR DESCRIPTION
## Goal
Add a `permissions.allow` rule for `Bash(gh pr merge:*)` to the distributed `.claude/settings.json` so `/ship`'s merge step clears the harness auto-mode authorization gate.

## How this serves the mission
Removes a per-merge authorization prompt from the `unattended` flow (MISSION "Success looks like" — an unattended session producing a merged PR). The merge was the one remaining manual touch in an otherwise end-to-end `/ship`.

## Plan
`chore` (config-only; no Doc→Test→Code — no behavior in shell scripts changes, only a Claude Code permission grant). No linked issue (optional commit group).

## Alternatives considered
- **`.claude/settings.local.json` (gitignored, local-only)**: scopes the grant to this machine, does NOT propagate to shell adopters. Narrower blast radius. Rejected *for this PR* only because the maintainer explicitly chose the shared/committed path; this is the documented trade.
- **No standing rule — authorize each merge manually**: status quo; rejected because it leaves a manual touch in every `/ship`.

## Key context
- `.claude/settings.json` is the committed config adopting repos inherit — this grant propagates to them.
- The harness auto-mode classifier (separate from the shell's `ac-closeout` hook) is what previously denied autonomous merge.

## Out of scope
- Any change to the shell's hook enforcement or runtime scripts.
- Scoping the grant per-repo (would be `settings.local.json`).

## Risks
- **Breadth (security surface)**: a committed `gh pr merge` allow grants auto-merge authorization to *every* repo that adopts this shell, not just the maintainer. The `security-reviewer` gate is the explicit checkpoint for whether that breadth is intended. If it flags this, the fallback is `settings.local.json`.

## Decisions
- 2026-05-29: Maintainer chose the shared/committed `settings.json` over local-only `settings.local.json` (option (a)), accepting adopter-wide propagation.

## Test plan
- [ ] `jq -e . .claude/settings.json` parses (valid JSON).
- [ ] `scripts/test/smoke.sh` unaffected (388 baseline).

## Docs touched
- [~] N/A — config grant, no SSOT prose surface.

## Ship gate
- [ ] All tests pass
- [ ] code-reviewer passed
- [ ] security-reviewer passed (breadth decision)
- [ ] Docs in sync
- [ ] PR body curated
- [ ] CI green
