### PR TITLE
docs(#411): reconcile README Quick start with the Adopting section

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -21,24 +21,24 @@ export PATH="$PWD/bin:$PATH"            # or: alias claude-eng="$PWD/bin/claude-
 ## Quick start
 
 ```bash
-# Clone a target repo into the shell's workspace/ (or register an external path — see below).
-./scripts/clone-into.sh https://github.com/<owner>/<repo>.git
-cd workspace/<repo>
-claude-eng
+# 전제조건: gh auth login (PR을 열고 issue를 다룰 수 있는 토큰).
+# 주입되는 것과 claude-eng vs claude 선택은 아래 "Adopting it on your repo"에
+# 한 곳에 정리돼 있습니다 — 실제 첫 실행 전에 읽어 두세요.
+
+# 기존 로컬 레포에 셸을 붙입니다(흔한 경로):
+./scripts/register.sh ~/code/<repo>
+cd ~/code/<repo>
+claude                          # 그냥 `claude`가 셸을 스스로 찾습니다; 아래 Invocation 참고
+#   …또는 새 레포를 workspace/로 clone하려면:
+#   ./scripts/clone-into.sh https://github.com/<owner>/<repo>.git && cd workspace/<repo>
 
 # Inside the session — the engineering loop:
-> /onboard                      # one-time: check upstream, permissions, SSOT, CI
+> /onboard                      # one-time, read-only: upstream, permissions, SSOT, CI
 > /file-issue <description>     # files the Issue as status:proposed
 > /activate <issue#>            # Proposed → Active (reviewer-gated; required before /work-on)
 > /work-on <issue#>             # branch + draft PR + planner
                                 #   …or  /work-on <issue#> --base experiment/foo  (topic-branch flow, SPEC §10.5)
 > /ship                         # review, tick AC, mark ready (→ merge in unattended mode)
-```
-
-`workspace/`로 clone하는 대신 외부 경로를 등록해도 됩니다.
-
-```bash
-./scripts/register.sh ~/code/<repo>     # or: claude-eng ~/code/<repo> — an unregistered path prompts to register
 ```
 
 ## Adopting it on your repo

--- a/README.md
+++ b/README.md
@@ -21,24 +21,24 @@ export PATH="$PWD/bin:$PATH"            # or: alias claude-eng="$PWD/bin/claude-
 ## Quick start
 
 ```bash
-# Clone a target repo into the shell's workspace/ (or register an external path — see below).
-./scripts/clone-into.sh https://github.com/<owner>/<repo>.git
-cd workspace/<repo>
-claude-eng
+# Prerequisites: gh auth login (a token that can open PRs + manage issues).
+# What this puts in your repo, and the claude-eng-vs-claude choice, are under
+# "Adopting it on your repo" below — read it before the first real run.
+
+# Point the shell at an existing local repo (the common path):
+./scripts/register.sh ~/code/<repo>
+cd ~/code/<repo>
+claude                          # plain `claude` self-locates the shell; see Invocation below
+#   …or clone a fresh target into workspace/ instead:
+#   ./scripts/clone-into.sh https://github.com/<owner>/<repo>.git && cd workspace/<repo>
 
 # Inside the session — the engineering loop:
-> /onboard                      # one-time: check upstream, permissions, SSOT, CI
+> /onboard                      # one-time, read-only: upstream, permissions, SSOT, CI
 > /file-issue <description>     # files the Issue as status:proposed
 > /activate <issue#>            # Proposed → Active (reviewer-gated; required before /work-on)
 > /work-on <issue#>             # branch + draft PR + planner
                                 #   …or  /work-on <issue#> --base experiment/foo  (topic-branch flow, SPEC §10.5)
 > /ship                         # review, tick AC, mark ready (→ merge in unattended mode)
-```
-
-Register an external repo instead of cloning into `workspace/`:
-
-```bash
-./scripts/register.sh ~/code/<repo>     # or: claude-eng ~/code/<repo> — an unregistered path prompts to register
 ```
 
 ## Adopting it on your repo

--- a/changelog_unreleased/changed/411.md
+++ b/changelog_unreleased/changed/411.md
@@ -1,0 +1,1 @@
+- README Quick start reconciled with the "Adopting it on your repo" section (#409): a one-line prerequisites pointer now leads, `register.sh <existing repo>` is the primary path (clone-into-`workspace/` shown as a secondary one-liner), and the duplicated register/invocation detail is stated once in the Adopting section instead of twice. (#411)


### PR DESCRIPTION
Closes #411

## Goal
Finish the #409 work: reconcile the README Quick start with the "Adopting it on your repo" section so first contact reads as one coherent flow, not a self-contradicting, duplicated pair.

## How this serves the mission
MISSION — selective-injection / "improves under use." #409 added the runbook section additively and left Quick start contradicting it (prereqs after the commands that need them) and duplicating it (register/invocation stated twice). This removes that fresh hand-sync drift surface and the self-contradiction — the exact first-contact friction #409 set out to eliminate.

## Plan
Docs refactor, README.md + README.ko.md, Quick start block only:
- A one-line **prerequisites pointer** (`gh auth login`) now leads Quick start and points down to "Adopting it on your repo" rather than restating it (fixes the ordering inversion without relocating the section).
- **`register.sh <existing repo>` is the primary path**; clone-into-`workspace/` is demoted to a secondary one-liner comment.
- The **duplicated** register block + `claude-eng`-vs-`claude` detail is **removed** from Quick start; it lives once in the Adopting section (Footprint + Invocation), which Quick start references.
- README.ko.md mirrors the restructure.

Doc→Test→Code relaxation: this is a **docs refactor** — it reorganizes existing documented content, introduces no new contract, and the #409 `§34` presence greps + `§110` floor guard already backstop that the Adopting section stays intact. No new Test phase; smoke stays green by construction.

## Alternatives considered
- **Lead-with-register, keep duplication/order (minimal)**: rejected — leaves the ordering inversion and the two-places-to-sync drift, the core of the complaint.
- **Merge Quick start into the Adopting section (one unified flow)**: rejected — a larger restructure than the friction warrants; Quick start as a fast command crib + Adopting as the orientation detail is a useful split once deduped.
- **Relocate the whole Adopting section above Quick start**: rejected — the one-line top pointer resolves the inversion at far lower churn; the detailed section reads better after the command crib it supports.

## Key context
- `README.md` / `README.ko.md` — Quick start block (now leads with prereq pointer + register.sh); Adopting section retained verbatim as the single source for footprint/invocation.
- `scripts/test/smoke.sh` §34 / §110 (#409) — unchanged guards; confirmed green post-edit.

## Checklist
- [x] **Doc**: Quick start opens with a one-line prerequisites pointer referencing the Adopting section (AC#1)
- [x] **Doc**: Quick start leads with `register.sh <existing repo>`; clone-into-workspace is a secondary one-liner (AC#2)
- [x] **Doc**: duplicated register/invocation detail removed from Quick start — stated once in Adopting (AC#3)
- [x] **Doc**: README.ko.md mirrors the restructure (AC#4)
- [x] **Test**: `bash scripts/test/smoke.sh` green — #409 §34/§110 guards still pass (AC#5) — pass=740 fail=0
- [~] **Code**: N/A — docs refactor, no behavior change

## Out of scope
- No new Adopting-section content; no SPEC change; no behavior change to register.sh / clone-into.sh / onboard.

## Risks
- README.ko mirror drift — mitigated by mirroring in the same commit; the §34 mirror-presence assertion backstops the section heading.
- Low blast radius: prose reorg within a single section, no runtime/hook change.

## Test plan
- [x] `bash scripts/test/smoke.sh` → pass=740 fail=0 (the seven #409 guards green).
- [x] `./scripts/build_toc.sh --check` unaffected (no SPEC change).
