### PR TITLE
fix(#375): scope bypass-suspect to shell-spawning heredocs + add /sync-pr Stop arm

### DIFF
--- a/.claude/hooks/helpers/pr_cache.sh
+++ b/.claude/hooks/helpers/pr_cache.sh
@@ -81,6 +81,27 @@ pr_cache_read() {
   printf '%s' "$sha"
 }
 
+pr_cache_head() {
+  # Print the cached `last_synced_head` (the HEAD SHA at the last /sync-pr) for
+  # PR <n>, or empty if no cache exists. Mirrors pr_cache_read's jq-primary +
+  # grep-fallback shape and the `cache_path` naming hazard note (#82). The Stop
+  # hook compares this to `git rev-parse HEAD` to decide the /sync-pr nudge
+  # (SPEC §6.3); a differing/empty result is treated as "not in sync" by the
+  # caller, so a corrupt/absent cache fails soft to no-nudge rather than erroring.
+  local cache_path
+  cache_path=$(_pr_cache_path "$1")
+  [ -f "$cache_path" ] || return 0
+
+  local head=""
+  if command -v jq >/dev/null 2>&1; then
+    head=$(jq -er '.last_synced_head // ""' "$cache_path" 2>/dev/null) || head=""
+  else
+    head=$(grep -oE '"last_synced_head"[[:space:]]*:[[:space:]]*"[^"]*"' "$cache_path" 2>/dev/null \
+      | head -1 | sed -E 's/.*"([^"]*)"$/\1/')
+  fi
+  printf '%s' "$head"
+}
+
 pr_cache_write() {
   local n="$1" body_sha="$2" head="${3:-}"
   # See pr_cache_read for why `path` is renamed to `cache_path` (#82).

--- a/.claude/hooks/pre_tool_use.sh
+++ b/.claude/hooks/pre_tool_use.sh
@@ -138,9 +138,17 @@ case "$tool" in
     # `eval "git push --force"` still gets blocked by the force-push
     # matcher on the literal substring, while plain `eval "ls"` warns
     # and proceeds.
-    # Heredoc pattern excludes `<<<` here-strings (preceding-char check).
+    # Heredoc branch is scoped to *shell-spawning* heredocs per SPEC §6.1
+    # ("heredoc-spawned shells (bash <<EOF)") — a shell verb (bash/sh/zsh,
+    # optionally /path/-prefixed or env-wrapped, with short flags) in command
+    # position governing `<<`. So `bash <<EOF`, `env bash <<EOF`, `/bin/bash
+    # <<EOF` warn, while benign data heredocs do NOT — incl. a `.sh`/`.zsh`
+    # *operand* (`cat foo.sh <<EOF`), since only the verb + short flags may sit
+    # between it and `<<`. Excludes `<<<` here-strings (delimiter check). Residual
+    # under-warn: a shell reached via a *non-space* adjacency (backtick, `>`, tab)
+    # — warn-only matcher, so an under-warn costs an audit line, not a gate (§6.0).
     if printf '%s' "$cmd" | grep -qE '(^|[^[:alnum:]_])(eval|bash[[:space:]]+-c|sh[[:space:]]+-c|python[[:space:]]*[0-9.]*[[:space:]]+-c)([^[:alnum:]_]|$)' \
-       || printf '%s' "$cmd" | grep -qE '(^|[^<])<<-?[[:space:]]*[A-Za-z_]'; then
+       || printf '%s' "$cmd" | grep -qE '(^| |;|\||&|\(|\{)(env )?(/[^ ]*/)?(bash|sh|zsh)( -[A-Za-z]+)* *['\''"]*<<-?[[:space:]]*['\''"]*[A-Za-z_]'; then
       decided=
       audit_log warn bypass-suspect notice "$cmd"
       decided=1

--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -35,4 +35,21 @@ if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; th
   printf '[claude-eng-shell] uncommitted changes present. consider /review.\n' >&2
 fi
 
+# Suggest /sync-pr when HEAD has advanced past the last /sync-pr — i.e. commit(s)
+# happened since the PR body was last curated, so its checklist is stale relative
+# to HEAD (SPEC §6.3 second arm). Detection is local (cached last_synced_head vs
+# `git rev-parse HEAD`) behind one `current_pr_number` lookup; this whole block
+# is already gated by the modulo throttle above, so the gh touch runs at most
+# once per N responses. No PR / no cache (never synced) / no gh → silent no-op.
+safe_source "$SHELL_ROOT/.claude/hooks/helpers/gh_state.sh" stop-syncpr || true
+safe_source "$SHELL_ROOT/.claude/hooks/helpers/pr_cache.sh" stop-syncpr || true
+pr_n=$(current_pr_number 2>/dev/null || true)
+if [ -n "$pr_n" ]; then
+  cached_head=$(pr_cache_head "$pr_n" 2>/dev/null || true)
+  cur_head=$(git rev-parse HEAD 2>/dev/null || true)
+  if [ -n "$cached_head" ] && [ -n "$cur_head" ] && [ "$cached_head" != "$cur_head" ]; then
+    printf '[claude-eng-shell] commit(s) since last /sync-pr. consider /sync-pr.\n' >&2
+  fi
+fi
+
 exit 0

--- a/changelog_unreleased/added/375.md
+++ b/changelog_unreleased/added/375.md
@@ -1,0 +1,1 @@
+- Stop-hook nudge: when commits land after the last `/sync-pr`, the shell now suggests `/sync-pr` so the PR-body checklist stays in sync with HEAD (SPEC §6.3 second arm). (#375)

--- a/changelog_unreleased/fixed/375.md
+++ b/changelog_unreleased/fixed/375.md
@@ -1,0 +1,1 @@
+- `bypass-suspect` hook no longer over-warns on benign data heredocs (e.g. `cat`/`wc` reading a heredoc, including a `.sh`/`.zsh` filename used as an operand); the warn is now scoped to shell-spawning heredocs as SPEC §6.1 specifies. (#375)

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -1123,7 +1123,109 @@ else
   ng "hook: single-line force-push regression (#17)"
 fi
 
+# 15f-15j (#375): bypass-suspect heredoc warn is scoped to *shell-spawning*
+# heredocs (SPEC §6.1, "heredoc-spawned shells (bash <<EOF)"). Pre-#375 the
+# matcher warned on ANY heredoc opener; benign data heredocs (cat/wc, incl. a
+# `.sh` filename used as an OPERAND) must NOT trip it, while `bash <<EOF` and
+# `env bash <<EOF` still must. Helper: does running <cmd> add a bypass-suspect
+# audit line?
+bypass_warns() {
+  local cmd="$1" b a d
+  b=$(wc -l < "$REAL_AUDIT" 2>/dev/null | tr -d ' '); [ -z "$b" ] && b=0
+  hook_run "$cmd" >/dev/null
+  a=$(wc -l < "$REAL_AUDIT" 2>/dev/null | tr -d ' '); [ -z "$a" ] && a=0
+  d=$((a - b))
+  [ "$d" -ge 1 ] && tail -n "$d" "$REAL_AUDIT" 2>/dev/null | grep -q 'bypass-suspect'
+}
+# Benign data heredocs — must NOT warn (RED on the pre-#375 broad regex).
+if ! bypass_warns 'cat <<EOF
+hello
+EOF'; then
+  ok "15f: benign 'cat <<EOF' does not trip bypass-suspect (#375)"
+else
+  ng "15f: 'cat <<EOF' over-warns bypass-suspect (heredoc scope too broad) (#375)"
+fi
+if ! bypass_warns 'cat foo.sh <<EOF
+x
+EOF'; then
+  ok "15g: 'cat foo.sh <<EOF' (.sh operand) does not trip bypass-suspect (#375)"
+else
+  ng "15g: '.sh' filename operand false-trips bypass-suspect (#375)"
+fi
+if ! bypass_warns 'wc -l <<EOF
+x
+EOF'; then
+  ok "15h: benign 'wc -l <<EOF' does not trip bypass-suspect (#375)"
+else
+  ng "15h: 'wc -l <<EOF' over-warns bypass-suspect (#375)"
+fi
+# Shell-spawning heredocs — must STILL warn.
+if bypass_warns 'bash <<EOF
+echo hi
+EOF'; then
+  ok "15i: 'bash <<EOF' still warns bypass-suspect (shell-spawning) (#375)"
+else
+  ng "15i: 'bash <<EOF' no longer warns — under-warns shell-spawning heredoc (#375)"
+fi
+if bypass_warns 'env bash <<EOF
+echo hi
+EOF'; then
+  ok "15j: 'env bash <<EOF' still warns bypass-suspect (env-wrapped shell) (#375)"
+else
+  ng "15j: 'env bash <<EOF' no longer warns (#375)"
+fi
+
 rm -rf "$HOOK_TMP"
+
+# ---------- 15s (#375): /sync-pr Stop-arm detection (SPEC §6.3 second arm) ----------
+# The Stop hook's second arm nudges /sync-pr when HEAD advanced past the last
+# /sync-pr (cached last_synced_head != git rev-parse HEAD). The detection unit
+# is the new pr_cache_head reader + a head comparison; stop.sh wires it behind
+# current_pr_number + the modulo throttle (the gh/in_scope/throttle gating is
+# exercised structurally below, not end-to-end — it cannot fire in the unregistered
+# fake repo without gh). pr_cache_head does not exist pre-#375 → these go RED.
+S15S_DIR="$TMP/syncpr"
+mkdir -p "$S15S_DIR"
+(
+  cd "$S15S_DIR" || exit 1
+  git init -q . && git config user.email t@t && git config user.name t
+  git commit -q --allow-empty -m seed
+) >/dev/null 2>&1
+# shellcheck disable=SC1091
+. "$SHELL_ROOT/.claude/hooks/helpers/pr_cache.sh"
+export PR_CACHE_DIR="$S15S_DIR/cache" PR_CACHE_REPO="test/repo"
+old_head=$(cd "$S15S_DIR" && git rev-parse HEAD)
+pr_cache_write 7 deadbeefsha "$old_head"
+# §15s-a: pr_cache_head reads back the written head.
+if [ "$(pr_cache_head 7)" = "$old_head" ]; then
+  ok "15s-a: pr_cache_head returns the cached last_synced_head (#375)"
+else
+  ng "15s-a: pr_cache_head missing or wrong (got '$(pr_cache_head 7)') (#375)"
+fi
+# §15s-b: in-sync — cached head == current HEAD → NOT out of sync.
+cur_head=$(cd "$S15S_DIR" && git rev-parse HEAD)
+if [ "$(pr_cache_head 7)" = "$cur_head" ]; then
+  ok "15s-b: HEAD unchanged since sync → no /sync-pr nudge condition (#375)"
+else
+  ng "15s-b: in-sync HEAD wrongly differs from cached (#375)"
+fi
+# §15s-c: out-of-sync — advance HEAD, cached head now differs → nudge condition.
+(cd "$S15S_DIR" && git commit -q --allow-empty -m next) >/dev/null 2>&1
+new_head=$(cd "$S15S_DIR" && git rev-parse HEAD)
+if [ "$(pr_cache_head 7)" != "$new_head" ]; then
+  ok "15s-c: commit since last /sync-pr → out-of-sync condition holds (#375)"
+else
+  ng "15s-c: out-of-sync not detected after a new commit (#375)"
+fi
+unset PR_CACHE_DIR PR_CACHE_REPO
+# §15s-d: stop.sh wires the arm (current_pr_number + pr_cache_head + /sync-pr nudge).
+if grep -q 'pr_cache_head' "$SHELL_ROOT/.claude/hooks/stop.sh" \
+   && grep -q 'current_pr_number' "$SHELL_ROOT/.claude/hooks/stop.sh" \
+   && grep -q '/sync-pr' "$SHELL_ROOT/.claude/hooks/stop.sh"; then
+  ok "15s-d: stop.sh wires the /sync-pr arm (current_pr_number + pr_cache_head) (#375)"
+else
+  ng "15s-d: stop.sh missing the /sync-pr arm wiring (#375)"
+fi
 
 # ---------- 16. heredoc -m subject extraction (#28) ----------
 # pre_tool_use must accept the heredoc `-m "$(cat <<'TAG' ... TAG )"` form

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -1186,10 +1186,13 @@ rm -rf "$HOOK_TMP"
 # fake repo without gh). pr_cache_head does not exist pre-#375 → these go RED.
 S15S_DIR="$TMP/syncpr"
 mkdir -p "$S15S_DIR"
+# commit.gpgsign=false guards against a developer's global gpgsign=true, which
+# would fail the test identity's signing and leave HEAD unborn (#375).
+S15S_GIT=(git -c commit.gpgsign=false -c user.email=t@t -c user.name=t)
 (
   cd "$S15S_DIR" || exit 1
-  git init -q . && git config user.email t@t && git config user.name t
-  git commit -q --allow-empty -m seed
+  git init -q .
+  "${S15S_GIT[@]}" commit -q --allow-empty -m seed
 ) >/dev/null 2>&1
 # shellcheck disable=SC1091
 . "$SHELL_ROOT/.claude/hooks/helpers/pr_cache.sh"
@@ -1210,7 +1213,7 @@ else
   ng "15s-b: in-sync HEAD wrongly differs from cached (#375)"
 fi
 # §15s-c: out-of-sync — advance HEAD, cached head now differs → nudge condition.
-(cd "$S15S_DIR" && git commit -q --allow-empty -m next) >/dev/null 2>&1
+(cd "$S15S_DIR" && "${S15S_GIT[@]}" commit -q --allow-empty -m next) >/dev/null 2>&1
 new_head=$(cd "$S15S_DIR" && git rev-parse HEAD)
 if [ "$(pr_cache_head 7)" != "$new_head" ]; then
   ok "15s-c: commit since last /sync-pr → out-of-sync condition holds (#375)"


### PR DESCRIPTION
Closes #375

## Goal
Resolve two code↔SPEC behavior mismatches surfaced by the accuracy sweep, both toward SPEC: (1) the `bypass-suspect` hook over-warned on *any* heredoc; narrow it to shell-spawning heredocs (SPEC §6.1). (2) The §6.3 Stop hook promised a `/sync-pr` nudge that was never implemented; add it.

## How this serves the mission
MISSION §1.3 (active SSOT) + §6.0 (enforcement-style). Arm 2 restores a positive, ignorable nudge SPEC §6.3 promises; arm 1 narrows a warn matcher firing wider than its documented scope (audit-log noise degrades the #356 observability signal). Parent Directive #373 (reconciliation arm).

## Plan
`fix` → reproduce-first. Doc n/a (SPEC §6.3/§6.1 already correct). Test (failing smoke) → Code.

## Alternatives considered
- Arm-1 detection — gh-API checklist diff: rejected (per-response gh round-trip; the Stop hook fires every response). Local `last_synced_head` vs `git rev-parse HEAD` is free.
- Arm-1 — reuse the body-SHA cache: rejected (tracks the PR body, not HEAD; §6.3 keys on commit-recency).
- Arm-2 narrowing — allow-list benign openers: rejected (open-ended; inverts SPEC's positive "shell-spawning" framing). Verb-anchoring is the closed form.
- Arm-2 — drop the heredoc branch: rejected (`bash <<…` with no `-c` is a genuine in-scope shell-spawning heredoc).

## Key context
- `pre_tool_use.sh` bypass-suspect matcher — heredoc branch narrowed to a shell verb (bash/sh/zsh, env-/path-prefixed, short flags) governing the heredoc operator; tolerates the single-quoting `parse_env_prefix` applies to the operator token. Decided-state shape unchanged (§6.1 pass-through invariant).
- `pr_cache.sh` — new `pr_cache_head` reader (`.last_synced_head`), mirrors `pr_cache_read`.
- `stop.sh` — second arm: `current_pr_number` + `pr_cache_head` vs `git rev-parse HEAD`, under the existing `CLAUDE_ENG_STOP_THROTTLE`; never blocks; no-op on no-PR/no-cache/no-gh.

## Checklist
- [~] **Doc**: N/A — SPEC §6.3/§6.1 already state the target behavior; code aligns to SPEC.
- [x] **Test**: smoke §15f–15j (heredoc scope) + §15s (pr_cache_head + out-of-sync condition + stop.sh wiring); RED before code.
- [x] **Code**: regex narrowing + `pr_cache_head` + stop.sh arm.

## Out of scope
- No SPEC prose change (already correct). No change to the `bash -c`/`sh -c`/`python -c` branch. No `/sync-pr` skill change.

## Risks
- **Arm-2 residual under-warn**: a shell reached via a *non-space* adjacency (backtick, `>`, tab) won't warn. Accepted: warn-only matcher → an under-warn costs an audit line, not a gate (§6.0 cost-asymmetry). `bash -c`-style spawns still caught by the first branch.
- **Arm-1 false nudge**: a never-synced PR has no cached head → no-op (won't nag before first sync).
- No security/data surface: arm 1 strictly *removes* spurious warns; arm 2 is stderr-only.

## Test plan
- [x] `bash scripts/test/smoke.sh` green (pass=693, fail=0); §15f-j + §15s added.
- [x] `shellcheck -S error` clean on the touched hooks/helpers.

## Docs touched
- [~] N/A — code-to-SPEC alignment; SPEC already correct.

## Ship gate
- [x] All tests pass (smoke pass=693)
- [x] code-reviewer passed (ship)
- [~] (conditional) security-reviewer — N/A — warn-only matcher narrowing, no block/auth/input surface (reviewer-confirmed)
- [x] Docs in sync (SPEC already correct)
- [x] PR body curated
- [x] CI green