### PR TITLE
fix(#452): /reflect PATCH uses -F body=@- (stdin) instead of -f (literal)

### DIFF
--- a/.claude/commands/reflect.md
+++ b/.claude/commands/reflect.md
@@ -37,8 +37,8 @@ Post a structured reflection comment on a PR's parent Directive summarizing what
    ```
    Read the Directive's `## Success signals` section from its body (the same field `activation-reviewer` uses at completion time). For each signal, search the PR body / AC closeout comment for evidence; if no evidence is found, mark the signal as "not advanced by this PR" rather than fabricating a claim.
 
-5. **Write the comment** — branch on step 3's classification. Pass the body via stdin / a temp file (`--body-file` / `-f body=@-`), **never** argument-interpolated, so PR/Directive text cannot inject `gh` arguments:
-   - **enrich in place** (step 3 found the `reflect-stub`): edit the bot-authored stub by REST id — `printf '%s' "<composed>" | gh api -X PATCH "/repos/<owner>/<repo>/issues/comments/<id>" -f body=@-`. (`gh issue comment --edit-last` can't be used — it only edits the caller's own last comment, and the stub is authored by `github-actions[bot]`.) This swaps the `reflect-stub` marker for `reflect-enriched` in place, preserving the comment's position.
+5. **Write the comment** — branch on step 3's classification. Pass the body via stdin / a temp file (`--body-file` / `-F body=@-`), **never** argument-interpolated, so PR/Directive text cannot inject `gh` arguments:
+   - **enrich in place** (step 3 found the `reflect-stub`): edit the bot-authored stub by REST id — `printf '%s' "<composed>" | gh api -X PATCH "/repos/<owner>/<repo>/issues/comments/<id>" -F body=@-`. (`gh issue comment --edit-last` can't be used — it only edits the caller's own last comment, and the stub is authored by `github-actions[bot]`.) This swaps the `reflect-stub` marker for `reflect-enriched` in place, preserving the comment's position.
    - **post fresh** (no stub or enriched comment present): `gh issue comment <D> --body-file <file>`.
    Capture the comment URL.
 

--- a/changelog_unreleased/fixed/452.md
+++ b/changelog_unreleased/fixed/452.md
@@ -1,0 +1,1 @@
+- `/reflect` enrich-in-place PATCH now uses `gh api -F body=@-` (reads stdin) instead of `-f` (which set the literal string `@-`), so enriching a Directive reflection comment no longer corrupts its body; guarded by a smoke check against the broken form in any command doc. (#452)

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -10391,6 +10391,22 @@ else
   ng "116: SPEC §1.9 coverage parity drift — classified=$s116_rows expected=$s116_exp (levers=$s116_levers agents=$s116_agents cmds=$s116_cmds hooks=$s116_hooks) (#450)"
 fi
 
+# ---------- §117: command docs use -F (not -f) for gh api stdin/file body (#452) ----------
+# Placed before §110 (the README floor guard, which runs last by design). `gh api
+# -f field=@-` sets the LITERAL string "@-" — only `-F field=@-` reads stdin/file.
+# A command doc teaching the lowercase form silently corrupts the artifact it writes
+# (hit live: /reflect's enrich-in-place PATCH wrote "@-" into a Directive comment).
+# The legitimate graphql `-f query=<string>` form has no `=@`, so anchoring on `=@`
+# is precise. NON-VACUOUS: a file-count guard fails loud if the commands glob is
+# empty (rather than greening on nothing scanned).
+s117_files=$(ls "$SHELL_ROOT"/.claude/commands/*.md 2>/dev/null | wc -l | tr -d ' ')
+s117_bad=$(grep -rlE '\-f [a-zA-Z_]+=@' "$SHELL_ROOT"/.claude/commands/*.md 2>/dev/null | wc -l | tr -d ' ')
+if [ "$s117_files" -gt 0 ] && [ "$s117_bad" = 0 ]; then
+  ok "117: no .claude/commands/*.md teaches the broken 'gh api -f <field>=@' form (use -F for stdin/file) (#452)"
+else
+  ng "117: broken 'gh api -f <field>=@' (literal, not stdin) in commands docs — use -F (files=$s117_files bad=$s117_bad) (#452)"
+fi
+
 # ---------- §110: README assertion-count floor (#409) ----------
 # README's "Verify" block advertises an assertion count as "<N>+". A count that
 # OVERSTATES coverage (claims more than the suite runs) is the misleading


### PR DESCRIPTION
Closes #452

## Goal
Fix the `/reflect` enrich-in-place PATCH, which used `gh api -f body=@-` — lowercase `-f` sets the field to the literal string `@-` instead of reading stdin (only `-F` reads stdin/file) — silently corrupting the Directive reflection comment body. Reproduced live on #449 this session.

## How this serves the mission
Serves MISSION "The mechanism": GitHub artifacts are the shell's durable-memory substrate; a canonical command that silently corrupts one undermines it.

## Plan
**Work order — `fix` relaxation:** Doc phase skipped — SPEC §5.15 specifies `/reflect` behavior but not the PATCH flag, so the SSOT is unaffected (Docs: n/a). Reproduce-first → Test → Code:
- **Test**: smoke §117 fails loud if any `.claude/commands/*.md` teaches the broken `gh api -f <field>=@` form (the graphql `-f query=<string>` literal form has no `=@`, so it's exempt); file-count guard makes it non-vacuous. Confirmed red-first against the live defect (files=30, bad=1).
- **Code**: both occurrences in `reflect.md` step 5 (prose line 40 + command line 41) switched `-f body=@-` → `-F body=@-`.

## Alternatives considered
- Fix reflect.md only, no guard: rejected — the bug is a recurrence-prone class (the doc taught the broken form); a smoke guard prevents any command doc from reintroducing it. Forced toward the guard.
- Guard via a hook vs a smoke assertion: a smoke test is the right face — this is a doc-content invariant checked in CI, not a runtime action to gate (§6.0).

## Checklist
- [x] **Test**: smoke §117 (red-first confirmed, then green)
- [x] **Code**: reflect.md both occurrences → `-F`
- [x] **Docs**: n/a — SPEC §5.15 does not carry the flag

## Out of scope
- SPEC §5.15 (no contract change); other `/reflect` behavior; non-command files (verified clean).

## Risks
- Doc-only + a read-only smoke assertion; no runtime code/hook change. Full smoke green (762/0).

## Ship gate
- [x] All tests pass
- [x] code-reviewer passed
- [x] CI green
