### PR TITLE
docs(#513): CLAUDE.md SessionStart names both silent-no-op detectors

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,7 +78,7 @@ Pointer index — every contract below lives in full in SPEC §6.1 (PreToolUse m
 - **out-of-scope (destructive)** — `rm`/`mv`/`cp` with a force/recursive flag in any surface form and out-of-registry args blocked; no carve-out (SPEC §6.1).
 - **shell-root resolution** — hooks resolve the shell via `$CLAUDE_ENG_SHELL_ROOT` else self-locate through the per-project `.claude/eng-shell-root` binding symlink, so a plain `claude` in a target needs no global env (SPEC §3.2.1).
 - **per-project state** — audit log, caches, and the scope-guard registry resolve per-project under `eng-state/` (`eng_state_dir`/`eng_registry_file`); missing/empty registry fails open (SPEC §3.2.2).
-- **SessionStart banner** — surfaces the one detectable silent-no-op (`hookrt.sh` missing) via a once-per-session banner naming the fix (SPEC §6.5(c)).
+- **SessionStart banner** — surfaces the detectable silent-no-op states (runtime `hookrt.sh` missing; and a present-but-empty scope registry that silently disarms enforcement, #502) via a once-per-session banner naming the fix (SPEC §6.5(c)).
 - **safe_source** — every helper source (hook-to-helper and helper-to-helper) goes through `safe_source`, fail-open with `audit_log warn <category> helper-missing` on miss (SPEC §6.1 fail-policy table).
 - **pass-through invariant** — every matcher reaches a decided state per fire; happy paths `mark_allow` silently, anomalous silent fall-through is caught by `pass_through_trace` (SPEC §6.1).
 - **audit observability** — records carry an additive `source` field (`test` only via the harness-owned, uninjectable marker) and reviewers emit a categorized reject record; both observability surfaces, not gates (SPEC §6.1).

--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -8550,6 +8550,19 @@ if grep -qF '*test*' "$SHELL_ROOT/.claude/CLAUDE.md" 2>/dev/null; then
 else
   ok "71f: CLAUDE.md no longer cites the stale *test*/*example* globs (#217)"
 fi
+# 71g (#513 / Directive #498 residual): CLAUDE.md's SessionStart-banner line must
+# name BOTH detectable silent-no-op states — `hookrt.sh` missing AND the
+# registry-zeroed disarm (#502, SPEC §6.5(c)) — and must NOT assert "the one"
+# (a count claim the SSOT contradicts since #502 added the second detector).
+s71g_md="$SHELL_ROOT/.claude/CLAUDE.md"
+s71g_line=$(grep -iE 'SessionStart banner' "$s71g_md" 2>/dev/null)
+if printf '%s' "$s71g_line" | grep -qiE 'hookrt' \
+   && printf '%s' "$s71g_line" | grep -qiE 'registr' \
+   && ! printf '%s' "$s71g_line" | grep -qiE 'the one detectable silent-no-op'; then
+  ok "71g: CLAUDE.md SessionStart line names both silent-no-op detectors (hookrt + registry), no stale 'the one' count (#513)"
+else
+  ng "71g: CLAUDE.md SessionStart line stale — must name both hookrt + registry-zeroed detectors, drop 'the one' (#513)"
+fi
 
 # ---------- 72. robustness cluster: release_consolidate + ac_closeout symmetry (#218) ----------
 # Script-content assertions (the affected scripts talk to git/gh and aren't


### PR DESCRIPTION
Closes #513

## Goal
Correct a now-false count claim in `.claude/CLAUDE.md`: the SessionStart-banner line said "the one detectable silent-no-op (`hookrt.sh` missing)", but #502 added a SECOND SessionStart detector (registry-zeroed, SPEC §6.5(c)). Active-SSOT residual of #502, surfaced by the pre-release doc-sync audit.

## How this serves the mission
MISSION "the flow holds … rather than silent regressions" + doc-as-SSOT (SPEC §9): a false count of the silent-no-op enforcement surface in the per-session operating-norms summary misleads the next agent/reader. A thin pointer may omit detail but must not assert a count the SSOT contradicts.

## Plan
`docs`. Recast CLAUDE.md:81 count-neutral, naming both detectors. §71g smoke lock (RED→GREEN) guards the count against future drift. No behavior/posture change (the 'What hooks enforce' bullets remain true — #502 added observability, not a gate/fail-open change).

## Commits (Test → Doc)
- **test(#513)**: §71g lock.
- **docs(#513)**: the CLAUDE.md recast.

## Checklist
- [x] **Test**: §71g RED→GREEN
- [x] **Doc**: CLAUDE.md:81 recast count-neutral, both detectors, → SPEC §6.5(c)
- [x] no other CLAUDE.md bullet changed

## Test plan
- [x] `bash scripts/test/smoke.sh` → pass=913 fail=0; §71g GREEN; §71f + §68 (other CLAUDE.md locks) intact.

## Ship gate
- [ ] All tests pass
- [ ] code-reviewer passed
- [ ] (conditional) security-reviewer — n/a (doc-only)
- [ ] Docs in sync
- [ ] PR body curated
- [ ] CI green