### PR TITLE
fix(#644): terminate the §116 posture-row window at the next depth-2-3 heading

### DIFF
--- a/scripts/test/smoke.d/50-perproject-recall.sh
+++ b/scripts/test/smoke.d/50-perproject-recall.sh
@@ -2627,12 +2627,106 @@ s116_agents=$(ls "$SHELL_ROOT"/.claude/agents/*.md 2>/dev/null | wc -l | tr -d '
 s116_cmds=$(grep -cE '^### 5\.[0-9]+ `/' "$s116_spec")
 s116_hooks=$(grep -oE 'should_skip [a-z-]+' "$SHELL_ROOT"/.claude/hooks/pre_tool_use.sh | awk '{print $2}' | sort -u | wc -l | tr -d ' ')
 s116_exp=$((s116_levers + s116_agents + s116_cmds + s116_hooks))
-s116_rows=$(awk '/^### 1\.9 /{i=1;next} /^## 2\. /{exit} i' "$s116_spec" \
-            | grep -E '^\|' | grep -cE '`(cede-to-harness|keep-as-policy|keep-as-safety-redundancy)`')
+# s116_posture_rows <spec-file> → count of §1.9 posture rows in that file. The
+# SINGLE derivation of the count: the live parity arm below AND the §116a-§116c
+# window-terminator arms (#644) both call it, so the window rule lives in exactly
+# one place and cannot be fixed in one caller while drifting in the other.
+s116_posture_rows() {
+  awk '/^### 1\.9 /{i=1;next} /^## 2\. /{exit} i' "$1" \
+    | grep -E '^\|' | grep -cE '`(cede-to-harness|keep-as-policy|keep-as-safety-redundancy)`'
+}
+s116_rows=$(s116_posture_rows "$s116_spec")
 if [ "$s116_rows" -gt 0 ] && [ "$s116_rows" = "$s116_exp" ]; then
   ok "116: SPEC §1.9 classifies all $s116_exp enumerated mechanisms (parity, #450)"
 else
   ng "116: SPEC §1.9 coverage parity drift — classified=$s116_rows expected=$s116_exp (levers=$s116_levers agents=$s116_agents cmds=$s116_cmds hooks=$s116_hooks) (#450)"
+fi
+
+# ---------- §116a-§116d: §116's row-count window terminator (#644) ----------
+# Phase B (Test). §116's window opens at `### 1.9 ` and must close at the NEXT
+# HEADING OF DEPTH ≤ 3 — not at the literal `## 2. `. With the literal
+# terminator, everything authored between §1.9 and `## 2. ` (a new `### 1.10`,
+# say) sits INSIDE the counting window, so an unrelated table row quoting a
+# backticked posture token inflates the count and reds §116 for a cause outside
+# its subject. A genuine `#### 1.9.1` sub-section of §1.9 must stay INSIDE.
+#
+# Fixtures are COPIES under $TMP (cleaned by the preamble's EXIT trap); no arm
+# writes to the real SPEC.md, and §116d pins that (AC5) — nothing here removes a
+# path, so there is no cleanup to prefix-guard.
+#
+# WITNESS HONESTY: only §116a reds against the current terminator. §116b and
+# §116c pass both before and after the fix — they are REGRESSION GUARDS bounding
+# the fix (b: it must not shrink the real scope; c: the pair is not
+# always-failing), not witnesses. §116b does carry one load-bearing job for
+# §116a: it proves the decoy row IS countable when in scope, so a green §116a
+# cannot be a decoy that simply never matched the counting regex.
+S116W_DIR="$TMP/s116w"
+mkdir -p "$S116W_DIR"
+S116W_MARK='smoke-fixture-decoy-644'
+# s116w_fixture <heading-line> <out-file> — a SPEC.md copy with <heading-line>
+# plus ONE decoy posture row spliced in just before the `## 2. ` heading. Only
+# the heading DEPTH differs between §116a and §116b, so the heading rule is the
+# single variable under test.
+s116w_fixture() {
+  awk -v h="$1" -v m="$S116W_MARK" '
+    /^## 2\. /&&!d { print h; print ""
+                     print "| " m " (§0) | `keep-as-policy` | decoy row planted by smoke §116a/§116b (#644). |"
+                     print ""; d=1 }
+    { print }' "$s116_spec" > "$2"
+}
+s116w_excl="$S116W_DIR/excl.md"
+s116w_incl="$S116W_DIR/incl.md"
+s116w_pristine="$S116W_DIR/pristine.md"
+cp "$s116_spec" "$s116w_pristine"
+s116w_fixture '### 1.10 Smoke fixture decoy section (#644)'    "$s116w_excl"
+s116w_fixture '#### 1.9.1 Smoke fixture sub-section (#644)'    "$s116w_incl"
+# Baseline over the untouched SPEC. `-gt 0` below fails LOUD if the window
+# collapsed (a §1.9 rename, an awk that exits before the window opens) rather
+# than reading an empty window as agreement.
+s116w_base=$(s116_posture_rows "$s116_spec")
+
+# §116a (AC2, THE WITNESS — RED until the terminator is scoped): a decoy posture
+# row inside a `### 1.10` is OUT of §1.9 and must not move the count.
+s116w_a=$(s116_posture_rows "$s116w_excl")
+if [ ! -s "$s116w_excl" ] || [ "$(grep -c "$S116W_MARK" "$s116w_excl")" != 1 ]; then
+  ng "116a: fixture not built — '### 1.10' decoy SPEC copy missing or lacks exactly one decoy row (#644)"
+elif [ "$s116w_base" -gt 0 ] && [ "$s116w_a" = "$s116w_base" ]; then
+  ok "116a: a posture row inside a '### 1.10' is EXCLUDED from the §1.9 window (count stays $s116w_base) (#644)"
+else
+  ng "116a: §116's window admits a '### 1.10' — count=$s116w_a baseline=$s116w_base; the terminator must be the next heading of depth ≤ 3, not the literal '## 2. ' (#644)"
+fi
+
+# §116b (AC3, regression guard — green before and after): the SAME row inside a
+# `#### 1.9.1` is a genuine §1.9 sub-section and stays counted. Doubles as
+# §116a's non-vacuity proof (the decoy row does match the counting regex).
+s116w_b=$(s116_posture_rows "$s116w_incl")
+if [ ! -s "$s116w_incl" ] || [ "$(grep -c "$S116W_MARK" "$s116w_incl")" != 1 ]; then
+  ng "116b: fixture not built — '#### 1.9.1' decoy SPEC copy missing or lacks exactly one decoy row (#644)"
+elif [ "$s116w_base" -gt 0 ] && [ "$s116w_b" = "$((s116w_base + 1))" ]; then
+  ok "116b: a posture row inside a '#### 1.9.1' is still INCLUDED (count $s116w_base → $s116w_b) (#644)"
+else
+  ng "116b: §116's window lost a genuine '#### 1.9.1' sub-section row — count=$s116w_b expected=$((s116w_base + 1)) (#644)"
+fi
+
+# §116c (AC4, regression guard — green before and after): an UNMODIFIED copy
+# still balances against the independently derived expectation, so §116a+§116b
+# are not simply bounding an always-failing derivation.
+s116w_c=$(s116_posture_rows "$s116w_pristine")
+if [ ! -s "$s116w_pristine" ]; then
+  ng "116c: fixture not built — pristine SPEC copy missing or empty (#644)"
+elif [ "$s116w_c" -gt 0 ] && [ "$s116w_c" = "$s116_exp" ]; then
+  ok "116c: an unmodified SPEC copy still balances ($s116w_c = $s116_exp) (#644)"
+else
+  ng "116c: unmodified SPEC copy no longer balances — classified=$s116w_c expected=$s116_exp (#644)"
+fi
+
+# §116d (AC5, regression guard — green before and after): the real SPEC.md is
+# byte-identical to the copy taken before any fixture was built. Pins that the
+# fixture builder writes only to $TMP.
+if [ -s "$s116w_pristine" ] && cmp -s "$s116_spec" "$s116w_pristine"; then
+  ok "116d: the real SPEC.md is unmutated by the §116a-§116c fixtures (#644)"
+else
+  ng "116d: SPEC.md changed while the §116 window fixtures ran — a fixture wrote to the real SSOT (#644)"
 fi
 
 # ---------- §117: command docs use -F (not -f) for gh api stdin/file body (#452) ----------

--- a/scripts/test/smoke.d/50-perproject-recall.sh
+++ b/scripts/test/smoke.d/50-perproject-recall.sh
@@ -2631,21 +2631,37 @@ s116_exp=$((s116_levers + s116_agents + s116_cmds + s116_hooks))
 # SINGLE derivation of the count: the live parity arm below AND the §116a-§116c
 # window-terminator arms (#644) both call it, so the window rule lives in exactly
 # one place and cannot be fixed in one caller while drifting in the other.
+# THE SINGLE DEFINITION of "what ends §1.9's window" (#644). Used by BOTH the
+# live derivation below AND the §116a/§116b fixture builder, so the guard and the
+# arms that bound it cannot drift apart — which is the whole reason the
+# derivation was extracted into a function in the first place.
+#
+# DEPTH 2-3, not "depth <= 3". `^# ` is deliberately ABSENT: it matches any
+# shell comment, and SPEC carries 16 such lines inside fenced examples, so
+# including it would collapse the window to 0 the day §1.9 gains a fenced
+# example (measured). Dropping it costs nothing — the only thing it could ever
+# terminate on is a SECOND document H1 appearing after §1.9, in a file with
+# exactly one H1 (line 1) across 2900+ lines, and the `i&&` guard already keeps
+# line 1 from closing a window that has not opened.
+#
+# RESIDUAL, named rather than rounded off: this rule is line-oriented and knows
+# nothing about code fences, so 9 fence-interior `^## ` lines elsewhere in SPEC
+# remain collidable. Accepted for #644 — §1.9 carries no fence today and the
+# failure is loud (§116 reds at classified=0) rather than silent. Fence-state
+# tracking is deliberately NOT attempted here.
+S116_END_RE='^## |^### '
+
 s116_posture_rows() {
-  # Terminate at the NEXT HEADING OF DEPTH <= 3, not at the literal `## 2. ` (#644).
-  # The old terminator put every section between §1.9 and `## 2.` INSIDE the
-  # counting window, so a posture-token table row in a new `### 1.10` inflated
-  # the count and reddened §116 for a reason unrelated to the parity it checks
-  # (measured: 66 -> 67). `#### ` is deliberately NOT a terminator — position 3
-  # is `#`, not a space, so a genuine `#### 1.9.1` sub-section of §1.9 stays in
-  # scope and its rows still count (§116b pins that direction).
+  # `#### ` is NOT a terminator — position 3 is `#`, not a space — so a genuine
+  # `#### 1.9.1` sub-section of §1.9 stays in scope and its rows still count
+  # (§116b pins that direction).
   #
   # The `i&&` guard is LOAD-BEARING, not defensive: without it the terminator
-  # matches SPEC's own H1 (`# GHJig-Claude — Design Specification`) on LINE 1 and
+  # matches the §1.9 heading itself and every earlier `## `/`### ` heading, and
   # awk exits before the window ever opens, yielding 0. That would not fail
-  # silently — §116's `-gt 0` check and §116a-§116c's baseline guards all catch
+  # silently — §116's `-gt 0` check and the §116a-§116c baseline guards all catch
   # it — but the guard is what keeps the rule scoped to the window it describes.
-  awk '/^### 1\.9 /{i=1;next} i&&/^# |^## |^### /{exit} i' "$1" \
+  awk -v endre="$S116_END_RE" '/^### 1\.9 /{i=1;next} i&&$0~endre{exit} i' "$1" \
     | grep -E '^\|' | grep -cE '`(cede-to-harness|keep-as-policy|keep-as-safety-redundancy)`'
 }
 s116_rows=$(s116_posture_rows "$s116_spec")
@@ -2677,14 +2693,26 @@ S116W_DIR="$TMP/s116w"
 mkdir -p "$S116W_DIR"
 S116W_MARK='smoke-fixture-decoy-644'
 # s116w_fixture <heading-line> <out-file> — a SPEC.md copy with <heading-line>
-# plus ONE decoy posture row spliced in just before the `## 2. ` heading. Only
-# the heading DEPTH differs between §116a and §116b, so the heading rule is the
+# plus ONE decoy posture row spliced in at THE END OF §1.9, i.e. immediately
+# before the first line that $S116_END_RE says closes the window. Only the
+# heading DEPTH differs between §116a and §116b, so the heading rule stays the
 # single variable under test.
+#
+# ANCHORED TO §1.9, NOT TO `## 2. ` (#644 round-1 F1). An earlier revision
+# spliced at the literal `## 2. `, which is the end of §1.9 only while §1.9
+# happens to be §1's LAST subsection. The moment a real `### 1.10` lands, that
+# anchor puts §116b's decoy BEHIND the window it is meant to be inside, and the
+# arm reds for a cause outside its own subject — the very pathology §116a
+# exists to prevent, reproduced one level up in the fixture that bounds it.
+# #644 names three Active Directives planning a §1.x section, so this is the
+# anticipated future, not a hypothetical. The anchor reuses $S116_END_RE rather
+# than re-spelling the heading rule, so it cannot drift from the derivation.
 s116w_fixture() {
-  awk -v h="$1" -v m="$S116W_MARK" '
-    /^## 2\. /&&!d { print h; print ""
-                     print "| " m " (§0) | `keep-as-policy` | decoy row planted by smoke §116a/§116b (#644). |"
-                     print ""; d=1 }
+  awk -v h="$1" -v m="$S116W_MARK" -v endre="$S116_END_RE" '
+    /^### 1\.9 /  { i=1; print; next }
+    i&&!d&&$0~endre { print h; print ""
+                      print "| " m " (§0) | `keep-as-policy` | decoy row planted by smoke §116a/§116b (#644). |"
+                      print ""; d=1 }
     { print }' "$s116_spec" > "$2"
 }
 s116w_excl="$S116W_DIR/excl.md"

--- a/scripts/test/smoke.d/50-perproject-recall.sh
+++ b/scripts/test/smoke.d/50-perproject-recall.sh
@@ -2641,7 +2641,7 @@ s116_exp=$((s116_levers + s116_agents + s116_cmds + s116_hooks))
 # including it would collapse the window to 0 the day §1.9 gains a fenced
 # example (measured). Dropping it costs nothing — the only thing it could ever
 # terminate on is a SECOND document H1 appearing after §1.9, in a file with
-# exactly one H1 (line 1) across 2900+ lines, and the `i&&` guard already keeps
+# exactly one H1 (line 1) across 2,893 lines, and the `i&&` guard already keeps
 # line 1 from closing a window that has not opened.
 #
 # RESIDUAL, named rather than rounded off: this rule is line-oriented and knows
@@ -2657,8 +2657,8 @@ s116_posture_rows() {
   # (§116b pins that direction).
   #
   # The `i&&` guard is LOAD-BEARING, not defensive: without it the terminator
-  # matches the §1.9 heading itself and every earlier `## `/`### ` heading, and
-  # awk exits before the window ever opens, yielding 0. That would not fail
+  # matches every EARLIER `## `/`### ` heading and awk exits before the window
+  # ever opens, yielding 0 (measured on the real SPEC). That would not fail
   # silently — §116's `-gt 0` check and the §116a-§116c baseline guards all catch
   # it — but the guard is what keeps the rule scoped to the window it describes.
   awk -v endre="$S116_END_RE" '/^### 1\.9 /{i=1;next} i&&$0~endre{exit} i' "$1" \
@@ -2673,7 +2673,7 @@ fi
 
 # ---------- §116a-§116d: §116's row-count window terminator (#644) ----------
 # Phase B (Test). §116's window opens at `### 1.9 ` and must close at the NEXT
-# HEADING OF DEPTH ≤ 3 — not at the literal `## 2. `. With the literal
+# WINDOW-CLOSING HEADING (depth 2-3) — not at the literal `## 2. `. With the literal
 # terminator, everything authored between §1.9 and `## 2. ` (a new `### 1.10`,
 # say) sits INSIDE the counting window, so an unrelated table row quoting a
 # backticked posture token inflates the count and reds §116 for a cause outside
@@ -2734,7 +2734,7 @@ if [ ! -s "$s116w_excl" ] || [ "$(grep -c "$S116W_MARK" "$s116w_excl")" != 1 ]; 
 elif [ "$s116w_base" -gt 0 ] && [ "$s116w_a" = "$s116w_base" ]; then
   ok "116a: a posture row inside a '### 1.10' is EXCLUDED from the §1.9 window (count stays $s116w_base) (#644)"
 else
-  ng "116a: §116's window admits a '### 1.10' — count=$s116w_a baseline=$s116w_base; the terminator must be the next heading of depth ≤ 3, not the literal '## 2. ' (#644)"
+  ng "116a: §116's window admits a '### 1.10' — count=$s116w_a baseline=$s116w_base; the terminator must be the next window-closing heading (depth 2-3), not the literal '## 2. ' (#644)"
 fi
 
 # §116b (AC3, regression guard — green before and after): the SAME row inside a

--- a/scripts/test/smoke.d/50-perproject-recall.sh
+++ b/scripts/test/smoke.d/50-perproject-recall.sh
@@ -2632,7 +2632,20 @@ s116_exp=$((s116_levers + s116_agents + s116_cmds + s116_hooks))
 # window-terminator arms (#644) both call it, so the window rule lives in exactly
 # one place and cannot be fixed in one caller while drifting in the other.
 s116_posture_rows() {
-  awk '/^### 1\.9 /{i=1;next} /^## 2\. /{exit} i' "$1" \
+  # Terminate at the NEXT HEADING OF DEPTH <= 3, not at the literal `## 2. ` (#644).
+  # The old terminator put every section between §1.9 and `## 2.` INSIDE the
+  # counting window, so a posture-token table row in a new `### 1.10` inflated
+  # the count and reddened §116 for a reason unrelated to the parity it checks
+  # (measured: 66 -> 67). `#### ` is deliberately NOT a terminator — position 3
+  # is `#`, not a space, so a genuine `#### 1.9.1` sub-section of §1.9 stays in
+  # scope and its rows still count (§116b pins that direction).
+  #
+  # The `i&&` guard is LOAD-BEARING, not defensive: without it the terminator
+  # matches SPEC's own H1 (`# GHJig-Claude — Design Specification`) on LINE 1 and
+  # awk exits before the window ever opens, yielding 0. That would not fail
+  # silently — §116's `-gt 0` check and §116a-§116c's baseline guards all catch
+  # it — but the guard is what keeps the rule scoped to the window it describes.
+  awk '/^### 1\.9 /{i=1;next} i&&/^# |^## |^### /{exit} i' "$1" \
     | grep -E '^\|' | grep -cE '`(cede-to-harness|keep-as-policy|keep-as-safety-redundancy)`'
 }
 s116_rows=$(s116_posture_rows "$s116_spec")


### PR DESCRIPTION
Closes #644

## Goal

Stop `§116`'s parity guard from reddening for a cause outside its subject: its counting window ran to the literal `## 2. `, so any section added between §1.9 and there — a `### 1.10`, anything — sat **inside** the window, and a posture-token table row placed there inflated the count.

## How this serves the mission

MISSION *"The mechanism"*: which face a rule wears is decided by the asymmetry in the cost of being wrong, and *"a wrong nudge is simply ignored at no cost"* is what makes a positive rule cheap. A parity guard that reds for an unrelated cause is **not** cheap — it trains the operator to read a red `§116` as noise, which is the failure mode the guard exists to prevent, inverted.

## Plan

Type is `fix`, so §1.2's reproduce-first relaxation applies — the defect was reproduced against a copy of the real SPEC before anything was written.

**Docs: n/a — no SSOT contract changes.** `§116`'s window is a smoke-arm implementation detail with no SPEC clause; the arm's own header is its documentation, and it is updated in the Code commit. Test-only surface, so `skip-changelog` per §18.7 (*"`test`-only"* is explicitly listed as skip-eligible).

The planner gate did not fire: this is a single-file change, not the 3+ files / schema / API / migration shape that requires it.

**Deviation, disclosed: this PR was opened ready, not draft-first.** Both commits were complete before it was created, so the backbone's `draft PR → checklist commits → ready PR` cadence and the commit→body curation order were both skipped. The ground was that a single-file test fix with `Docs: n/a` has no Phase-A commit to seed a draft with — but that is a reason, not an exemption, and the omission is named here because a Plan that lists three deviations and silently drops a fourth reads as a complete disclosure when it is not. The history cannot be replayed; this line is the whole remedy.

## Key context

The old terminator, and why the depth-2-3 rule is the right replacement:

| fixture | before | after | wanted |
|---|---|---|---|
| healthy SPEC | 66 | 66 | unchanged |
| decoy posture row in a new `### 1.10` | **67** | **66** | EXCLUDED |
| same row in a `#### 1.9.1` | 67 | 67 | still INCLUDED |

`#### ` is deliberately **not** a terminator — position 3 is `#`, not a space — so a genuine sub-section of §1.9 stays in scope and its rows still count.

## Checklist

- [x] **Test** (`e20137f`): `§116a` exclusion (the witness), `§116b` inclusion, `§116c` healthy, `§116d` AC5 no-mutation. Red before Code.
- [x] **Code** (`6e8dbf1`): terminate at the next window-closing heading, scoped with `i&&`.
- [x] **Review fixes** (`13e2b7d`, `18c3cbc`): round-1 F1 + F2 from one shared rule; round-2 corrections to three stale claims.
- [~] **Doc**: N/A — no SSOT contract change; see Plan.

## Out of scope

Upgrading `§116` from **count** parity to **name-level identity** parity. Today a lever row and a posture row for two *different* mechanisms cancel out and the guard still balances — a real weakness, not created here, and a larger change (the issue says the same).

## Round-1 review fixes (`13e2b7d`)

The judged list is posted above. Two fix-now findings, both landed from **one** definition (`S116_END_RE`) used by the derivation and the fixture builder alike — two copies of "what ends §1.9" would be exactly the drift the extraction was introduced to prevent.

**F1 — my own new arm reproduced this PR's bug one level up.** `§116b` spliced its decoy at the literal `## 2. `, which is the end of §1.9 *only while §1.9 is §1's last subsection*. Given a real `### 1.10`, the decoy lands **behind** the window it is meant to be inside and the arm reds for a cause outside its subject. Re-anchored to the first window-closing line *after* `### 1.9 `, computed. Verified on today's SPEC **and** one carrying a real `### 1.10` — `base=66, excl=66, incl=67` in both, with `§116a` still a **live witness** (pre-fix `excl=67` vs `base=66`) in both.

**F2 — dropped the `^# ` alternative.** It matches any shell comment, and SPEC carries 16 such lines inside fenced examples, so a fenced example in §1.9 would collapse the window (measured: **0** with it, **66** without). No measurable cost, and it cannot reintroduce the line-1 trap since `i&&` is load-bearing for the `^## ` arm regardless. **This makes the rule depth 2–3, not "depth ≤ 3" as AC1 words it** — a deliberate, measured divergence from the AC's letter, recorded rather than glossed. Residual named: the rule is fence-blind, so 9 fence-interior `^## ` lines elsewhere remain collidable — accepted, since §1.9 has no fence today and the failure is loud.

**F3 and F4 were ruled `drop`** — both true, both behaviour-free. `§116c` is information-equivalent to `§116`, but AC4 asks for it in so many words, so deleting it would fail the AC's letter at closeout.

## Adjacent defect found by this review — tracked as #668

Round 3's reviewer noticed the **same bug class one line above this diff**: `s116_levers` terminates its §1.8 window at a literal `### 1.9 ` heading (and anchors its start on a literal `### 1.8 `). Measured — a `### 1.8.5` carrying one `| **`-shaped row takes the lever count 6 → 7, which reds §116 on a false parity mismatch; a renumbered §1.8 takes it to 0.

The judge ruled it `defer-to-issue` **with filing required before this PR merges**, on the ground that "out of scope" and "file it" are two halves of one disposition rather than alternatives — and because this repo has twice had an artifact assert a tracking item that did not exist. **#668 was filed before this line was written**; nothing here claimed it was tracked until it was.

It is deliberately **not** fixed here: round 3's discipline is zero-code, and a second terminator change is exactly the non-required finding that has manufactured the next round's defect three times in this PR.

## Risks

- **The `i&&` guard is load-bearing, not defensive.** Without it the terminator matches every **earlier** `## `/`### ` heading and awk exits before the window opens, yielding 0 (measured on the real SPEC). *(An earlier revision of this bullet blamed SPEC's H1 on line 1 — true while the terminator still carried `^# `, and falsified by dropping it in `13e2b7d`. The §1.9 heading itself is also not the cause: rule 1's `next` means that line never reaches the terminator.)* It would not fail silently — `§116`'s `-gt 0` check and the new arms' baseline guards all catch it — but the comment records it so it is not reintroduced.
- **A behaviour-preserving extraction rides along.** The derivation moved into `s116_posture_rows()` and `§116` now calls it. Without that, the Code fix would edit one site while the new arms read a second copy of the awk, leaving `§116a` unfixable. It is stated here as an addition rather than smuggled in; it changed no verdict (`§116` still greens at 66 across the extraction commit).

## Test plan

`§116a` is the **only** witness — red at `1283/1` before the fix, green after. `§116b` and `§116c` pass **both** before and after and are labelled in-file as bounds rather than witnesses; dressing a guard up as a witness manufactures confidence the arms do not have.

`§116b` doubles as `§116a`'s **non-vacuity proof**: it shows the *identical* decoy row **is** countable when in scope, so a green `§116a` cannot be a decoy that simply never matched the posture-token regex. Both fixtures come from one builder spliced at one anchor and differ **only** in the heading line's depth — the single variable under test.

**Measured, in a window with no live agent worktree:** `pass=1283 fail=1` before → **`pass=1284 fail=0`** after; `lint OK: 79 files clean`; and `git status` confirms the real `SPEC.md` is unmodified after a full run (AC5).
