### PR TITLE
fix(#501): case-fold + documented-contract globs in sensitive-file matcher

### DIFF
--- a/.claude/hooks/pre_tool_use.sh
+++ b/.claude/hooks/pre_tool_use.sh
@@ -1089,14 +1089,23 @@ case "$tool" in
       sens_rp=$(printf '%s' "$target" | python3 -c 'import os,sys; sys.stdout.write(os.path.realpath(sys.stdin.read()))' 2>/dev/null)
       [ -n "$sens_rp" ] && sens_resolved=$(basename "$sens_rp")
     fi
-    sens_hit=
-    case "$base" in
-      .env|.env.*|*.pem|credentials|credentials.*|id_rsa|id_rsa.*|id_ed25519|id_ed25519.*) sens_hit=1 ;;
-    esac
-    if [ -z "$sens_hit" ] && [ -n "$sens_resolved" ]; then
-      case "$sens_resolved" in
-        .env|.env.*|*.pem|credentials|credentials.*|id_rsa|id_rsa.*|id_ed25519|id_ed25519.*) sens_hit=1 ;;
+    # #501: match case-INSENSITIVELY (so `.ENV`/`X.PEM` don't slip past) and use
+    # the documented `credentials*`/`id_rsa*`/`id_ed25519*` PREFIX globs (SPEC
+    # §6.1 / CLAUDE.md) rather than the narrower `credentials.*` — so
+    # `credentialsX`/`id_rsa_backup` block — plus `*.pem.*` for a double-extension
+    # backup key (`key.pem.txt`). One helper, used for both the lexical basename
+    # and the symlink-resolved one, so the two can't drift.
+    _sens_match() {  # $1 = basename → rc 0 if it names a sensitive file
+      local b; b=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+      case "$b" in
+        .env|.env.*|*.pem|*.pem.*|credentials*|id_rsa*|id_ed25519*) return 0 ;;
       esac
+      return 1
+    }
+    sens_hit=
+    _sens_match "$base" && sens_hit=1
+    if [ -z "$sens_hit" ] && [ -n "$sens_resolved" ]; then
+      _sens_match "$sens_resolved" && sens_hit=1
     fi
     if [ -n "$sens_hit" ]; then
       should_skip sensitive || block sensitive "sensitive file edit blocked: $target${sens_resolved:+ (symlink to a sensitive target)}"

