### PR TITLE
docs(#298): reword SPEC §0.1 dir-mode label to "Setting direction"

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -123,7 +123,7 @@ An operating shell for Claude Code that runs on top of the standard GitHub workf
 The shell covers two layers of the same workflow:
 
 - **Engineering execution** — issue → branch → draft PR → checklist commits → ready PR → merge. Per the GitHub-standard flow.
-- **Directing maintenance** — `MISSION.md` → Directive Issue → Execution Issue, where a Directive is a medium-term directional context that scopes several issues without being directly executable.
+- **Setting direction** — `MISSION.md` → Directive Issue → Execution Issue, where a Directive is a medium-term directional context that scopes several issues — a feature with subsystems, a refactor, a migration alike — without being directly executable.
 
 Both layers use the same generate → review → mode-based-approval → audit pattern (§1.5). See §1.7 for the eng-mode / dir-mode split, §2.1 for the Directive lifecycle, §4.9 for the dir-mode reviewer.
 


### PR DESCRIPTION
Closes #298

## Goal
Reword SPEC §0.1's dir-mode label from "Directing maintenance" to "Setting direction" so the SSOT label matches its own type-neutral definition.

## How this serves the mission
Active SSOT maintenance — SPEC is the process SSOT. A label that contradicts its adjacent definition ("a Directive is a medium-term directional context that scopes several issues") is the drift class the shell exists to prevent, and "maintenance" can mislead a contributor about when to reach for a Directive.

## Plan
One-line prose reword in SPEC §0.1. **Doc → Test → Code relaxed** (no Test/Code phases): this is a label clarification with no executable contract — external behavior is the rendered SPEC text. **planner skipped**: 1 file, one line, below CLAUDE.md's planner threshold (3+ files / migration / schema / external-contract change); the §0.1 *definition* is unchanged, so this is not a contract change.

## Alternatives considered
- Keep SPEC's "Directing maintenance" label verbatim: rejected — it's the lone surviving instance of the narrow framing the project already retired in the README (#297), and it contradicts the definition beside it.
- "Direction-setting" / "Directing the work": viable, but "Setting direction" matches the README's "setting direction" wording (#297), which is the whole point of the alignment. Forced toward the README-consistent phrasing.

## Key context
- `SPEC.md:126` — the sole occurrence of "Directing maintenance" (confirmed by grep at filing + activation review).
- `README.md:49` — already uses "setting direction" (merged in #297); this aligns SPEC to it.

## Checklist
- [x] **Doc**: reword SPEC §0.1 dir-mode label + name feature/refactor/migration scope inline

## Out of scope
- No behavior / hook / skill changes.
- No change to the §0.1 section heading ("What this is") — TOC unaffected.
- README already fixed in #297.

## Test plan
- [x] `grep -in "directing maintenance" SPEC.md` → 0 remaining
- [x] `./scripts/build_toc.sh --check` → clean (heading unchanged)
- [x] `./scripts/test/smoke.sh` → pass=547 fail=0

## Docs touched
- [x] SPEC.md (§0.1 label)

## Ship gate
- [x] All tests pass — local `./scripts/test/smoke.sh` = pass=547 fail=0
- [x] code-reviewer passed (verdict: pass, no blockers; security-reviewer N/A — docs only)
- [x] Docs in sync — repo-wide grep shows no remaining "directing maintenance"; README already aligned
- [x] PR body curated
- [x] CI green — `gh pr checks 299`: bash -n + smoke pass on macos-latest and ubuntu-latest

