### PR TITLE
fix(#309): repair check-changelog.yml YAML startup-failure (heredoc to here-string)

### DIFF
--- a/.claude/templates/target-substrate/workflows/check-changelog.yml
+++ b/.claude/templates/target-substrate/workflows/check-changelog.yml
@@ -117,9 +117,11 @@ jobs:
             fi
 
             echo "check-changelog: $path validates (stem=$stem, bullet form, in allow-set)"
-          done <<EOF
-$added
-EOF
+            # Here-string (not a `<<EOF` heredoc): a heredoc terminator must sit
+            # at column 0, which dedents out of this `run: |` YAML block scalar
+            # and startup-fails the whole workflow (#309). `<<<` keeps every line
+            # inside the block. smoke §81 guards against re-introducing the break.
+          done <<< "$added"
 
           if [ "$bad" = 1 ]; then
             echo "::error::One or more added fragments failed validation. Every added fragment must satisfy all rules (positive-integer stem, leading '- ' bullet, (#<N>) ref matching the stem, stem in the PR/issue allow-set) — one valid fragment does not excuse a malformed sibling. See SPEC §18.6." >&2

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -117,9 +117,11 @@ jobs:
             fi
 
             echo "check-changelog: $path validates (stem=$stem, bullet form, in allow-set)"
-          done <<EOF
-$added
-EOF
+            # Here-string (not a `<<EOF` heredoc): a heredoc terminator must sit
+            # at column 0, which dedents out of this `run: |` YAML block scalar
+            # and startup-fails the whole workflow (#309). `<<<` keeps every line
+            # inside the block. smoke §81 guards against re-introducing the break.
+          done <<< "$added"
 
           if [ "$bad" = 1 ]; then
             echo "::error::One or more added fragments failed validation. Every added fragment must satisfy all rules (positive-integer stem, leading '- ' bullet, (#<N>) ref matching the stem, stem in the PR/issue allow-set) — one valid fragment does not excuse a malformed sibling. See SPEC §18.6." >&2

--- a/changelog_unreleased/fixed/309.md
+++ b/changelog_unreleased/fixed/309.md
@@ -1,0 +1,1 @@
+- `check-changelog.yml` no longer startup-fails: a bash heredoc whose `EOF` terminator sat at column 0 dedented out of the `run: |` YAML block scalar and made GitHub fail to load the whole workflow, so the per-PR changelog fragment gate had silently never run. Replaced with an indented here-string; a new smoke §81 parses every workflow YAML to catch regressions. (#309)

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -7363,6 +7363,52 @@ else
   ng "80g: /onboard.md must stay read-only — no mutating command (#307)"
 fi
 
+# ---------- 81. workflow YAML loadability (#309) ----------
+# A workflow file that fails to PARSE startup-fails on GitHub — every job is
+# skipped, the run name shows the file path instead of the declared `name:`,
+# and it fires on the raw push event regardless of `on:`. Such a failure is
+# invisible unless the workflow is a required check. #309's root cause was a
+# bash heredoc whose `EOF` terminator sat at column 0, dedenting out of the
+# `run: |` block scalar and breaking YAML for the whole file. This regression
+# parses EVERY workflow so a future block-scalar break is caught pre-merge.
+
+# Parse one YAML file. rc 0 = parses, 1 = parse error, 2 = no parser available.
+s81_yaml_ok() {
+  if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+    python3 -c 'import yaml,sys; yaml.safe_load(open(sys.argv[1]))' "$1" >/dev/null 2>&1
+    return $?
+  elif command -v ruby >/dev/null 2>&1; then
+    ruby -ryaml -e 'YAML.load_file(ARGV[0])' "$1" >/dev/null 2>&1
+    return $?
+  fi
+  return 2
+}
+
+s81_parser=skip
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+  s81_parser=python3
+elif command -v ruby >/dev/null 2>&1; then
+  s81_parser=ruby
+fi
+
+if [ "$s81_parser" = skip ]; then
+  # No YAML parser in this environment — the GitHub CI run is the backstop.
+  ok "81a: workflow-YAML parse regression skipped — no python3-yaml/ruby parser here (#309)"
+else
+  s81_bad=""
+  for wf in "$SHELL_ROOT"/.github/workflows/*.yml "$SHELL_ROOT"/.github/workflows/*.yaml; do
+    [ -e "$wf" ] || continue
+    if ! s81_yaml_ok "$wf"; then
+      s81_bad="$s81_bad $(basename "$wf")"
+    fi
+  done
+  if [ -z "$s81_bad" ]; then
+    ok "81a: every .github/workflows/*.yml parses as YAML (parser=$s81_parser) (#309)"
+  else
+    ng "81a: workflow YAML failed to parse —$s81_bad (parser=$s81_parser) (#309)"
+  fi
+fi
+
 # ---------- restore registry ----------
 if [ -n "$ORIG_REG_BAK" ]; then
   mv "$ORIG_REG_BAK" "$ORIG_REG"


### PR DESCRIPTION
Closes #309

## Goal
Repair `check-changelog.yml`, which has been startup-failing on GitHub so the per-PR changelog fragment gate never actually ran.

## How this serves the mission
Serves MISSION § "Success looks like > The flow holds in unattended runs" — a release-backbone gate (SPEC §18.6) that silently never runs is a false-green that lets malformed/missing fragments through until a `/release`. This PR makes the gate real.

## Plan
`fix` — **reproduce-first** (doc phase relaxed: no external contract change; the gate's contract is unchanged, only its YAML loadability). Root cause: a bash heredoc whose `EOF` terminator sits at column 0 dedents out of the `run: |` YAML block scalar, so GitHub cannot parse the file → startup_failure (run name = file path, 0 jobs, fires on raw `push`; **no `pull_request` run ever existed**, across #303 and #308). Reproduced with ruby Psych: `could not find expected ':' ... line 121 column 1`.

Fix: replace the column-0 heredoc with an indented here-string `done <<< "$added"` (functionally identical, stays inside the block), in **both** the shell-root workflow and the byte-identical canonical `target-substrate` copy (smoke §66b). Add smoke §81 parsing every workflow YAML as a regression.

Phasing: **Test** (smoke §81, red against the broken file) → **Code** (heredoc → here-string in both copies, §81 green).

## Alternatives considered
- **Apply the `skip-changelog` label to suppress the failure**: rejected — the label is checked in a *step inside a job*, but a startup_failure runs *zero* jobs, so the label can never be reached. It treats the symptom (a red mark) not the cause (unparseable YAML).
- **`<<-EOF` (dash heredoc)**: rejected — `<<-` only strips leading *tabs*, and tabs can't be used for YAML indentation; the terminator would still need to align inside the block. The here-string is simpler and unambiguous.

## Key context
- `.github/workflows/check-changelog.yml` (+ canonical `.claude/templates/target-substrate/workflows/check-changelog.yml`) — the heredoc at the former lines 120–122.
- `scripts/test/smoke.sh` §81 (new), §66b (byte-identity invariant).

## Checklist
- [x] **Test**: smoke §81 parses every `.github/workflows/*.yml` (python3-yaml or ruby; graceful skip if neither). Red against the broken file.
- [x] **Code**: heredoc → here-string in both byte-identical copies; §81 + §66b green; full smoke 554/0.
- [x] **Reproduce-first**: ruby Psych error captured before the fix.

## Out of scope
- No change to the fragment-gate validation logic / contract (SPEC §18.1/§18.6).
- No change to branch-protection required checks.
- No retroactive fragment validation of already-merged PRs.

## Risks
- Low. The here-string is functionally identical to the heredoc (feeds `$added` + newline into the `while` loop). The chief verification is that `check-changelog` now appears as a real `pull_request` PR check on *this* PR with `jobs > 0` — which also exercises the gate against this PR's own `fixed/309.md` fragment.

## Test plan
- [x] `ruby -ryaml` parses both copies.
- [x] smoke 554/0 (§81 + §66b green).
- [ ] On this PR, `check-changelog` runs as a `pull_request` check (name `check-changelog`, jobs > 0) and passes on `fixed/309.md`.

## Docs touched
- [x] n/a — no SSOT/contract change (workflow comment added explaining the constraint). `fix`, external behavior of the gate unchanged.

## Ship gate
- [ ] All tests pass
- [ ] code-reviewer passed
- [ ] Docs in sync
- [ ] PR body curated
- [ ] CI green (incl. the now-live check-changelog)