--- a/changelog_unreleased/security/501.md
+++ b/changelog_unreleased/security/501.md
@@ -1,0 +1,1 @@
+- The sensitive-file Edit/Write guard now matches case-insensitively (`.ENV`, `key.PEM`) and uses the documented `credentials*`/`id_rsa*`/`id_ed25519*` prefix globs (so `credentialsX`/`id_rsa_backup` are caught) plus `*.pem.*` double-extension backups — closing naming-based evasions of the key-material gate. EI-3 of the hook-enforcement hardening directive. (#501)

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -405,6 +405,27 @@ rc=$?
               || ng "234: symlink to non-sensitive target wrongly blocked (rc=$rc) (#234)"
 rm -f "$TMP/fake/notes_link"
 
+# ---- §501a-g (#501 / Directive #498): sensitive-file matcher case-fold +
+# documented-contract globs. In-scope paths under $TMP/fake/sub so the
+# out-of-scope arm doesn't pre-empt; basenames need not exist (lexical match).
+s501_run() {  # $1 = basename → echoes the hook rc for an Edit under $TMP/fake/sub
+  ( cd "$TMP/fake" && fake_input "Edit" "{\"file_path\":\"$TMP/fake/sub/$1\"}" \
+    | "$SHELL_ROOT/.claude/hooks/pre_tool_use.sh" >/dev/null 2>&1 ); echo $?
+}
+# 501a/b (case-fold): uppercase variants of sensitive basenames must block.
+[ "$(s501_run '.ENV')" = 2 ]    && ok "501a: '.ENV' (case variant) edit blocked (#501)"        || ng "501a: '.ENV' not blocked — case-sensitive matcher (#501)"
+[ "$(s501_run 'key.PEM')" = 2 ] && ok "501b: 'key.PEM' (case variant) edit blocked (#501)"     || ng "501b: 'key.PEM' not blocked — case-sensitive matcher (#501)"
+# 501c/d (documented-contract prefix globs): `credentials*` / `id_rsa*` per the
+# SPEC §6.1 / CLAUDE.md contract (code used the narrower `credentials.*`).
+[ "$(s501_run 'credentialsX')" = 2 ]  && ok "501c: 'credentialsX' edit blocked (credentials* contract) (#501)"  || ng "501c: 'credentialsX' not blocked — code narrower than documented contract (#501)"
+[ "$(s501_run 'id_rsa_backup')" = 2 ] && ok "501d: 'id_rsa_backup' edit blocked (id_rsa* contract) (#501)"      || ng "501d: 'id_rsa_backup' not blocked — code narrower than contract (#501)"
+# 501e (double-extension): a renamed/backup key like `key.pem.txt` must block.
+[ "$(s501_run 'key.pem.txt')" = 2 ] && ok "501e: 'key.pem.txt' (double-extension) edit blocked (#501)" || ng "501e: 'key.pem.txt' not blocked — double-extension evasion (#501)"
+# 501f (no over-block GUARD — must stay green): an in-scope non-sensitive file is allowed.
+[ "$(s501_run 'notes.md')" = 0 ]  && ok "501f: in-scope 'notes.md' still allowed (no over-block) (#501)" || ng "501f: non-sensitive 'notes.md' wrongly blocked (#501)"
+# 501g (regression): the canonical lowercase '.env' still blocks.
+[ "$(s501_run '.env')" = 2 ]      && ok "501g: '.env' still blocked (lowercase regression) (#501)"        || ng "501g: '.env' regression — no longer blocked (#501)"
+
 # Bash rm -rf $HOME
 out=$(cd "$TMP/fake" && fake_input "Bash" "{\"command\":\"rm -rf \$HOME/somewhere\"}" \
   | "$SHELL_ROOT/.claude/hooks/pre_tool_use.sh" 2>&1)


### PR DESCRIPTION
Closes #501

## Goal
Stop naming-based evasions of the sensitive-file Edit/Write matcher (`pre_tool_use.sh`): case variants (`.ENV`, `key.PEM`), the documented-vs-code glob gap (`credentialsX`, `id_rsa_backup` slipped because the code used `credentials.*` not the documented `credentials*`), and a double-extension backup key (`key.pem.txt`). EI-3 of Directive #498.

## How this serves the mission
MISSION "the flow holds … rather than silent regressions." The sensitive-file gate is the Edit/Write-time defense against committing key material; a file named `id_rsa_backup` or `key.PEM` defeated it, and the code was narrower than the SPEC §6.1 / CLAUDE.md contract promised.

## Plan
`fix`, reproduce-first (Doc→Test→Code relaxed; this aligns the code to the *already-documented* `credentials*`/`id_rsa*`/`id_ed25519*` contract — no SPEC change). Lowercase-fold the basename, switch `credentials.*`→`credentials*` etc., add `*.pem.*` for double-extension. Factored both match sites (lexical basename + symlink-resolved) into one `_sens_match` helper so they can't drift. Authored in the main loop (implementer opt-out — a focused single-arm matcher change); reviewer-gated.

## Commits (Test → Code)
- `6a7a261` **test**: §501a-g locks (in §234's live `$TMP/fake` harness).
- `dead457` **fix**: case-fold + contract globs + `_sens_match` helper.

## Out of scope
- Broadening to `*.env`/`*.credentials` "any env/credential file" semantics — that's a **contract change**, not this consistency fix (the literal `.env`/`credentials` family is unchanged; a follow-up could widen it).
- TOCTOU / hardlinks (pre-existing documented residual, unchanged).

## Checklist
- [x] **Test**: §501a-g RED locks; RED confirmed pre-fix, GREEN post-fix
- [x] **Code**: case-fold + `credentials*`/`id_rsa*`/`id_ed25519*` + `*.pem.*`, DRY helper
- [x] **Doc**: n/a — aligns code TO the documented §6.1 contract (no contract change)

## Risks
Over-block guarded by §501f (in-scope `notes.md` allowed). `*.pem.*` could match a benign `template.pem.example` — conservative (blocks a pem-named file), acceptable for a key-material gate. Symlink-resolved path uses the same helper (no drift).

## Test plan
- [x] `bash scripts/test/smoke.sh` → pass=889 fail=0; §501a-g GREEN; §234 + §60c/e/g (sensitive under carve-outs) still pass.

## Review response
security-reviewer (correctness+security mandate) verified all functional aspects ship-quality and flagged one blocker: the `fix` commit subject was 74 codepoints (>72 convention). Reworded to 69 (`…in sensitive matcher`) and force-pushed to this non-protected branch. **Follow-up candidate** (noted to #498): the commit-format check appears to measure the description, not the full `<type>(#N): <subject>` line, so a 74-codepoint full line passed `eng_commit`/the hook — a discrepancy vs CLAUDE.md's documented "codepoint 1–72" of the whole line.

## Ship gate
- [x] All tests pass — pass=889 fail=0
- [x] code+security-reviewer passed — ship (after the subject reword)
- [x] Docs in sync — n/a (aligns code to the documented §6.1 contract)
- [x] PR body curated
- [ ] CI green — pending after ready
