### PR TITLE
fix(#417): stop §357 live-sink snapshots leaking a No such file stderr line

### DIFF
--- a/changelog_unreleased/fixed/419.md
+++ b/changelog_unreleased/fixed/419.md
@@ -1,0 +1,1 @@
+- `scripts/test/smoke.sh` no longer prints a spurious `No such file or directory` stderr line on a clean run — the §357 live-sink snapshots now guard absent legacy paths with `[ -f ]` before the input redirect, leaving the assertion semantics unchanged (#419).

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -37,8 +37,12 @@ export CLAUDE_ENG_SHELL_ROOT="$SHELL_ROOT"
 # before the §4 registry backup, so it reflects the truly untouched live state.
 S357_LIVE_AUDIT="$SHELL_ROOT/.claude/audit/audit.jsonl"
 S357_LIVE_REG="$SHELL_ROOT/.claude/state/registry.txt"
-s357_audit_before=$(wc -l < "$S357_LIVE_AUDIT" 2>/dev/null | tr -d ' '); [ -z "$s357_audit_before" ] && s357_audit_before=0
-s357_reg_before=$(wc -l < "$S357_LIVE_REG" 2>/dev/null | tr -d ' '); [ -z "$s357_reg_before" ] && s357_reg_before=0
+# Guard with [ -f ] before the `< file` redirect: bash applies `< file` BEFORE
+# `2>/dev/null`, so on an absent path the open-failure reaches the real stderr
+# unsuppressed (a spurious "No such file" line, #417). An absent sink snapshots
+# as 0 — the assertion semantics are unchanged.
+s357_audit_before=0; [ -f "$S357_LIVE_AUDIT" ] && s357_audit_before=$(wc -l < "$S357_LIVE_AUDIT" | tr -d ' ')
+s357_reg_before=0; [ -f "$S357_LIVE_REG" ] && s357_reg_before=$(wc -l < "$S357_LIVE_REG" | tr -d ' ')
 
 # §357 — pin ALL fixture hook fires to an isolated ephemeral state dir for the
 # whole run. eng_state_dir() honors ENG_STATE_DIR_OVERRIDE as top priority, so
@@ -10096,8 +10100,8 @@ fi
 # else the assertion would be vacuous (it would compare the isolated dir to
 # itself). On pre-#357 code this FAILS (fixture fires append to the live audit);
 # after the whole-run override it passes (every fire resolves to $SMOKE_STATE).
-s357_audit_after=$(wc -l < "$S357_LIVE_AUDIT" 2>/dev/null | tr -d ' '); [ -z "$s357_audit_after" ] && s357_audit_after=0
-s357_reg_after=$(wc -l < "$S357_LIVE_REG" 2>/dev/null | tr -d ' '); [ -z "$s357_reg_after" ] && s357_reg_after=0
+s357_audit_after=0; [ -f "$S357_LIVE_AUDIT" ] && s357_audit_after=$(wc -l < "$S357_LIVE_AUDIT" | tr -d ' ')
+s357_reg_after=0; [ -f "$S357_LIVE_REG" ] && s357_reg_after=$(wc -l < "$S357_LIVE_REG" | tr -d ' ')
 if [ "$s357_audit_after" = "$s357_audit_before" ] && [ "$s357_reg_after" = "$s357_reg_before" ]; then
   ok "357: smoke run left the live audit log + scope registry untouched (#357)"
 else


### PR DESCRIPTION
## What
`bash scripts/test/smoke.sh` printed a spurious redirection-failure line:
`scripts/test/smoke.sh: line NNNN: /…/.claude/state/registry.txt: No such file or directory`

Cause: the §357 live-shared-sink snapshots used `wc -l < "$VAR" 2>/dev/null`. Bash applies the `< file` input redirect **before** `2>/dev/null`, so on an absent path the open-failure reaches the real stderr unsuppressed — `2>/dev/null` does not catch it. This hit `S357_LIVE_REG` (absent post-#314/#316, leaks every run) and `S357_LIVE_AUDIT` (leaks on a fresh clone), each at a before- and after-site (four call-sites).

The assertion was always functionally sound (absent → 0; a pollution write → before≠after → caught); this was purely output noise that reads as a failure to a newcomer and erodes the smoke harness's value as the shell's self-verification surface.

## Fix
Guard all four call-sites with `[ -f "$path" ]` before the `< file` redirect: an absent sink snapshots as `0`, so the assertion semantics and falsifiability are unchanged, and no open is attempted on a missing path.

## Plan (Doc → Test → Code)
`fix`, single-file, test-harness internal — reproduce-first relaxation applies.
- **Doc**: n/a — internal test-harness output noise; no SSOT/contract surface.
- **Code**: guard the four `S357_LIVE_{REG,AUDIT}` before/after snapshots in `scripts/test/smoke.sh`.

## Alternatives considered
- **Reorder `2>/dev/null` ahead of the input redirect** (so fd2 is redirected before the open): also suppresses the noise, minimal diff — rejected in favor of the `[ -f ]` guard, which is self-documenting rather than relying on subtle redirection-ordering semantics.
- **Re-point the snapshot paths to the `.claude/eng-state/` locations** — out of scope per the issue (a separate question); this PR only suppresses the noise.

## Acceptance criteria
- [x] `bash scripts/test/smoke.sh 2>&1` produces no "No such file or directory" line, including where both legacy paths are absent (verified: 0 occurrences).
- [x] Fix covers all four call-sites (`S357_LIVE_REG` + `S357_LIVE_AUDIT`, before + after).
- [x] The §357 assertion still passes AND still detects a live-sink write (verified: before=0, after>0 → caught).

## Verification
`scripts/test/smoke.sh` → **pass=744 fail=0**, zero "No such file" lines, §357 green; falsifiability proven directly.

Closes #417