### PR TITLE
fix(#607): strip heredoc data in the --amend matcher arm before scanning

### DIFF
--- a/.claude/hooks/pre_tool_use.sh
+++ b/.claude/hooks/pre_tool_use.sh
@@ -1205,8 +1205,8 @@ case "$tool" in
     # rationale — so a command whose heredoc body merely mentions
     # "commit … --no-verify" does not false-trip this arm. This was the residual
     # raw-$cmd data-as-token gap after #366/#403/#446 fixed the sibling arms.
-    # (The adjacent --amend arm below still scans raw $cmd — same class, tracked
-    # separately; out of #605's scope.)
+    # (#607 fixed the adjacent --amend arm below the same way — it was the last
+    # residual raw-$cmd arm in this class.)
     if printf '%s' "$(strip_command_data "$raw_cmd" heredoc)" | grep -qE "${GIT_PREFIX}commit\b.*\-\-no-verify\b"; then
       decided=
       should_skip no-verify && decided=1 || block no-verify "--no-verify blocked"
@@ -1214,7 +1214,14 @@ case "$tool" in
     fi
 
     # --amend (only when the commit is already pushed)
-    if printf '%s' "$cmd" | grep -qE "${GIT_PREFIX}commit\b.*\-\-amend\b"; then
+    # #607: strip heredoc DATA before scanning (mirroring the --no-verify arm
+    # above, fixed in #605, and the commit-umbrella entry below) — so a command
+    # whose heredoc/quoted body merely mentions "commit … --amend" does not
+    # false-trip this block. This was the last residual raw-$cmd data-as-token
+    # arm after #366/#403/#446/#605 fixed the siblings. heredoc mode is
+    # under-block-safe (a real "$(git commit --amend)" substitution is left
+    # intact); strip_command_data falls back to raw on failure (fail-closed).
+    if printf '%s' "$(strip_command_data "$raw_cmd" heredoc)" | grep -qE "${GIT_PREFIX}commit\b.*\-\-amend\b"; then
       decided=
       if git rev-parse '@{upstream}' >/dev/null 2>&1; then
         if git merge-base --is-ancestor HEAD '@{upstream}' 2>/dev/null; then

--- a/changelog_unreleased/fixed/607.md
+++ b/changelog_unreleased/fixed/607.md
@@ -1,0 +1,1 @@
+- The PreToolUse `--amend` matcher no longer false-blocks a command whose heredoc/quoted body merely mentions the amend flag (e.g. committing or filing an issue *about* amending) — the arm now strips heredoc data before scanning, matching its sibling arms and the `--no-verify` fix in #605; a genuine amend of an already-pushed commit still blocks. (#607)

--- a/scripts/test/smoke.d/50-perproject-recall.sh
+++ b/scripts/test/smoke.d/50-perproject-recall.sh
@@ -1917,7 +1917,7 @@ else
   git init -q --bare "$S151_REMOTE" >/dev/null 2>&1
   git clone -q "$S151_REMOTE" "$S151_TARGET" >/dev/null 2>&1
   S151_TARGET=$(cd "$S151_TARGET" && pwd -P)
-  (cd "$S151_TARGET"
+  (cd "$S151_TARGET" || exit 1
    git checkout -q -b feat/x 2>/dev/null || git checkout -q feat/x
    git -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
    git push -q -u origin feat/x) >/dev/null 2>&1

--- a/scripts/test/smoke.d/50-perproject-recall.sh
+++ b/scripts/test/smoke.d/50-perproject-recall.sh
@@ -1890,6 +1890,76 @@ EOF
   rm -rf "$S150_DIR"
 fi
 
+# ---------- §151 (#607): --amend arm does not false-positive on heredoc DATA ----------
+# Twin of §150 (#605): the --amend matcher arm (pre_tool_use.sh:1217) scanned the RAW $cmd
+# for `git ... commit ... --amend`, unlike every neighbouring arm (the clean :198, merge :333,
+# the adjacent --no-verify arm fixed in #605, and the commit-umbrella :1256) which first pass
+# raw_cmd through strip_command_data. So a NON-git command whose heredoc DATA body merely
+# mentions the tokens `git commit ... --amend` on one line false-trips the `--amend of an
+# already-pushed commit blocked` block. The Code fix gates the entry on strip_command_data
+# "$raw_cmd" heredoc (heredoc mode — matching the sibling arms; under-block-safe because a real
+# "$(git commit --amend)" substitution is left intact). 151a: heredoc-body false-positive must
+# be ALLOWED (RED pre-fix). 151b: no-under-block guard — a genuine `git commit --amend` of an
+# already-pushed commit still blocks.
+#
+# The amend block is conditional on the commit being pushed (HEAD an ancestor of @{upstream}),
+# so unlike §150 this fixture is a bare "remote" + clone: after the initial push, the working
+# clone's HEAD == origin/feat/x, which satisfies the ancestor check. That makes 151a a genuine
+# RED (the raw scan matches the DATA line AND the pushed condition holds → block) and lets 151b
+# exercise the real-amend block on the same fixture.
+if ! command -v jq >/dev/null 2>&1; then
+  ng "151a: jq missing — cannot drive the --amend DATA test (#607)"
+  ng "151b: jq missing (#607)"
+else
+  S151_DIR=$(mktemp -d)
+  S151_REMOTE="$S151_DIR/remote.git"
+  S151_TARGET="$S151_DIR/target"
+  git init -q --bare "$S151_REMOTE" >/dev/null 2>&1
+  git clone -q "$S151_REMOTE" "$S151_TARGET" >/dev/null 2>&1
+  S151_TARGET=$(cd "$S151_TARGET" && pwd -P)
+  (cd "$S151_TARGET"
+   git checkout -q -b feat/x 2>/dev/null || git checkout -q feat/x
+   git -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
+   git push -q -u origin feat/x) >/dev/null 2>&1
+  printf '%s\n' "$S151_TARGET" >> "$SMOKE_REG"
+
+  s151_bash_run() {
+    local cmd="$1"
+    ( cd "$S151_TARGET" || exit 1
+      jq -nc --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}' \
+        | GHJIG_ROOT_OVERRIDE="$SHELL_ROOT" bash "$SHELL_ROOT/.claude/hooks/pre_tool_use.sh" >/dev/null 2>&1 )
+    return $?
+  }
+
+  # 151a: a gh-issue-create whose --body carries the `git commit ... --amend` tokens on one
+  #       HEREDOC body line, run on the already-pushed feature branch → must be ALLOWED (rc=0).
+  #       The real #607 false-positive. RED pre-fix (the raw scan matches the DATA line, the
+  #       pushed condition holds, so it blocks with rc=2).
+  sq="'"
+  s151_data_cmd="gh issue create --title x --body \"\$(cat <<${sq}EOF${sq}
+to reword the last commit you can run git commit --amend by hand
+EOF
+)\""
+  s151_bash_run "$s151_data_cmd"; s151a_rc=$?
+  if [ "$s151a_rc" = 0 ]; then
+    ok "151a: --amend arm ignores the tokens inside a heredoc --body (no false-positive) (#607)"
+  else
+    ng "151a: --amend arm false-positives on 'git commit ... --amend' in a heredoc --body (rc=$s151a_rc, want 0) (#607)"
+  fi
+
+  # 151b (no under-block): a REAL `git commit --amend` of an already-pushed commit still blocks
+  #       (rc=2). Passes now and must keep passing after the heredoc-strip fix (strip_command_data
+  #       heredoc leaves a flag-bearing invocation with no heredoc intact).
+  s151_real_cmd="git commit --amend -m 'fix(#607): reword'"
+  s151_bash_run "$s151_real_cmd"; s151b_rc=$?
+  if [ "$s151b_rc" = 2 ]; then
+    ok "151b: a real 'git commit --amend' of a pushed commit still blocks (no under-block) (#607)"
+  else
+    ng "151b: real 'git commit --amend' of a pushed commit not blocked (rc=$s151b_rc, want 2) (#607)"
+  fi
+  rm -rf "$S151_DIR"
+fi
+
 # ---------- §109 (#404): is_trusted_filer resolves trust portably across gh --json support ----------
 # Reproduce-first: on a gh version that REJECTS `gh issue view --json authorAssociation`
 # (Unknown JSON field) but serves `gh api .../issues/N -q .author_association`, the helper


### PR DESCRIPTION
Closes #607

## Goal
Strip heredoc/quoted DATA in the PreToolUse `--amend` matcher arm before scanning, so a command whose data body merely mentions the amend flag no longer false-blocks — the last residual raw-`$cmd` arm, twin of the `--no-verify` arm fixed in #605.

## How this serves the mission
Matcher correctness / enforcement-face accuracy (SPEC §6.0): an over-block firing on data-as-token erodes gate trust and forces workarounds (reproduced **three** times now — twice while committing #605, and once more when the first `gh pr create` for this very PR was itself false-blocked by the unfixed arm). The fix keeps the block precise — firing on a genuine amend of a pushed commit, never on prose about it.

## Plan
Trivial one-arm fix, `fix`/reproduce-first — planner/contest gate skipped (not a 3+-file / schema / API change; direct adjacent precedent in #605). Doc **n/a** — the contract (block a genuine amend of an already-pushed commit) is unchanged; data-robustness only, like #366/#403/#605.

1. **Test** (red): smoke §151 reproducing the false-positive + a no-under-block guard.
2. **Code**: gate the arm's match on `strip_command_data "$raw_cmd" heredoc`; update the stale #605 code comment.

## Key context
- `.claude/hooks/pre_tool_use.sh` — the `--amend` arm (was scanning raw `$cmd`).
- The `--no-verify` sibling arm fixed in #605 (pattern to mirror) + the commit-umbrella entry (same strip idiom).
- `scripts/test/smoke.d/50-perproject-recall.sh` — §108/§150 harness reused for §151.

## Checklist
- [x] **Test**: smoke §151 — 151a false-positive repro (red), 151b no-under-block guard.
- [x] **Code**: the arm gates on `strip_command_data "$raw_cmd" heredoc`; #605 comment updated.

## Out of scope
- Any matcher arm other than `--amend` (the last known residual raw-scan arm).
- The git-hook enforcement layer (#604).

## Risks
Under-block if the strip hid a real invocation — mitigated by **heredoc** mode (leaves `"$(...)"` substitutions intact) + fail-closed fallback to raw on strip failure, and asserted by §151b (a genuine amend of a pushed commit still blocks). Confirmed by the §4.11 security-reviewer tier (3/3 approve).

## Test plan
- [x] §151a: a heredoc `--body` mentioning the amend tokens is ALLOWED (no false-positive).
- [x] §151b: a real amend of an already-pushed commit still blocks.
- [x] Full smoke suite green (local pass=1098 fail=0; CI smoke ubuntu+macos green); no regression to §108/§150 or sibling arms.

## Docs touched
- [~] N/A — data-robustness only; contract unchanged (SPEC §6.0 matcher-correctness). Confirmed no SPEC/docs drift by code-reviewer.

## Ship gate
- [x] All tests pass (smoke 1098/0 local + CI; mutation guard green)
- [x] code-reviewer passed (+ §4.11 high-asymmetry security-reviewer tier: 3/3 valid approve at head)
- [x] Docs in sync (n/a — contract unchanged)
- [x] PR body curated
- [x] CI green (bash -n, shellcheck, fragment-gate, smoke ×2, mutation — all pass)
