### PR TITLE
test(#517): lock implementer fail-open reversibility degradation

### DIFF
--- a/scripts/test/smoke.sh
+++ b/scripts/test/smoke.sh
@@ -12593,6 +12593,28 @@ else
   fi
 fi
 
+# ---------- §126e: implementer fail-open reversibility degradation lock (#517, promoted from discussion #496 Gap 2) ----------
+# Regression lock (NOT RED-first — the contract already lives in the docs; this pins it
+# against silent removal, §126a-style). The fail-open reversibility safety valve —
+# "a missing implementer path degrades to main-loop authoring" — was leaned on IN LIEU
+# OF the descoped A/B measurement (Directive #477), yet §126a-c never asserted it.
+# Locked across all three documenting surfaces. NON-VACUOUS: any missing file fails LOUD.
+S126E_CMD="$SHELL_ROOT/.claude/commands/implement.md"
+S126E_WORKON="$SHELL_ROOT/.claude/commands/work-on.md"
+S126E_AGENT="$SHELL_ROOT/.claude/agents/implementer.md"
+if [ ! -f "$S126E_CMD" ] || [ ! -f "$S126E_WORKON" ] || [ ! -f "$S126E_AGENT" ]; then
+  ng "126e: implementer fail-open file missing — cannot assert degradation contract (#517)"
+else
+  s126e_cmd=$(grep -ciE 'fail-open reversibility|degrades? to main-loop authoring' "$S126E_CMD" 2>/dev/null | tr -d ' ')
+  s126e_workon=$(grep -ciE 'fail-open reversibility|degrades? to main-loop authoring' "$S126E_WORKON" 2>/dev/null | tr -d ' ')
+  s126e_agent=$(grep -ciE 'fail-open reversibility|degrades? to main-loop authoring' "$S126E_AGENT" 2>/dev/null | tr -d ' ')
+  if [ "$s126e_cmd" -ge 1 ] && [ "$s126e_workon" -ge 1 ] && [ "$s126e_agent" -ge 1 ]; then
+    ok "126e: fail-open reversibility degradation contract documented across implement.md / work-on.md / implementer.md (#517)"
+  else
+    ng "126e: fail-open degradation contract missing a surface (implement=$s126e_cmd work-on=$s126e_workon implementer=$s126e_agent) (#517)"
+  fi
+fi
+
 # ---------- §127: directive-level coding-memory loop contract (#488 / Directive #477) ----------
 # Placed before §110 (the README floor guard, which runs last by design). Phase B
 # (Test) for EI-2 under Directive #477. The Doc phase already landed the contract


### PR DESCRIPTION
## How this serves the mission
MISSION's safety doctrine pins documented guarantees with locks so the shell "improves under use" rather than drifting. The fail-open reversibility valve — *a missing implementer path degrades to main-loop authoring* — is the hedge Directive #477 leaned on **in lieu of** the descoped A/B measurement, yet `§126a-c` never asserted it. An untested load-bearing safety guarantee is exactly the drift this lock closes.

Closes #517.

## Plan
Promoted from discussion #496 (Gap 2 only). Single `test` commit:

- **Test**: smoke `§126e` asserting the fail-open reversibility contract token (`fail-open reversibility` / `degrades to main-loop authoring`) is present across all three documenting surfaces — `implement.md`, `work-on.md`, `implementer.md`. NON-VACUOUS missing-file guard mirroring §126a.

**Doc / Code phases — n/a.** The fail-open contract **already exists** in the docs (`implement.md:8`, `work-on.md:57`, `implementer.md:37`); this PR only *locks* it. So it follows the **§126a regression-lock pattern, not RED-first** — the lock is GREEN on landing because the contract is present. The relaxed Doc→Test→Code clause applies (the contract being locked is pre-existing). Non-vacuousness is proven by **mutation** instead of RED-first: removing the token from `implement.md` drops the count to 0 and fires `ng` (verified locally).

## AC reconciliation
The filed AC said "a failing Phase-B test (RED) confirmed first." That was written before recognizing the contract **pre-exists** — there is nothing to add to the docs to turn a RED lock green. The honest equivalent for a regression lock is **non-vacuousness by mutation**, which is demonstrated above. The remaining AC (lock asserts the contract across the three surfaces; no A/B re-introduction; build_toc/SPEC consistency) hold.

## Target base
main

## Key context
- `scripts/test/smoke.sh` §126 block (lock added before §127)
- `.claude/commands/implement.md:8`, `.claude/commands/work-on.md:57`, `.claude/agents/implementer.md:37` — the three documenting surfaces (read-only references)

## Checklist
- [x] **Test**: smoke §126e asserts the fail-open degradation contract across the three surfaces.
- [x] Non-vacuousness demonstrated by mutation (token removed → lock RED).
- [x] No A/B measurement re-introduction (Gap 1 stays out of scope — resolved no-action on #496).
- [x] Full smoke green (914/0); `bash -n` + shellcheck clean.

## Out of scope
- Gap 1 (a `code-phase` dispatch audit signal) — resolved **no-action** on #496 (re-opens deliberately-descoped scope; structurally only half-observable).
