### PR TITLE
fix(#668): anchor the §116 lever window on the section title and the shared terminator

### DIFF
--- a/scripts/test/smoke.d/50-perproject-recall.sh
+++ b/scripts/test/smoke.d/50-perproject-recall.sh
@@ -2622,7 +2622,22 @@ fi
 # rename / empty table (anti-vacuity #2). A mechanism added to any of the four
 # families bumps the expected total and trips this guard until a §1.9 row is added.
 s116_spec="$SHELL_ROOT/SPEC.md"
-s116_levers=$(awk '/^### 1\.8 /{i=1;next} /^### 1\.9 /{exit} i&&/^\| \*\*/{n++} END{print n+0}' "$s116_spec")
+# s116_lever_rows <spec-file> → count of §1.8 narrowing-lever table rows in that
+# file. THE SINGLE DERIVATION of the lever count: the live `s116_levers` below
+# AND the §116e-§116g lever-window arms (#668) both call it, so the window rule
+# lives in exactly one place and cannot be repaired in one caller while drifting
+# in the other. Same shape, and for the same reason, as s116_posture_rows below.
+#
+# THIS IS NOT THE FIX (#668, Phase B). The awk body is the PRE-FIX derivation
+# verbatim — both ends of the window are still literal headings — so §116e and
+# §116f red against it exactly as #668 measured. The extraction is
+# behaviour-preserving (`s116_levers` still derives 6); without it the Code
+# phase would repair the inline copy while the new arms went on reading a
+# second one, leaving both witnesses unfixable.
+s116_lever_rows() {
+  awk '/^### 1\.8 /{i=1;next} /^### 1\.9 /{exit} i&&/^\| \*\*/{n++} END{print n+0}' "$1"
+}
+s116_levers=$(s116_lever_rows "$s116_spec")
 s116_agents=$(ls "$SHELL_ROOT"/.claude/agents/*.md 2>/dev/null | wc -l | tr -d ' ')
 s116_cmds=$(grep -cE '^### 5\.[0-9]+ `/' "$s116_spec")
 s116_hooks=$(grep -oE 'should_skip [a-z-]+' "$SHELL_ROOT"/.claude/hooks/pre_tool_use.sh | awk '{print $2}' | sort -u | wc -l | tr -d ' ')
@@ -2671,56 +2686,118 @@ else
   ng "116: SPEC §1.9 coverage parity drift — classified=$s116_rows expected=$s116_exp (levers=$s116_levers agents=$s116_agents cmds=$s116_cmds hooks=$s116_hooks) (#450)"
 fi
 
-# ---------- §116a-§116d: §116's row-count window terminator (#644) ----------
-# Phase B (Test). §116's window opens at `### 1.9 ` and must close at the NEXT
-# WINDOW-CLOSING HEADING (depth 2-3) — not at the literal `## 2. `. With the literal
-# terminator, everything authored between §1.9 and `## 2. ` (a new `### 1.10`,
-# say) sits INSIDE the counting window, so an unrelated table row quoting a
-# backticked posture token inflates the count and reds §116 for a cause outside
-# its subject. A genuine `#### 1.9.1` sub-section of §1.9 must stay INSIDE.
+# ---------- §116a-§116g: §116's two windowed extractors (#644, #668) ----------
+# Phase B (Test). §116 derives its verdict from TWO windowed walks of SPEC —
+# §1.9's posture-row count (`s116_posture_rows`, arms §116a-§116c, #644) and
+# §1.8's lever-row count (`s116_lever_rows`, arms §116e-§116g, #668) — and both
+# feed the same comparison. The arms share ONE fixture builder and ONE
+# $S116_END_RE, so "what ends a §1.x window" is spelled once for every window
+# under test. §116d is the AC5 sentinel for every fixture below and is kept LAST
+# by design.
+#
+# THE ROW WINDOW (#644): §116's posture-row window opens at `### 1.9 ` and must
+# close at the NEXT WINDOW-CLOSING HEADING (depth 2-3) — not at the literal
+# `## 2. `. With the literal terminator, everything authored between §1.9 and
+# `## 2. ` (a new `### 1.10`, say) sits INSIDE the counting window, so an
+# unrelated table row quoting a backticked posture token inflates the count and
+# reds §116 for a cause outside its subject. A genuine `#### 1.9.1` sub-section
+# of §1.9 must stay INSIDE.
+#
+# THE LEVER WINDOW (#668): the same shape, one section up and on BOTH ends.
+# `s116_lever_rows`' window opens at the literal `### 1.8 ` and closes at the
+# literal `### 1.9 `, so (a) a `| **`-shaped row in a new `### 1.8.5` sibling is
+# counted as a lever it is not, and (b) renumbering §1.8 collapses the window to
+# 0 and silently drops every real lever from `s116_exp`. Both ends must go: the
+# terminator becomes the shared $S116_END_RE, the start anchor becomes the
+# section's TITLE rather than its number. A genuine `#### 1.8.1` sub-section of
+# §1.8 must stay INSIDE.
 #
 # Fixtures are COPIES under $TMP (cleaned by the preamble's EXIT trap); no arm
 # writes to the real SPEC.md, and §116d pins that (AC5) — nothing here removes a
 # path, so there is no cleanup to prefix-guard.
 #
-# WITNESS HONESTY: only §116a reds against the current terminator. §116b and
+# WITNESS HONESTY (#644, the row window): only §116a reds against the current
+# row-window terminator. §116b and
 # §116c pass both before and after the fix — they are REGRESSION GUARDS bounding
 # the fix (b: it must not shrink the real scope; c: the pair is not
 # always-failing), not witnesses. §116b does carry one load-bearing job for
 # §116a: it proves the decoy row IS countable when in scope, so a green §116a
 # cannot be a decoy that simply never matched the counting regex.
+#
+# WITNESS HONESTY (#668, the lever window): §116e and §116f are WITNESSES — each
+# reds against `s116_lever_rows` as it stands (measured: 7 and 0 against a
+# baseline of 6). §116g is a BOUND, not a witness: it reads 7 both before and
+# after the repair, so it constrains the repair's shape rather than
+# demonstrating the defect. It is labelled that way at its own arm too.
 S116W_DIR="$TMP/s116w"
 mkdir -p "$S116W_DIR"
 S116W_MARK='smoke-fixture-decoy-644'
-# s116w_fixture <heading-line> <out-file> — a SPEC.md copy with <heading-line>
-# plus ONE decoy posture row spliced in at THE END OF §1.9, i.e. immediately
-# before the first line that $S116_END_RE says closes the window. Only the
-# heading DEPTH differs between §116a and §116b, so the heading rule stays the
-# single variable under test.
+# s116w_fixture <open-re> <heading-line> <decoy-row> <out-file> — a SPEC.md copy
+# with <heading-line> plus ONE <decoy-row> spliced in at THE END OF the section
+# <open-re> opens, i.e. immediately before the first following line that
+# $S116_END_RE says closes a §1.x window. Only the heading DEPTH differs between
+# the exclusion and the inclusion fixture of each pair, so the heading rule
+# stays the single variable under test.
 #
-# ANCHORED TO §1.9, NOT TO `## 2. ` (#644 round-1 F1). An earlier revision
-# spliced at the literal `## 2. `, which is the end of §1.9 only while §1.9
-# happens to be §1's LAST subsection. The moment a real `### 1.10` lands, that
-# anchor puts §116b's decoy BEHIND the window it is meant to be inside, and the
-# arm reds for a cause outside its own subject — the very pathology §116a
-# exists to prevent, reproduced one level up in the fixture that bounds it.
-# #644 names three Active Directives planning a §1.x section, so this is the
-# anticipated future, not a hypothetical. The anchor reuses $S116_END_RE rather
-# than re-spelling the heading rule, so it cannot drift from the derivation.
+# ONE BUILDER FOR BOTH WINDOWS (#668). §1.9's arms (#644) and §1.8's arms (#668)
+# pass different <open-re>/<decoy-row> and share everything else, so the splice
+# rule — "the end of a §1.x section" — exists in exactly one place, for the same
+# reason $S116_END_RE does. A second builder would be the drift that shared
+# definition exists to prevent.
+#
+# ANCHORED TO THE SECTION UNDER TEST, NOT TO A DOCUMENT-GLOBAL LITERAL (#644
+# round-1 F1). An earlier revision spliced at the literal `## 2. `, which is the
+# end of §1.9 only while §1.9 happens to be §1's LAST subsection. The moment a
+# real `### 1.10` lands, that anchor puts §116b's decoy BEHIND the window it is
+# meant to be inside, and the arm reds for a cause outside its own subject — the
+# very pathology §116a exists to prevent, reproduced one level up in the fixture
+# that bounds it. #644 names three Active Directives planning a §1.x section, so
+# this is the anticipated future, not a hypothetical. The same reasoning binds
+# the §1.8 fixtures: they splice at the end of §1.8 as $S116_END_RE finds it,
+# never at the literal `### 1.9 `. The anchor reuses $S116_END_RE rather than
+# re-spelling the heading rule, so it cannot drift from the derivation.
 s116w_fixture() {
-  awk -v h="$1" -v m="$S116W_MARK" -v endre="$S116_END_RE" '
-    /^### 1\.9 /  { i=1; print; next }
-    i&&!d&&$0~endre { print h; print ""
-                      print "| " m " (§0) | `keep-as-policy` | decoy row planted by smoke §116a/§116b (#644). |"
-                      print ""; d=1 }
-    { print }' "$s116_spec" > "$2"
+  awk -v openre="$1" -v h="$2" -v row="$3" -v endre="$S116_END_RE" '
+    !i&&$0~openre   { i=1; print; next }
+    i&&!d&&$0~endre { print h; print ""; print row; print ""; d=1 }
+    { print }' "$s116_spec" > "$4"
 }
+S116W_ROW="| $S116W_MARK (§0) | \`keep-as-policy\` | decoy row planted by smoke §116a/§116b (#644). |"
 s116w_excl="$S116W_DIR/excl.md"
 s116w_incl="$S116W_DIR/incl.md"
 s116w_pristine="$S116W_DIR/pristine.md"
 cp "$s116_spec" "$s116w_pristine"
-s116w_fixture '### 1.10 Smoke fixture decoy section (#644)'    "$s116w_excl"
-s116w_fixture '#### 1.9.1 Smoke fixture sub-section (#644)'    "$s116w_incl"
+s116w_fixture '^### 1\.9 ' '### 1.10 Smoke fixture decoy section (#644)'  "$S116W_ROW" "$s116w_excl"
+s116w_fixture '^### 1\.9 ' '#### 1.9.1 Smoke fixture sub-section (#644)'  "$S116W_ROW" "$s116w_incl"
+
+# ---- §116e-§116g fixtures (#668), built HERE, up front, alongside the #644
+# ones so that §116d — which runs LAST and pins AC5 — covers these too. Same
+# builder, same anchor discipline; only the section and the decoy row's SHAPE
+# differ (§1.8's window counts `| **`-leading rows; §1.9's counts backticked
+# posture tokens). The decoy carries no posture token, so it is inert to
+# s116_posture_rows even if a future window ever spans both sections.
+S116L_MARK='smoke-fixture-decoy-668'
+S116L_ROW="| **$S116L_MARK** (§0) | decoy lever row planted by smoke §116e/§116g (#668). | **Guidance** — fixture only. |"
+s116l_excl="$S116W_DIR/lever-excl.md"
+s116l_incl="$S116W_DIR/lever-incl.md"
+s116l_renum="$S116W_DIR/lever-renum.md"
+s116w_fixture '^### 1\.8 ' '### 1.8.5 Smoke fixture decoy section (#668)' "$S116L_ROW" "$s116l_excl"
+s116w_fixture '^### 1\.8 ' '#### 1.8.1 Smoke fixture sub-section (#668)'  "$S116L_ROW" "$s116l_incl"
+# §116f's fixture is a RENAME, not a splice: §1.8's heading keeps its TITLE and
+# loses its NUMBER, which is the only thing the start anchor may legitimately
+# depend on. Derived from the live heading line — no SPEC title is hardcoded
+# here — so the copy differs from the real SPEC in exactly that one line, and a
+# §1.8 that has already been renumbered upstream leaves $s116l_h_orig empty and
+# trips §116f's fixture guard rather than quietly producing a no-op copy.
+s116l_h_orig=$(grep -m1 '^### 1\.8 ' "$s116_spec")
+s116l_h_renum="### 1.8a ${s116l_h_orig#\#\#\# 1.8 }"
+awk -v o="$s116l_h_orig" -v n="$s116l_h_renum" '!r&&$0==o { print n; r=1; next } { print }' \
+  "$s116_spec" > "$s116l_renum"
+# Lever-count baseline over the untouched SPEC, the DENOMINATOR every §116e-§116g
+# comparison is gated on: `-gt 0` fails LOUD if the lever window collapsed (a
+# §1.8 rename, an awk that exits before the window opens) rather than letting an
+# empty window read as agreement.
+s116l_base=$(s116_lever_rows "$s116_spec")
 # Baseline over the untouched SPEC. `-gt 0` below fails LOUD if the window
 # collapsed (a §1.9 rename, an awk that exits before the window opens) rather
 # than reading an empty window as agreement.
@@ -2761,13 +2838,63 @@ else
   ng "116c: unmodified SPEC copy no longer balances — classified=$s116w_c expected=$s116_exp (#644)"
 fi
 
-# §116d (AC5, regression guard — green before and after): the real SPEC.md is
+# §116e (#668 AC2, THE WITNESS — RED until the lever window's terminator stops
+# being the literal `### 1.9 `): a decoy `| **`-shaped row inside a NEW
+# `### 1.8.5` sibling section is OUT of §1.8's lever table and must not move the
+# count. Measured pre-fix: levers=7 against a baseline of 6, i.e. an unrelated
+# table row inflates s116_exp and reds §116 — AND §116c, whose message then
+# blames the SPEC copy — for a cause outside either arm's subject.
+s116l_e=$(s116_lever_rows "$s116l_excl")
+if [ ! -s "$s116l_excl" ] || [ "$(grep -c "$S116L_MARK" "$s116l_excl")" != 1 ]; then
+  ng "116e: fixture not built — '### 1.8.5' decoy SPEC copy missing or lacks exactly one decoy lever row (#668)"
+elif [ "$s116l_base" -gt 0 ] && [ "$s116l_e" = "$s116l_base" ]; then
+  ok "116e: a '| **' row inside a '### 1.8.5' is EXCLUDED from the §1.8 lever window (count stays $s116l_base) (#668)"
+else
+  ng "116e: §116's lever window admits a '### 1.8.5' — levers=$s116l_e baseline=$s116l_base; the terminator must be the shared \$S116_END_RE, not the literal '### 1.9 ' (#668)"
+fi
+
+# §116f (#668 AC4, THE WITNESS — RED until the START anchor stops being the
+# literal `### 1.8 `): a SPEC copy whose §1.8 is RENUMBERED (title untouched)
+# must still yield the same lever count. Measured pre-fix: levers=0 against a
+# baseline of 6 — the window never opens, so every lever silently vanishes from
+# s116_exp. The fixture guard is on the DENOMINATOR: it demands the renumbered
+# heading be present exactly once AND the old numbering be gone, so a rename
+# that silently did nothing fails loud instead of reading as a pass.
+s116l_f=$(s116_lever_rows "$s116l_renum")
+if [ ! -s "$s116l_renum" ] || [ -z "$s116l_h_orig" ] \
+   || [ "$(grep -cF "$s116l_h_renum" "$s116l_renum")" != 1 ] \
+   || [ "$(grep -c '^### 1\.8 ' "$s116l_renum")" != 0 ]; then
+  ng "116f: fixture not built — renumbered SPEC copy missing, or its §1.8 heading was not rewritten to '### 1.8a <same title>' (#668)"
+elif [ "$s116l_base" -gt 0 ] && [ "$s116l_f" = "$s116l_base" ]; then
+  ok "116f: renumbering §1.8 keeps its levers in the window (count stays $s116l_base) (#668)"
+else
+  ng "116f: §116's lever window opens only at the literal '### 1.8 ' — levers=$s116l_f baseline=$s116l_base; anchor the start on the section TITLE, not on its number (#668)"
+fi
+
+# §116g (#668 AC3, a BOUND — NOT a witness: measured 7 both before and after the
+# repair): the SAME decoy row inside a genuine `#### 1.8.1` sub-section of §1.8
+# is still COUNTED, so scoping the terminator must not shrink the lever window's
+# real reach (`#### ` is depth 4 and $S116_END_RE deliberately stops at 3).
+# It also carries §116e's non-vacuity: it proves the IDENTICAL row IS countable
+# when in scope, so a green §116e cannot be a decoy that simply never matched
+# `^\| \*\*`.
+s116l_g=$(s116_lever_rows "$s116l_incl")
+if [ ! -s "$s116l_incl" ] || [ "$(grep -c "$S116L_MARK" "$s116l_incl")" != 1 ]; then
+  ng "116g: fixture not built — '#### 1.8.1' decoy SPEC copy missing or lacks exactly one decoy lever row (#668)"
+elif [ "$s116l_base" -gt 0 ] && [ "$s116l_g" = "$((s116l_base + 1))" ]; then
+  ok "116g: a '| **' row inside a '#### 1.8.1' is still INCLUDED (count $s116l_base → $s116l_g) (#668)"
+else
+  ng "116g: §116's lever window lost a genuine '#### 1.8.1' sub-section row — levers=$s116l_g expected=$((s116l_base + 1)) (#668)"
+fi
+
+# §116d (AC5, regression guard — green before and after; kept LAST by design so
+# it covers every fixture above, #644's and #668's alike): the real SPEC.md is
 # byte-identical to the copy taken before any fixture was built. Pins that the
 # fixture builder writes only to $TMP.
 if [ -s "$s116w_pristine" ] && cmp -s "$s116_spec" "$s116w_pristine"; then
-  ok "116d: the real SPEC.md is unmutated by the §116a-§116c fixtures (#644)"
+  ok "116d: the real SPEC.md is unmutated by the §116a-§116g fixtures (#644, #668)"
 else
-  ng "116d: SPEC.md changed while the §116 window fixtures ran — a fixture wrote to the real SSOT (#644)"
+  ng "116d: SPEC.md changed while the §116 window fixtures ran — a fixture wrote to the real SSOT (#644, #668)"
 fi
 
 # ---------- §117: command docs use -F (not -f) for gh api stdin/file body (#452) ----------

--- a/scripts/test/smoke.d/50-perproject-recall.sh
+++ b/scripts/test/smoke.d/50-perproject-recall.sh
@@ -2622,11 +2622,6 @@ fi
 # rename / empty table (anti-vacuity #2). A mechanism added to any of the four
 # families bumps the expected total and trips this guard until a §1.9 row is added.
 s116_spec="$SHELL_ROOT/SPEC.md"
-# s116_lever_rows <spec-file> → count of §1.8 narrowing-lever table rows in that
-# file. THE SINGLE DERIVATION of the lever count: the live `s116_levers` below
-# AND the §116e-§116g lever-window arms (#668) both call it, so the window rule
-# lives in exactly one place and cannot be repaired in one caller while drifting
-# in the other. Same shape, and for the same reason, as s116_posture_rows below.
 # THE SINGLE DEFINITION of "what ends a §1.x window" (#644, widened to §1.8 by
 # #668). Used by BOTH live derivations (§1.8's lever count and §1.9's posture
 # count) AND the shared fixture builder, so the guards and the arms that bound
@@ -2636,9 +2631,14 @@ s116_spec="$SHELL_ROOT/SPEC.md"
 # DEFINED HERE, ABOVE THE FIRST CONSUMER, DELIBERATELY. `s116_lever_rows` runs
 # ~30 lines below and takes this as `-v endre=`; defined after it, the first call
 # expands an unset variable, the command substitution's subshell dies under
-# `set -u`, and `s116_levers` becomes EMPTY — which reds §116 AND §116c with an
-# arithmetic error rather than a parity message (measured during #668's Test
-# phase). Order is load-bearing, not cosmetic.
+# `set -u`, and `s116_levers` becomes EMPTY. Measured, that is WORSE than it
+# sounds: the suite runs `set -uo pipefail` with no `-e`, so the assignment still
+# completes, an empty-but-set variable evaluates as 0 in `$(( ))`, and §116 and
+# §116c both red with an ORDINARY PARITY MESSAGE — `expected=60` and an empty
+# `levers=` field — accompanied only by one `unbound variable` line on stderr. A
+# parity-shaped red is indistinguishable from genuine §1.9 drift except for that
+# stderr line, which is exactly the wrong-cause failure §116 exists to avoid.
+# Order is load-bearing, not cosmetic.
 #
 # DEPTH 2-3, not "depth <= 3". `^# ` is deliberately ABSENT: it matches any
 # shell comment, and SPEC carries 16 such lines inside fenced examples, so
@@ -2655,7 +2655,6 @@ s116_spec="$SHELL_ROOT/SPEC.md"
 # tracking is deliberately NOT attempted here.
 S116_END_RE='^## |^### '
 
-#
 # NEITHER END IS A SECTION NUMBER (#668). The window used to open on the literal
 # `### 1.8 ` and close on the literal `### 1.9 `, so it broke in both directions:
 # a `### 1.8.5` sibling sat INSIDE the window and inflated the count (6 -> 7),
@@ -2668,6 +2667,11 @@ S116_END_RE='^## |^### '
 # window uses, rather than re-spelling it. `#### ` is not a terminator (position
 # 4 is `#`, not a space), so a genuine `#### 1.8.1` sub-section of §1.8 stays in
 # scope and its rows still count — §116g pins that direction.
+# s116_lever_rows <spec-file> → count of §1.8 narrowing-lever table rows in that
+# file. THE SINGLE DERIVATION of the lever count: the live `s116_levers` below
+# AND the §116e-§116g lever-window arms (#668) both call it, so the window rule
+# lives in exactly one place and cannot be repaired in one caller while drifting
+# in the other. Same shape, and for the same reason, as s116_posture_rows below.
 s116_lever_rows() {
   awk -v endre="$S116_END_RE" \
     '/^### .*[Ii]n-session narrowing levers/{i=1;next} i&&$0~endre{exit} i&&/^\| \*\*/{n++} END{print n+0}' "$1"
@@ -2720,13 +2724,13 @@ fi
 # of §1.9 must stay INSIDE.
 #
 # THE LEVER WINDOW (#668): the same shape, one section up and on BOTH ends.
-# `s116_lever_rows`' window opens at the literal `### 1.8 ` and closes at the
-# literal `### 1.9 `, so (a) a `| **`-shaped row in a new `### 1.8.5` sibling is
-# counted as a lever it is not, and (b) renumbering §1.8 collapses the window to
-# 0 and silently drops every real lever from `s116_exp`. Both ends must go: the
-# terminator becomes the shared $S116_END_RE, the start anchor becomes the
-# section's TITLE rather than its number. A genuine `#### 1.8.1` sub-section of
-# §1.8 must stay INSIDE.
+# `s116_lever_rows`' window must open on §1.8's TITLE and close on the shared
+# $S116_END_RE. With the literal ends it carried before #668 — opening at
+# `### 1.8 `, closing at `### 1.9 ` — it broke in both directions: (a) a
+# `| **`-shaped row in a new `### 1.8.5` sibling counted as a lever it is not,
+# and (b) renumbering §1.8 collapsed the window to 0 and silently dropped every
+# real lever from `s116_exp`. A genuine `#### 1.8.1` sub-section of §1.8 must
+# stay INSIDE.
 #
 # Fixtures are COPIES under $TMP (cleaned by the preamble's EXIT trap); no arm
 # writes to the real SPEC.md, and §116d pins that (AC5) — nothing here removes a
@@ -2741,7 +2745,7 @@ fi
 # cannot be a decoy that simply never matched the counting regex.
 #
 # WITNESS HONESTY (#668, the lever window): §116e and §116f are WITNESSES — each
-# reds against `s116_lever_rows` as it stands (measured: 7 and 0 against a
+# red against the PRE-#668 `s116_lever_rows` (measured: 7 and 0 against a
 # baseline of 6). §116g is a BOUND, not a witness: it reads 7 both before and
 # after the repair, so it constrains the repair's shape rather than
 # demonstrating the defect. It is labelled that way at its own arm too.
@@ -2783,8 +2787,8 @@ s116w_excl="$S116W_DIR/excl.md"
 s116w_incl="$S116W_DIR/incl.md"
 s116w_pristine="$S116W_DIR/pristine.md"
 cp "$s116_spec" "$s116w_pristine"
-s116w_fixture '^### 1\.9 ' '### 1.10 Smoke fixture decoy section (#644)'  "$S116W_ROW" "$s116w_excl"
-s116w_fixture '^### 1\.9 ' '#### 1.9.1 Smoke fixture sub-section (#644)'  "$S116W_ROW" "$s116w_incl"
+s116w_fixture '^### 1\\.9 ' '### 1.10 Smoke fixture decoy section (#644)'  "$S116W_ROW" "$s116w_excl"
+s116w_fixture '^### 1\\.9 ' '#### 1.9.1 Smoke fixture sub-section (#644)'  "$S116W_ROW" "$s116w_incl"
 
 # ---- §116e-§116g fixtures (#668), built HERE, up front, alongside the #644
 # ones so that §116d — which runs LAST and pins AC5 — covers these too. Same
@@ -2797,8 +2801,8 @@ S116L_ROW="| **$S116L_MARK** (§0) | decoy lever row planted by smoke §116e/§1
 s116l_excl="$S116W_DIR/lever-excl.md"
 s116l_incl="$S116W_DIR/lever-incl.md"
 s116l_renum="$S116W_DIR/lever-renum.md"
-s116w_fixture '^### 1\.8 ' '### 1.8.5 Smoke fixture decoy section (#668)' "$S116L_ROW" "$s116l_excl"
-s116w_fixture '^### 1\.8 ' '#### 1.8.1 Smoke fixture sub-section (#668)'  "$S116L_ROW" "$s116l_incl"
+s116w_fixture '^### 1\\.8 ' '### 1.8.5 Smoke fixture decoy section (#668)' "$S116L_ROW" "$s116l_excl"
+s116w_fixture '^### 1\\.8 ' '#### 1.8.1 Smoke fixture sub-section (#668)'  "$S116L_ROW" "$s116l_incl"
 # §116f's fixture is a RENAME, not a splice: §1.8's heading keeps its TITLE and
 # loses its NUMBER, which is the only thing the start anchor may legitimately
 # depend on. Derived from the live heading line — no SPEC title is hardcoded

--- a/scripts/test/smoke.d/50-perproject-recall.sh
+++ b/scripts/test/smoke.d/50-perproject-recall.sh
@@ -2627,29 +2627,18 @@ s116_spec="$SHELL_ROOT/SPEC.md"
 # AND the §116e-§116g lever-window arms (#668) both call it, so the window rule
 # lives in exactly one place and cannot be repaired in one caller while drifting
 # in the other. Same shape, and for the same reason, as s116_posture_rows below.
+# THE SINGLE DEFINITION of "what ends a §1.x window" (#644, widened to §1.8 by
+# #668). Used by BOTH live derivations (§1.8's lever count and §1.9's posture
+# count) AND the shared fixture builder, so the guards and the arms that bound
+# them cannot drift apart — which is the whole reason those derivations were
+# extracted into functions in the first place.
 #
-# THIS IS NOT THE FIX (#668, Phase B). The awk body is the PRE-FIX derivation
-# verbatim — both ends of the window are still literal headings — so §116e and
-# §116f red against it exactly as #668 measured. The extraction is
-# behaviour-preserving (`s116_levers` still derives 6); without it the Code
-# phase would repair the inline copy while the new arms went on reading a
-# second one, leaving both witnesses unfixable.
-s116_lever_rows() {
-  awk '/^### 1\.8 /{i=1;next} /^### 1\.9 /{exit} i&&/^\| \*\*/{n++} END{print n+0}' "$1"
-}
-s116_levers=$(s116_lever_rows "$s116_spec")
-s116_agents=$(ls "$SHELL_ROOT"/.claude/agents/*.md 2>/dev/null | wc -l | tr -d ' ')
-s116_cmds=$(grep -cE '^### 5\.[0-9]+ `/' "$s116_spec")
-s116_hooks=$(grep -oE 'should_skip [a-z-]+' "$SHELL_ROOT"/.claude/hooks/pre_tool_use.sh | awk '{print $2}' | sort -u | wc -l | tr -d ' ')
-s116_exp=$((s116_levers + s116_agents + s116_cmds + s116_hooks))
-# s116_posture_rows <spec-file> → count of §1.9 posture rows in that file. The
-# SINGLE derivation of the count: the live parity arm below AND the §116a-§116c
-# window-terminator arms (#644) both call it, so the window rule lives in exactly
-# one place and cannot be fixed in one caller while drifting in the other.
-# THE SINGLE DEFINITION of "what ends §1.9's window" (#644). Used by BOTH the
-# live derivation below AND the §116a/§116b fixture builder, so the guard and the
-# arms that bound it cannot drift apart — which is the whole reason the
-# derivation was extracted into a function in the first place.
+# DEFINED HERE, ABOVE THE FIRST CONSUMER, DELIBERATELY. `s116_lever_rows` runs
+# ~30 lines below and takes this as `-v endre=`; defined after it, the first call
+# expands an unset variable, the command substitution's subshell dies under
+# `set -u`, and `s116_levers` becomes EMPTY — which reds §116 AND §116c with an
+# arithmetic error rather than a parity message (measured during #668's Test
+# phase). Order is load-bearing, not cosmetic.
 #
 # DEPTH 2-3, not "depth <= 3". `^# ` is deliberately ABSENT: it matches any
 # shell comment, and SPEC carries 16 such lines inside fenced examples, so
@@ -2665,6 +2654,33 @@ s116_exp=$((s116_levers + s116_agents + s116_cmds + s116_hooks))
 # failure is loud (§116 reds at classified=0) rather than silent. Fence-state
 # tracking is deliberately NOT attempted here.
 S116_END_RE='^## |^### '
+
+#
+# NEITHER END IS A SECTION NUMBER (#668). The window used to open on the literal
+# `### 1.8 ` and close on the literal `### 1.9 `, so it broke in both directions:
+# a `### 1.8.5` sibling sat INSIDE the window and inflated the count (6 -> 7),
+# while renumbering §1.8 meant the window never opened at all (-> 0). Both feed
+# `s116_exp`, and both therefore red §116 *and* §116c for a cause outside the
+# parity being checked — with §116c's message wrongly blaming the SPEC copy.
+#
+# The start anchors on the section TITLE, which survives renumbering and matches
+# exactly one line; the end reuses $S116_END_RE, the same definition §1.9's
+# window uses, rather than re-spelling it. `#### ` is not a terminator (position
+# 4 is `#`, not a space), so a genuine `#### 1.8.1` sub-section of §1.8 stays in
+# scope and its rows still count — §116g pins that direction.
+s116_lever_rows() {
+  awk -v endre="$S116_END_RE" \
+    '/^### .*[Ii]n-session narrowing levers/{i=1;next} i&&$0~endre{exit} i&&/^\| \*\*/{n++} END{print n+0}' "$1"
+}
+s116_levers=$(s116_lever_rows "$s116_spec")
+s116_agents=$(ls "$SHELL_ROOT"/.claude/agents/*.md 2>/dev/null | wc -l | tr -d ' ')
+s116_cmds=$(grep -cE '^### 5\.[0-9]+ `/' "$s116_spec")
+s116_hooks=$(grep -oE 'should_skip [a-z-]+' "$SHELL_ROOT"/.claude/hooks/pre_tool_use.sh | awk '{print $2}' | sort -u | wc -l | tr -d ' ')
+s116_exp=$((s116_levers + s116_agents + s116_cmds + s116_hooks))
+# s116_posture_rows <spec-file> → count of §1.9 posture rows in that file. The
+# SINGLE derivation of the count: the live parity arm below AND the §116a-§116c
+# window-terminator arms (#644) both call it, so the window rule lives in exactly
+# one place and cannot be fixed in one caller while drifting in the other.
 
 s116_posture_rows() {
   # `#### ` is NOT a terminator — position 3 is `#`, not a space — so a genuine

--- a/scripts/test/smoke.d/50-perproject-recall.sh
+++ b/scripts/test/smoke.d/50-perproject-recall.sh
@@ -2634,8 +2634,9 @@ s116_spec="$SHELL_ROOT/SPEC.md"
 # `set -u`, and `s116_levers` becomes EMPTY. Measured, that is WORSE than it
 # sounds: the suite runs `set -uo pipefail` with no `-e`, so the assignment still
 # completes, an empty-but-set variable evaluates as 0 in `$(( ))`, and §116 and
-# §116c both red with an ORDINARY PARITY MESSAGE — `expected=60` and an empty
-# `levers=` field — accompanied only by one `unbound variable` line on stderr. A
+# §116c both red with an ORDINARY PARITY MESSAGE carrying `expected=60` (§116's
+# also shows an empty `levers=` field), accompanied only by one `unbound
+# variable` line on stderr. A
 # parity-shaped red is indistinguishable from genuine §1.9 drift except for that
 # stderr line, which is exactly the wrong-cause failure §116 exists to avoid.
 # Order is load-bearing, not cosmetic.
@@ -2776,6 +2777,15 @@ S116W_MARK='smoke-fixture-decoy-644'
 # the §1.8 fixtures: they splice at the end of §1.8 as $S116_END_RE finds it,
 # never at the literal `### 1.9 `. The anchor reuses $S116_END_RE rather than
 # re-spelling the heading rule, so it cannot drift from the derivation.
+# ESCAPE SPLIT, because the two engines disagree and the difference is silent
+# (#668 round 2). `awk -v` performs escape processing on the VALUE, so a literal
+# dot must be written `\\.` here — the four `s116w_fixture` calls below do that.
+# `grep` does NOT, so the two `grep` call sites further down (`s116l_h_orig`, and
+# §116f's leftover-heading guard) must keep the single `\.` form. Applying the
+# `awk` form to a `grep` site does not fail loudly: `grep -c '^### 1\\.8 '`
+# returns 0 on ANY file, so §116f's `!= 0` leftover check would never fire and
+# the anti-vacuity guard would SILENTLY STOP GUARDING. Measured both ways during
+# #668's round-2 review, after exactly that over-application was made and caught.
 s116w_fixture() {
   awk -v openre="$1" -v h="$2" -v row="$3" -v endre="$S116_END_RE" '
     !i&&$0~openre   { i=1; print; next }

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2442,10 +2442,25 @@ fi
 
 # §156j — POSITIVE parity assertion: the §1.8 lever row and the §1.9 posture row
 # added for the SSOT change sweep are shaped so §116's OWN derivations count them, and
-# §116's parity therefore still balances. The awk/grep expressions below are §116's
-# verbatim (50-perproject-recall.sh); they are re-derived here under an s156_ prefix
-# rather than reading §116's s116_* variables, because the smoke.sh header reserves
-# cross-section symbols for smoke.d/_preamble.sh. Nothing is hardcoded: expected and
+# §116's parity therefore still balances. The awk/grep expressions below are
+# re-derived here under an s156_ prefix rather than reading §116's s116_* variables,
+# because the smoke.sh header reserves cross-section symbols for smoke.d/_preamble.sh.
+#
+# THEY ARE NO LONGER §116'S VERBATIM, and nothing enforces that they ever were
+# (#670). An earlier revision of this comment claimed byte-identity; measured, the
+# claim is false in BOTH halves — the posture window diverged at #644/#667 (§116
+# moved to a shared terminator while this copy kept `/^## 2\. /`) and the lever
+# window at #668/#669 (§116 moved to a title anchor). Neither divergence reddened
+# anything, because no arm compares the two files: a claim of byte-identity that
+# nothing checks decays silently, which is why #670 is scoped to that claim's
+# ENFORCEABILITY and not only to the windows.
+#
+# The live consequence here is bounded and one-sided: renumbering §1.8 collapses
+# this copy's lever window, so `s156_lever` reads 0 and the `ng` below reports the
+# row as "mis-shaped or absent" when it is present and correctly shaped. A new
+# `### 1.8.5` sibling does NOT break it — but only because the predicate counts one
+# specific row rather than every `| **` row; the window itself admits the sibling
+# exactly as §116's did. Tracked in #670, deliberately not repaired here. Nothing is hardcoded: expected and
 # actual are both machine-derived (both are 65 at this commit — recorded here as a
 # provenance note only, deliberately NOT pinned, since any of the four families may
 # legitimately grow).


### PR DESCRIPTION
Closes #668

## Goal

Stop `§116`'s **lever** window from breaking in both directions. It opened on the literal `### 1.8 ` and closed on the literal `### 1.9 `, so a `### 1.8.5` sibling sat **inside** the window (levers 6 → 7) and renumbering §1.8 meant the window never opened at all (→ 0).

## How this serves the mission

MISSION *"The mechanism"* — the cost-asymmetry rule makes a wrong nudge cheap only when it is ignorable. Both defects feed `s116_exp`, which `§116` **and** `§116c` consume, so either one reds **two** arms for a cause outside the parity being checked — and `§116c`'s message wrongly blames the SPEC copy. A guard that reds for the wrong reason trains the operator to read it as noise.

## Plan

Type is `fix`, so §1.2's reproduce-first relaxation applies — all four directions were measured on `main` before anything was written.

**Docs: n/a — no SSOT contract changes.** The window is a smoke-arm implementation detail with no SPEC clause; the arm's own comments are its documentation. Test-only surface, so `skip-changelog` per §18.7 (`test`-only is explicitly skip-eligible).

The planner gate did not fire: two files at head (round-1's F3 added the second), against a 3+ threshold. **This PR was opened ready rather than draft-first** — with `Docs: n/a` there is no Phase-A commit to seed a draft with; disclosed here rather than left unstated.

## Key context

| fixture | before | after | wanted |
|---|---|---|---|
| SPEC as it stands | 6 | 6 | unchanged |
| a `\| **` row in a new `### 1.8.5` | **7** | **6** | EXCLUDED |
| §1.8 renumbered | **0** | **6** | window still opens |
| a `\| **` row in a genuine `#### 1.8.1` | 7 | 7 | still COUNTED |

The start anchors on the section **title** (matches exactly one line, survives renumbering); the end **reuses `S116_END_RE`**, the same definition §1.9's window uses. `#### ` is not a terminator — position 4 is `#`, not a space.

## Checklist

- [x] **Test** (`fe77a7f`): `§116e` exclusion + `§116f` start-anchor (both witnesses, both red), `§116g` inclusion (a bound). Red before Code.
- [x] **Code** (`820e18b`): title-anchored start, shared terminator, and the hoist below.
- [x] **Review fixes** (`e01e8ae`, `9c11226`): round-1 judged list — F1, F2, F3 (citing #670), F5, I1, I2; round-2 — N1, N3.
- [~] **Doc**: N/A — no SSOT contract change; see Plan.

## Risks

- **The hoist is load-bearing, not cosmetic.** `S116_END_RE` was defined ~30 lines *below* `s116_lever_rows`. Passing it as `-v endre=` from there expands an **unset** variable, the subshell dies under `set -u`, and `s116_levers` becomes **empty** — reddening `§116` *and* `§116c`. **Corrected in round 1:** the symptom is *not* an arithmetic error. `set -uo pipefail` carries no `-e`, so the assignment completes and an empty-but-set variable evaluates as 0 in `$(( ))`; both arms emit an **ordinary parity message** carrying `expected=60` (§116's also shows an empty `levers=` field), with only one `unbound variable` line on stderr. That is **worse** than the original claim — a parity-shaped red is indistinguishable from genuine §1.9 drift — so the constraint stands, more strongly. *(The `820e18b` commit body carries the original, superseded wording; commit bodies are immutable after push, so it is corrected here rather than by rewriting reviewed history.)*
- **One shared definition, still exactly one.** Verified: `S116_END_RE` is defined once and consumed by both live derivations and the fixture builder. Two copies of "what ends a §1.x window" is the drift AC1 exists to prevent.

## Round-1 review fixes (`e01e8ae`)

The judged list is posted above: **6 fix-now, 1 defer, 3 drop.** Two rulings are worth surfacing.

**F1's remedy was ruled *below the floor* as a token substitution.** Swapping "arithmetic error" → "parity message" would have produced *"a parity message rather than a parity message"* — the whole contrast was false, not the two words. See the corrected Risks bullet.

**F3 carried two coupled legs**, and the coupling was deliberate: the "verbatim" claim could not be corrected until the Issue it cites existed. **#670 was filed and numbered first.** The claim is false in *both* halves — the posture window had already diverged at #644/#667 — and nothing enforces it: that file makes zero references to §116's helpers, so no arm compares them and the claim decayed silently across two unrelated PRs. Only comment lines changed there; the awk expressions, the assertion and the `ng` text are byte-identical, and the true "Nothing is hardcoded" sentence is preserved.

**One over-application, caught and reverted.** F5's ceiling was the four `awk -v` sites; I initially rewrote six, including two adjacent `grep` calls. `grep` does **not** strip backslashes the way `awk -v` does, so there the change would have made the pattern match nothing. Caught by checking the count against the stated ceiling, and reverted.

**Deferred / dropped, not acted on:** F4 (a collapsed baseline emits a wrong-cause `ng` — confirmed *inherited* from #644, so fixing it here means touching six arms or diverging three); `s116l_base`'s recompute (it is the **arms' denominator**, deliberately distinct from the live parity input — collapsing them would couple the bounding arms to the derivation they bound); the pre-existing "position 3" explanation on an untouched line; and the missing `Docs: n/a` line in the pushed commit bodies, whose remedy is unexecutable.

## Round-2 review (`9c11226`)

`code-reviewer` returned **`ship`** — no blocker-stop — and raised four advisories. The judge ruled **2 fix-now, 1 defer, 1 drop**, and sharpened two of them.

**N1 — my over-application last round was worse than "matches nothing".** The two `grep` sites are not symmetric: at `s116l_h_orig` an empty result is caught loud, but §116f's leftover-heading guard fires on `!= 0`, and `grep -c` with the `awk` form returns **0 even on a file that has the heading** — so the leg would never fire and the **anti-vacuity guard would silently stop guarding**. The escape split is now stated at the builder, **addition only**: no existing line was edited, which is what separates this from every defect this PR has produced (the extraction, the stale recast and the over-application all came from *changing* existing content).

**N3 — a false detail in the block round 1 already corrected.** The `levers=` field exists in §116's `ng`, not §116c's. Applied as a **scoping deletion** rather than a recast, because removing a false clause cannot introduce a new one. This is the **third consecutive round** to find a defect in that one comment block; it is now the presumed generator, and the next finding in it faces a strong presumption of `drop`.

**Dropped, with the finding's framing corrected**: the `~30 lines below` clause. The reviewer implied this round degraded it to 23; measured, it was **19** when written and I1's move carried it *toward* `~30` — it is the most accurate it has ever been. **Deferred off the critical path**: the `Docs: n/a` norm, omitted in 3/3 commits here, whose remedy is unexecutable on pushed bodies but whose enforcement gap is real.

## Test plan

`§116e` and `§116f` are the **witnesses** — red at `1285/2` before the fix, green after. `§116g` passes **both** before and after and is labelled in-file as a **bound**, not a witness: `#### ` is depth 4 and the shared terminator stops at depth 3, so the change never touches it. It carries one load-bearing job for `§116e` — it proves the identical decoy row **does** match the counting regex, so a green `§116e` cannot be a decoy that never matched at all.

The fixture builder was **generalized, not duplicated** — it now takes an open-regex, so §1.8's and §1.9's fixtures share one builder. Both §1.8 fixtures splice at the first window-closing line *after* §1.8 opens, never at a document-global literal: that is #667's round-1 lesson applied one section up, where a fixture anchored at `## 2. ` would have reddened for a cause outside its subject the moment a sibling section landed. `§116f` is a rename rather than a splice and derives the renamed heading from the live line, so no SPEC title is hardcoded in the smoke file.

**Measured, in a window with no live agent worktree:** `pass=1285 fail=2` → **`pass=1287 fail=0`**; `lint OK: 79 files clean`; real `SPEC.md` unmodified after a full run (AC5, pinned by the existing `§116d`, whose claim now honestly reads `§116a-§116g`).
