### PR TITLE
fix(#615): dedup statusCheckRollup to the latest check-run in ship_classify_blocker

### DIFF
--- a/.claude/hooks/helpers/ship_mode.sh
+++ b/.claude/hooks/helpers/ship_mode.sh
@@ -104,8 +104,17 @@ ship_classify_blocker() {
     return 0
   fi
 
+  # #615: dedup the rollup to the LATEST check-run per name/context before the
+  # PENDING/FAILURE tests — statusCheckRollup can retain a stale, superseded entry
+  # for a check that re-ran (e.g. a fragment-gate that failed then passed after a
+  # skip-changelog label), and an undeduped any-PENDING/any-FAILURE would count the
+  # stale entry, false-classifying a clean PR as soft/hard. `latest per check` =
+  # group by name (check-run) or context (legacy status), take the newest by
+  # completedAt (fallback startedAt), mirroring `gh pr checks`'s per-context view.
   if printf '%s' "$json" | jq -e \
-       '(.statusCheckRollup // []) | map(.status // .conclusion // "") |
+       '(.statusCheckRollup // []) | group_by(.name // .context // "") |
+        map(sort_by(.completedAt // .startedAt // "") | last) |
+        map(.status // .conclusion // "") |
         any(. == "PENDING" or . == "IN_PROGRESS" or . == "QUEUED")' \
        >/dev/null 2>&1; then
     printf 'soft\n'; return 0
@@ -120,8 +129,12 @@ ship_classify_blocker() {
     printf 'hard\n'; return 0
   fi
 
+  # #615: same latest-per-check dedup as the PENDING test above — a superseded
+  # FAILURE (a check that later re-ran green) must not force `hard`.
   if printf '%s' "$json" | jq -e \
-       '(.statusCheckRollup // []) | map(.conclusion // "") |
+       '(.statusCheckRollup // []) | group_by(.name // .context // "") |
+        map(sort_by(.completedAt // .startedAt // "") | last) |
+        map(.conclusion // "") |
         any(. == "FAILURE" or . == "CANCELLED" or . == "TIMED_OUT")' \
        >/dev/null 2>&1; then
     printf 'hard\n'; return 0

--- a/changelog_unreleased/fixed/615.md
+++ b/changelog_unreleased/fixed/615.md
@@ -1,0 +1,1 @@
+- Unattended `/ship` no longer false-parks a clean PR when a CI check failed then passed on re-run: `ship_classify_blocker` now dedups `statusCheckRollup` to the latest check-run per check (by `completedAt`/`startedAt`) before its pending/failure test, so a superseded stale entry no longer masks the current green state (a genuinely-failing latest check still parks). (#615)

--- a/scripts/test/smoke.d/10-structure-hooks.sh
+++ b/scripts/test/smoke.d/10-structure-hooks.sh
@@ -670,6 +670,45 @@ rm -f "$MODE_TMP/.claude/state/mode" 2>/dev/null
   fi
 ) && ok "mode: unattended + soft → fix-and-wait" || ng "mode: soft → fix-and-wait dispatch wrong (#10)"
 
+# 11i (#615): a SUPERSEDED FAILURE check-run must not count — statusCheckRollup can
+# retain a stale entry for a check that failed then passed on re-run (e.g. fragment-gate
+# before/after a skip-changelog label). ship_classify_blocker must dedup to the LATEST
+# check-run per name/context before the FAILURE test, else a clean PR is false-`hard`-parked.
+# 11i: {FAILURE(early), SUCCESS(late)} same name → clean. RED pre-fix (any-FAILURE sees the stale entry).
+(
+  if command -v ship_classify_blocker >/dev/null 2>&1; then
+    j='{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"name":"gate","status":"COMPLETED","conclusion":"FAILURE","startedAt":"2026-01-01T00:00:00Z","completedAt":"2026-01-01T00:00:05Z"},{"name":"gate","status":"COMPLETED","conclusion":"SUCCESS","startedAt":"2026-01-01T00:01:00Z","completedAt":"2026-01-01T00:01:05Z"}]}'
+    [ "$(printf '%s' "$j" | ship_classify_blocker 2>/dev/null)" = clean ]
+  else exit 1; fi
+) && ok "classify: superseded FAILURE (stale, newer SUCCESS same check) → clean (#615)" || ng "classify: a stale FAILURE superseded by a newer SUCCESS should classify clean, not hard (#615)"
+
+# 11j (#615, no-false-clean guard): {SUCCESS(early), FAILURE(late)} same name → hard. A genuinely
+# failing LATEST check still parks. Passes pre- and post-fix (locks the safety floor).
+(
+  if command -v ship_classify_blocker >/dev/null 2>&1; then
+    j='{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"name":"gate","status":"COMPLETED","conclusion":"SUCCESS","startedAt":"2026-01-01T00:00:00Z","completedAt":"2026-01-01T00:00:05Z"},{"name":"gate","status":"COMPLETED","conclusion":"FAILURE","startedAt":"2026-01-01T00:01:00Z","completedAt":"2026-01-01T00:01:05Z"}]}'
+    [ "$(printf '%s' "$j" | ship_classify_blocker 2>/dev/null)" = hard ]
+  else exit 1; fi
+) && ok "classify: genuinely-failing LATEST check → hard (no false-clean) (#615)" || ng "classify: a newer FAILURE (latest) must still classify hard (#615)"
+
+# 11k (#615, guard): {SUCCESS(early), PENDING(late)} same name → soft. A fresh in-progress re-run
+# is still soft. Passes pre- and post-fix.
+(
+  if command -v ship_classify_blocker >/dev/null 2>&1; then
+    j='{"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":"APPROVED","statusCheckRollup":[{"name":"gate","status":"COMPLETED","conclusion":"SUCCESS","startedAt":"2026-01-01T00:00:00Z","completedAt":"2026-01-01T00:00:05Z"},{"name":"gate","status":"IN_PROGRESS","startedAt":"2026-01-01T00:01:00Z"}]}'
+    [ "$(printf '%s' "$j" | ship_classify_blocker 2>/dev/null)" = soft ]
+  else exit 1; fi
+) && ok "classify: fresh IN_PROGRESS re-run (latest) → soft (#615)" || ng "classify: a newer in-progress check (latest) must classify soft (#615)"
+
+# 11l (#615): {PENDING(early), SUCCESS(late)} same name → clean. A stale in-progress entry
+# superseded by a completed SUCCESS must not keep the PR soft. RED pre-fix (any-PENDING sees the stale entry).
+(
+  if command -v ship_classify_blocker >/dev/null 2>&1; then
+    j='{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"name":"gate","status":"IN_PROGRESS","startedAt":"2026-01-01T00:00:00Z"},{"name":"gate","status":"COMPLETED","conclusion":"SUCCESS","startedAt":"2026-01-01T00:01:00Z","completedAt":"2026-01-01T00:01:05Z"}]}'
+    [ "$(printf '%s' "$j" | ship_classify_blocker 2>/dev/null)" = clean ]
+  else exit 1; fi
+) && ok "classify: superseded IN_PROGRESS (stale, newer SUCCESS same check) → clean (#615)" || ng "classify: a stale in-progress superseded by a newer SUCCESS should classify clean, not soft (#615)"
+
 # 11g. classifier emits stderr warning on empty stdin (#10)
 (
   if command -v ship_classify_blocker >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #615

## Goal
`ship_classify_blocker` evaluated `any-PENDING` / `any-FAILURE` over the whole `statusCheckRollup` without deduping to the latest check-run per check. A stale, superseded entry (a check that failed or was in-progress, then re-ran green — e.g. `fragment-gate` before/after a `skip-changelog` label) then false-classified a clean PR as soft/hard → unattended `/ship` false-parked it. Dedup to the latest check-run per name/context before both tests.

## How this serves the mission
Enforcement / positive-face correctness (SPEC §6.0, §5.7.1): the unattended `/ship` classifier must read CI truthfully, else it parks clean work — a false negative that erodes the autonomy the shell provides (Directive #584). Reading the latest-per-check state matches what `gh pr checks` and GitHub's own mergeability report.

## Plan
`fix`, reproduce-first (a `statusCheckRollup` JSON fixture with a superseded entry is the failing test — no live CI race). Small, bounded jq change to `ship_classify_blocker`; the merge-review gate and merge strategy are untouched.

## Live repro
PR #612 this session: `gh pr checks` (latest-per-context) showed all-pass and GitHub reported `mergeable=CLEAN`, but `ship_classify_blocker` returned `hard` off a stale `fragment-gate` FAILURE left in the rollup by the pre-skip-changelog-label push.

## Key context
- `.claude/hooks/helpers/ship_mode.sh` — `ship_classify_blocker`; the two `jq -e` tests now `group_by(.name // .context)` and take the newest by `.completedAt // .startedAt` before the `any` test.
- `.claude/hooks/helpers/ac_closeout_gate.sh` — the merge-review gate (UNCHANGED; still the review-integrity gate).
- SPEC §5.7.1 — the clean/soft/hard→park taxonomy (contract unchanged in intent).

## Checklist
- [x] **Test**: smoke §11i–l — 11i (stale FAILURE→clean) + 11l (stale IN_PROGRESS→clean) RED pre-fix; 11j (newer FAILURE→hard) + 11k (newer IN_PROGRESS→soft) no-false-clean guards.
- [x] **Code**: dedup latest-per-check in both jq tests of `ship_classify_blocker`.

## Out of scope
- The merge-review gate (§6.1) and merge-strategy classifier — unchanged; only the check-rollup reading in the blocker classifier changes.
- How CI itself reports checks.

## Risks
- Over-eager dedup masking a real failure → mitigated by the fail-closed guard (§11j: a genuinely-failing LATEST check still classifies `hard`) and by the downstream gates (the merge-review gate + GitHub mergeability independently block a real failing required check — the classifier is a routing heuristic, not the sole gate).

## Test plan
- [x] §11i {FAILURE(old), SUCCESS(new)} → clean; §11l {IN_PROGRESS(old), SUCCESS(new)} → clean.
- [x] §11j {SUCCESS(old), FAILURE(new)} → hard; §11k {SUCCESS(old), IN_PROGRESS(new)} → soft.
- [x] Full smoke pass=1129 fail=0; lint clean (78 files).

## Docs touched
- [x] changelog `fixed/615.md`. SPEC §5.7.1 taxonomy unchanged in intent (Doc n/a).

## Ship gate
- [x] All tests pass (smoke 1129/0 local + CI; §148i-cli "twice" was a worktree artifact — committed hookrt.sh defines ghjig_state_dir_cli once, CI+local green)
- [x] code-reviewer passed (empirically ran all 4 fixtures through the jq)
- [x] security-reviewer passed (§4.11 tier: 3/3 valid approve at head; one shared Low tie-break note → P3 follow-up)
- [x] Docs in sync
- [x] PR body curated
- [x] CI green (bash -n, shellcheck, fragment-gate, smoke ×2, mutation)
