### PR TITLE
fix(#643): bound the §1.3.1 content-lock window on both sides

### DIFF
--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2338,8 +2338,9 @@ elif [ "$s156_n" -lt 18 ] || [ "$s156_n" -gt 60 ]; then
   # mode rather than removing it (#643). ONE unbalanced ``` inside §1.3.1 does not
   # make the toggle stick — it INVERTS THE PARITY from that point on, so headings
   # sitting in real prose are ignored while `#`-prefixed lines inside genuine
-  # fenced blocks are honoured as terminators. Measured: the window then spans
-  # SPEC 269-739 and exits at 740 on a shell comment inside a ```bash fence — 368
+  # fenced blocks are honoured as terminators. Measured on the over-extension
+  # fixture (SPEC.md plus one injected marker, 2895 lines): the window spans
+  # 269-739 and exits at 740 on a shell comment inside a ```bash fence — 368
   # non-blank lines against a healthy 22, stable across six injection offsets.
   # Before fence-awareness an unbalanced
   # fence TRUNCATED and the floor caught it loud; after it, the window
@@ -2356,8 +2357,9 @@ elif [ "$s156_n" -lt 18 ] || [ "$s156_n" -gt 60 ]; then
   # renamed heading; ceiling=60 leaves §1.3.1 room to nearly triple while sitting
   # six-fold below the ~368 a desync produces today. The bounds are NAMED in both
   # messages so a failure says which side tripped, and §156o/§156p parse those two
-  # spellings — renaming them fails CLOSED (measured: both arms red, because the
-  # arms' accept-check rejects an empty bound), so it is not a silent hazard.
+  # spellings — renaming them fails CLOSED (measured: both arms red), so it is not
+  # a silent hazard. The mechanism is stated once, at §156o's accept-check below;
+  # it is deliberately not restated here.
   ng "156a: SPEC §1.3.1 window out of bounds (non-blank lines=$s156_n, floor=18, ceiling=60) — below the floor the content locks would pass VACUOUSLY; above the ceiling the window has over-extended past §1.3.1 and the locks would be asserted over unrelated sections (#640, #643)"
 else
   ok "156a: SPEC §1.3.1 window resolves within bounds (non-blank lines=$s156_n, floor=18, ceiling=60) — content locks below are load-bearing (#640, #643)"
@@ -2470,21 +2472,23 @@ fi
 # ---------- §156o–§156r: the §1.3.1 window is bounded on BOTH sides (#643) ----------
 # The count-guard above is a FLOOR only. The fence-awareness that closed the
 # truncation gap (#641) opened the opposite one: with an ODD number of ``` markers
-# inside §1.3.1 INVERTS the `f` parity from that point on, so headings in real prose
-# stop terminating the window and it runs on — measured, to line 740 of 2895,
+# inside §1.3.1 the extra marker INVERTS the `f` parity from that point on, so headings in real prose
+# stop terminating the window and it runs on — measured, to line 740 of the 2895-line
+# over-extension fixture (SPEC.md is 2894),
 # swallowing §1.4 through §3.2. A floor cannot see that; the
 # guard then reports the eleven content locks "load-bearing" over a window whose
 # scope it has not checked, which is anti-pattern #2 in the smoke.sh header wearing
 # the opposite sign.
 #
 # WITNESS HONESTY — only ONE of the four arms below is a witness:
-#   §156p (over-extension) is the WITNESS. It is RED at this commit and greens only
+#   §156p (over-extension) is the WITNESS. It is RED at e8aa0db (the Test commit,
+#   guard floor-only) and greens only
 #          when a ceiling exists.
 #   §156o (both bounds named), §156q (truncation), §156r (healthy) are BOUNDS, not
 #          witnesses. §156q and §156r pass BEFORE and AFTER the fix by construction —
 #          they exist to prove the ceiling does not blind the floor (§156q) and that
 #          the pair is not simply always-failing (§156r). Neither is evidence that the
-#          defect was repaired; only §156p is. (§156o is red today for the same reason
+#          defect was repaired; only §156p is. (§156o is red at e8aa0db for the same reason
 #          §156p is, but it reads the guard's TEXT, not its behaviour.)
 #
 # NO LIVE SPEC MUTATION. All three fixtures are copies under the preamble's $TMP,
@@ -2562,7 +2566,7 @@ else
 fi
 
 # §156p — AC2, THE WITNESS. One unclosed fence inside §1.3.1 must make the guard fail
-# LOUD. RED at this commit: the floor admits the over-extended window.
+# LOUD. RED at e8aa0db: the floor admits the over-extended window.
 if [ "$s156o_hn" -lt 0 ] || [ "$s156o_on" -lt 0 ]; then
   ng "156p: over-extension fixture not built (healthy n=$s156o_hn over n=$s156o_on) — the ceiling is UNTESTED, not satisfied (#643)"
 elif [ "$s156o_ofence" -ne $((s156o_hfence + 1)) ]; then

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2440,6 +2440,136 @@ else
   fi
 fi
 
+# ---------- §156o–§156r: the §1.3.1 window is bounded on BOTH sides (#643) ----------
+# The count-guard above is a FLOOR only. The fence-awareness that closed the
+# truncation gap (#641) opened the opposite one: with an ODD number of ``` markers
+# inside §1.3.1 the `f` toggle sticks at 1, the heading terminator never fires, and
+# the window runs to EOF — swallowing §1.4 through §3. A floor cannot see that; the
+# guard then reports the eleven content locks "load-bearing" over a window whose
+# scope it has not checked, which is anti-pattern #2 in the smoke.sh header wearing
+# the opposite sign.
+#
+# WITNESS HONESTY — only ONE of the four arms below is a witness:
+#   §156p (over-extension) is the WITNESS. It is RED at this commit and greens only
+#          when a ceiling exists.
+#   §156o (both bounds named), §156q (truncation), §156r (healthy) are BOUNDS, not
+#          witnesses. §156q and §156r pass BEFORE and AFTER the fix by construction —
+#          they exist to prove the ceiling does not blind the floor (§156q) and that
+#          the pair is not simply always-failing (§156r). Neither is evidence that the
+#          defect was repaired; only §156p is. (§156o is red today for the same reason
+#          §156p is, but it reads the guard's TEXT, not its behaviour.)
+#
+# NO LIVE SPEC MUTATION. All three fixtures are copies under the preamble's $TMP,
+# removed by its EXIT trap; $S156_SPEC is only ever read.
+#
+# The arms drive the LIVE guard, not a paraphrase of it: the extractor is lifted
+# verbatim out of the guard's own source line, and the bounds are read out of the
+# `156a:` assertion messages — i.e. the bounds the guard TELLS a failing reader about.
+# A bound the guard does not declare cannot bind anything, so an undeclared ceiling
+# reads here exactly as it behaves there: absent.
+S156O_SRC="$SHELL_ROOT/scripts/test/smoke.d/70-gates-contentlocks.sh"
+s156o_msgs=""
+s156o_floor=""
+s156o_ceil=""
+s156o_prog=""
+if [ -f "$S156O_SRC" ]; then
+  s156o_msgs=$(grep -E '^[[:space:]]*(ok|ng) "156a:' "$S156O_SRC")
+  s156o_floor=$(printf '%s\n' "$s156o_msgs" | grep -oE 'floor=[0-9]+' | head -1 | cut -d= -f2)
+  s156o_ceil=$(printf '%s\n' "$s156o_msgs" | grep -oE 'ceiling=[0-9]+' | head -1 | cut -d= -f2)
+  # Line-anchored so this arm's own quoted copy of the pattern cannot match first.
+  s156o_line=$(grep -m1 -E '^[[:space:]]*s156_win=\$\(awk ' "$S156O_SRC")
+  case "$s156o_line" in
+    *"awk '"*) s156o_prog=${s156o_line#*awk \'}; s156o_prog=${s156o_prog%\'*} ;;
+  esac
+fi
+
+# s156o_accepts <non-blank-line-count> — 0 when the guard's DECLARED bounds admit a
+# window of that size. Mirrors §156a's decision; an undeclared bound is inert.
+s156o_accepts() {
+  local n="$1"
+  [ -n "$s156o_floor" ] && [ "$n" -lt "$s156o_floor" ] && return 1
+  [ -n "$s156o_ceil" ] && [ "$n" -gt "$s156o_ceil" ] && return 1
+  return 0
+}
+
+# Fixtures. -1 means NOT MEASURED, so no arm can read a zero as agreement.
+S156O_DIR="$TMP/s156o"
+s156o_hn=-1; s156o_on=-1; s156o_tn=-1
+s156o_hfence=-1; s156o_ofence=-1
+if [ -f "$S156_SPEC" ] && [ -n "$s156o_prog" ] && mkdir -p "$S156O_DIR" 2>/dev/null; then
+  if cp "$S156_SPEC" "$S156O_DIR/healthy.md" 2>/dev/null && [ -s "$S156O_DIR/healthy.md" ]; then
+    # (b) over-extension: ONE unclosed fence opened immediately after the §1.3.1
+    # heading — the minimum mutation that desyncs the toggle. (c) truncation: the
+    # heading renamed, so the window never opens.
+    awk '{print} /^#### 1\.3\.1 /{print "```"}' "$S156O_DIR/healthy.md" > "$S156O_DIR/overextended.md" 2>/dev/null
+    awk '/^#### 1\.3\.1 /{sub(/^#### 1\.3\.1 /, "#### 1.3.1-renamed ")} {print}' \
+      "$S156O_DIR/healthy.md" > "$S156O_DIR/renamed.md" 2>/dev/null
+    s156o_hfence=$(grep -c '^```' "$S156O_DIR/healthy.md")
+    [ -s "$S156O_DIR/overextended.md" ] && s156o_ofence=$(grep -c '^```' "$S156O_DIR/overextended.md")
+    s156o_hn=$(awk "$s156o_prog" "$S156O_DIR/healthy.md" | grep -c .)
+    [ -s "$S156O_DIR/overextended.md" ] && s156o_on=$(awk "$s156o_prog" "$S156O_DIR/overextended.md" | grep -c .)
+    # The renamed fixture is validated by its MARKER, not by its count: a count of 0
+    # is the very thing §156q asserts, so reading 0 as proof the fixture built would
+    # be circular. Only if the rename actually landed is the count trusted.
+    if [ -s "$S156O_DIR/renamed.md" ] && grep -q '^#### 1\.3\.1-renamed ' "$S156O_DIR/renamed.md" \
+       && ! grep -q '^#### 1\.3\.1 ' "$S156O_DIR/renamed.md"; then
+      s156o_tn=$(awk "$s156o_prog" "$S156O_DIR/renamed.md" | grep -c .)
+    fi
+  fi
+fi
+
+# §156o — AC1: the guard names BOTH bounds in its own assertion message, so a failure
+# says WHICH SIDE tripped. Reads the guard's text; §156p reads its behaviour.
+if [ -z "$s156o_msgs" ]; then
+  ng "156o: cannot read this suite's own 156a assertion messages — the window-bound arms below would be vacuous (#643)"
+elif [ -n "$s156o_floor" ] && [ -n "$s156o_ceil" ]; then
+  ok "156o: the §1.3.1 window guard names both bounds in its assertion message (floor=$s156o_floor ceiling=$s156o_ceil) — a failure names which side tripped (#643)"
+else
+  ng "156o: the §1.3.1 window guard declares only one bound (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) — a failure cannot name which side tripped (#643)"
+fi
+
+# §156p — AC2, THE WITNESS. One unclosed fence inside §1.3.1 must make the guard fail
+# LOUD. RED at this commit: the floor admits the over-extended window.
+if [ "$s156o_hn" -lt 0 ] || [ "$s156o_on" -lt 0 ]; then
+  ng "156p: over-extension fixture not built (healthy n=$s156o_hn over n=$s156o_on) — the ceiling is UNTESTED, not satisfied (#643)"
+elif [ "$s156o_ofence" -ne $((s156o_hfence + 1)) ]; then
+  ng "156p: over-extension fixture did not take (fence markers healthy=$s156o_hfence over=$s156o_ofence, expected +1) — arm would be vacuous (#643)"
+elif [ "$s156o_on" -le "$s156o_hn" ]; then
+  ng "156p: over-extension fixture did not over-extend (over n=$s156o_on vs healthy n=$s156o_hn) — arm would be vacuous (#643)"
+elif s156o_accepts "$s156o_on"; then
+  ng "156p: an unclosed fence in §1.3.1 runs the window to $s156o_on non-blank lines (healthy=$s156o_hn) and the declared bounds ACCEPT it (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) — the content locks would be called load-bearing over §1.4–§3 (#643)"
+else
+  ok "156p: an unclosed fence in §1.3.1 over-extends the window to $s156o_on non-blank lines and the declared bounds REJECT it (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) (#643)"
+fi
+
+# §156q — AC3, a BOUND (not a witness; passes before and after). The ceiling must not
+# blind the floor: a renamed heading still collapses the window and still fails loud.
+if [ "$s156o_tn" -lt 0 ]; then
+  ng "156q: renamed-heading fixture not built or rename did not land — the floor is UNTESTED, not satisfied (#643)"
+elif [ "$s156o_tn" -ne 0 ]; then
+  ng "156q: renamed-heading fixture left a non-empty window (n=$s156o_tn, expected 0) — arm would be vacuous (#643)"
+elif s156o_accepts "$s156o_tn"; then
+  ng "156q: a renamed §1.3.1 heading collapses the window to 0 non-blank lines and the declared bounds ACCEPT it (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) (#643)"
+else
+  ok "156q: a renamed §1.3.1 heading collapses the window to 0 non-blank lines and the declared bounds REJECT it — the ceiling does not blind the floor (#643)"
+fi
+
+# §156r — AC4, a BOUND (not a witness; passes before and after). The two rejections
+# above are not an always-fail: the unmodified SPEC still passes. The count equality
+# is also the anti-drift check — a fixture path that no longer reproduces the live
+# window fails loud instead of quietly measuring something else.
+if [ ! -f "$S156_SPEC" ]; then
+  ng "156r: SPEC.md absent — the healthy-window bound is UNTESTED, not satisfied (#643)"
+elif [ "$s156o_hn" -lt 0 ]; then
+  ng "156r: healthy fixture not built or the guard's extractor could not be lifted from its source — bound UNTESTED (#643)"
+elif [ "$s156o_hn" -ne "$s156_n" ]; then
+  ng "156r: healthy fixture window ($s156o_hn) disagrees with the live §156a window ($s156_n) — the fixture path no longer reproduces the guard (#643)"
+elif s156o_accepts "$s156o_hn"; then
+  ok "156r: the unmodified SPEC §1.3.1 window ($s156o_hn non-blank lines) is ACCEPTED by both declared bounds (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) (#643)"
+else
+  ng "156r: the unmodified SPEC §1.3.1 window ($s156o_hn non-blank lines) is REJECTED by the declared bounds (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) — the bounds are always-failing (#643)"
+fi
+
 # §156j — POSITIVE parity assertion: the §1.8 lever row and the §1.9 posture row
 # added for the SSOT change sweep are shaped so §116's OWN derivations count them, and
 # §116's parity therefore still balances. The awk/grep expressions below are

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2333,12 +2333,28 @@ s156_fx() { printf '%s\n' "$s156_win" | grep -qF "$1"; }
 
 if [ ! -f "$S156_SPEC" ]; then
   ng "156: SPEC.md absent — cannot assert the §1.3.1 SSOT change sweep protocol (#640)"
-elif [ "$s156_n" -lt 18 ]; then
-  # 21 non-blank lines at this commit; a floor of 18 catches a collapsed/renamed
-  # heading or a gutted section while tolerating ordinary prose tightening.
-  ng "156a: SPEC §1.3.1 window empty or collapsed (non-blank lines=$s156_n, floor=18) — the content locks below would pass VACUOUSLY (#640)"
+elif [ "$s156_n" -lt 18 ] || [ "$s156_n" -gt 60 ]; then
+  # TWO-SIDED, because the extractor is fence-aware and that INVERTED the failure
+  # mode rather than removing it (#643). The window closes on a heading only while
+  # the fence toggle `f` is 0, so ONE unbalanced ``` inside §1.3.1 desyncs the
+  # toggle, no heading ever terminates it, and it runs to EOF — measured, 368
+  # non-blank lines against a healthy 22. Before fence-awareness an unbalanced
+  # fence TRUNCATED and the floor caught it loud; after it, the window
+  # over-extends and a floor alone reports the locks "load-bearing" over §1.4–§3.
+  #
+  # 22 non-blank lines at this commit — RE-MEASURED, not carried forward: this
+  # comment previously read 21, which was correct at f5af42c and went stale when
+  # that same commit added a prose line (#643 AC5). The count is deliberately NOT
+  # pinned by an arm, per §156j's neighbouring note.
+  #
+  # floor=18 tolerates ordinary prose tightening and catches a collapsed or
+  # renamed heading; ceiling=60 leaves §1.3.1 room to nearly triple while sitting
+  # six-fold below the ~368 a desync produces. The bounds are NAMED in both
+  # messages so a failure says which side tripped — and §156o/§156p parse those
+  # two spellings, so renaming them silently unbinds the arms that check them.
+  ng "156a: SPEC §1.3.1 window out of bounds (non-blank lines=$s156_n, floor=18, ceiling=60) — below the floor the content locks would pass VACUOUSLY; above the ceiling the window has over-extended past §1.3.1 and the locks would be asserted over unrelated sections (#640, #643)"
 else
-  ok "156a: SPEC §1.3.1 window resolves non-empty (non-blank lines=$s156_n) — content locks below are load-bearing (#640)"
+  ok "156a: SPEC §1.3.1 window resolves within bounds (non-blank lines=$s156_n, floor=18, ceiling=60) — content locks below are load-bearing (#640, #643)"
 
   # §156b: the two commit-trailer KEYS, anchored to the code form (line-start inside the
   # fenced grammar block), not a backticked prose mention — the later Execution Issues
@@ -2424,7 +2440,12 @@ else
   # §156m: the MONOTONICITY DIRECTION — widen-yes / narrow-never — plus the re-anchor
   # carve-out the parent Directive states. §156d locks the `inconclusive` machinery;
   # this locks the rule that machinery guards.
-  if s156_re 'widened' && s156_re 'never be narrowed' && s156_re 're-anchor'; then
+  # PHRASES, not bare words (#643 AC6). `widened` and `re-anchor` were each
+  # individually satisfiable by unrelated prose anywhere in the window; only the
+  # conjunction carried the lock. Pinned to the forms §1.3.1 actually uses, so
+  # each conjunct now bites on its own.
+  if s156_re 'may be \*\*widened\*\*' && s156_re 'never be narrowed' \
+     && s156_re '\*\*re-anchor\*\* accompanying a heading rename'; then
     ok "156m: §1.3.1 keeps widen-yes / narrow-never with the re-anchor carve-out (#640)"
   else
     ng "156m: §1.3.1 lost the monotonicity direction or the re-anchor carve-out (#640)"

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2342,9 +2342,8 @@ elif [ "$s156_n" -lt 18 ] || [ "$s156_n" -gt 60 ]; then
   # fixture (SPEC.md plus one injected marker, 2895 lines): the window spans
   # 269-739 and exits at 740 on a shell comment inside a ```bash fence — 368
   # non-blank lines against a healthy 22, stable across six injection offsets.
-  # Before fence-awareness an unbalanced
-  # fence TRUNCATED and the floor caught it loud; after it, the window
-  # over-extends and a floor alone reports the locks "load-bearing" over §1.4–§3.
+  # When the window over-extends like that, a floor alone reports the locks
+  # "load-bearing" over §1.4–§3.
   #
   # 22 non-blank lines at this commit — RE-MEASURED, not carried forward from the
   # stale 21 this comment used to carry (#643 AC5). No history is reconstructed
@@ -2358,8 +2357,7 @@ elif [ "$s156_n" -lt 18 ] || [ "$s156_n" -gt 60 ]; then
   # six-fold below the ~368 a desync produces today. The bounds are NAMED in both
   # messages so a failure says which side tripped, and §156o/§156p parse those two
   # spellings — renaming them fails CLOSED (measured: both arms red), so it is not
-  # a silent hazard. The mechanism is stated once, at §156o's accept-check below;
-  # it is deliberately not restated here.
+  # a silent hazard.
   ng "156a: SPEC §1.3.1 window out of bounds (non-blank lines=$s156_n, floor=18, ceiling=60) — below the floor the content locks would pass VACUOUSLY; above the ceiling the window has over-extended past §1.3.1 and the locks would be asserted over unrelated sections (#640, #643)"
 else
   ok "156a: SPEC §1.3.1 window resolves within bounds (non-blank lines=$s156_n, floor=18, ceiling=60) — content locks below are load-bearing (#640, #643)"
@@ -2470,7 +2468,7 @@ else
 fi
 
 # ---------- §156o–§156r: the §1.3.1 window is bounded on BOTH sides (#643) ----------
-# The count-guard above is a FLOOR only. The fence-awareness that closed the
+# The count-guard above was a FLOOR only at e8aa0db. The fence-awareness that closed the
 # truncation gap (#641) opened the opposite one: with an ODD number of ``` markers
 # inside §1.3.1 the extra marker INVERTS the `f` parity from that point on, so headings in real prose
 # stop terminating the window and it runs on — measured, to line 740 of the 2895-line

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2335,23 +2335,29 @@ if [ ! -f "$S156_SPEC" ]; then
   ng "156: SPEC.md absent — cannot assert the §1.3.1 SSOT change sweep protocol (#640)"
 elif [ "$s156_n" -lt 18 ] || [ "$s156_n" -gt 60 ]; then
   # TWO-SIDED, because the extractor is fence-aware and that INVERTED the failure
-  # mode rather than removing it (#643). The window closes on a heading only while
-  # the fence toggle `f` is 0, so ONE unbalanced ``` inside §1.3.1 desyncs the
-  # toggle, no heading ever terminates it, and it runs to EOF — measured, 368
-  # non-blank lines against a healthy 22. Before fence-awareness an unbalanced
+  # mode rather than removing it (#643). ONE unbalanced ``` inside §1.3.1 does not
+  # make the toggle stick — it INVERTS THE PARITY from that point on, so headings
+  # sitting in real prose are ignored while `#`-prefixed lines inside genuine
+  # fenced blocks are honoured as terminators. Measured: the window then spans
+  # SPEC 269-739 and exits at 740 on a shell comment inside a ```bash fence — 368
+  # non-blank lines against a healthy 22, stable across six injection offsets.
+  # Before fence-awareness an unbalanced
   # fence TRUNCATED and the floor caught it loud; after it, the window
   # over-extends and a floor alone reports the locks "load-bearing" over §1.4–§3.
   #
-  # 22 non-blank lines at this commit — RE-MEASURED, not carried forward: this
-  # comment previously read 21, which was correct at f5af42c and went stale when
-  # that same commit added a prose line (#643 AC5). The count is deliberately NOT
-  # pinned by an arm, per §156j's neighbouring note.
+  # 22 non-blank lines at this commit — RE-MEASURED, not carried forward from the
+  # stale 21 this comment used to carry (#643 AC5). No history is reconstructed
+  # here on purpose: the count is deliberately NOT pinned by an arm (per §156j's
+  # neighbouring note), so nothing can ever catch a narrative about it drifting,
+  # and this line has already carried two successive wrong provenance stories.
+  # Re-measure it; do not re-tell it.
   #
   # floor=18 tolerates ordinary prose tightening and catches a collapsed or
   # renamed heading; ceiling=60 leaves §1.3.1 room to nearly triple while sitting
-  # six-fold below the ~368 a desync produces. The bounds are NAMED in both
-  # messages so a failure says which side tripped — and §156o/§156p parse those
-  # two spellings, so renaming them silently unbinds the arms that check them.
+  # six-fold below the ~368 a desync produces today. The bounds are NAMED in both
+  # messages so a failure says which side tripped, and §156o/§156p parse those two
+  # spellings — renaming them fails CLOSED (measured: both arms red, because the
+  # arms' accept-check rejects an empty bound), so it is not a silent hazard.
   ng "156a: SPEC §1.3.1 window out of bounds (non-blank lines=$s156_n, floor=18, ceiling=60) — below the floor the content locks would pass VACUOUSLY; above the ceiling the window has over-extended past §1.3.1 and the locks would be asserted over unrelated sections (#640, #643)"
 else
   ok "156a: SPEC §1.3.1 window resolves within bounds (non-blank lines=$s156_n, floor=18, ceiling=60) — content locks below are load-bearing (#640, #643)"
@@ -2464,8 +2470,9 @@ fi
 # ---------- §156o–§156r: the §1.3.1 window is bounded on BOTH sides (#643) ----------
 # The count-guard above is a FLOOR only. The fence-awareness that closed the
 # truncation gap (#641) opened the opposite one: with an ODD number of ``` markers
-# inside §1.3.1 the `f` toggle sticks at 1, the heading terminator never fires, and
-# the window runs to EOF — swallowing §1.4 through §3. A floor cannot see that; the
+# inside §1.3.1 INVERTS the `f` parity from that point on, so headings in real prose
+# stop terminating the window and it runs on — measured, to line 740 of 2895,
+# swallowing §1.4 through §3.2. A floor cannot see that; the
 # guard then reports the eleven content locks "load-bearing" over a window whose
 # scope it has not checked, which is anti-pattern #2 in the smoke.sh header wearing
 # the opposite sign.
@@ -2483,9 +2490,14 @@ fi
 # NO LIVE SPEC MUTATION. All three fixtures are copies under the preamble's $TMP,
 # removed by its EXIT trap; $S156_SPEC is only ever read.
 #
-# The arms drive the LIVE guard, not a paraphrase of it: the extractor is lifted
+# The arms drive the live guard's EXTRACTOR verbatim, but its DECISION is
+# re-implemented here from the two integers scraped out of the assertion messages
+# — so an executed condition that diverges from the declared bounds is NOT caught
+# by these arms (#643 round-1 F4b, deferred). The extractor is lifted
 # verbatim out of the guard's own source line, and the bounds are read out of the
 # `156a:` assertion messages — i.e. the bounds the guard TELLS a failing reader about.
+# This covers the OMISSION direction only — a divergence, where the guard declares
+# a bound it does not execute, is the deferred F4b vector.
 # A bound the guard does not declare cannot bind anything, so an undeclared ceiling
 # reads here exactly as it behaves there: absent.
 S156O_SRC="$SHELL_ROOT/scripts/test/smoke.d/70-gates-contentlocks.sh"


### PR DESCRIPTION
Closes #643

## Goal

`§156a` guarded the SPEC §1.3.1 content-lock window with a **floor and no ceiling**, so over-extension was silent. The fence-awareness that *made* a ceiling necessary was added without one.

## How this serves the mission

MISSION *"The mechanism"* — the audit-and-gate machinery is the shell's enforcement face. A guard that reports eleven content locks "load-bearing" over a window containing three unrelated SPEC sections is asserting something it has not checked. `§156a` exists specifically to convert the vacuous-lock anti-pattern into a loud failure; a one-sided bound converts only half of it.

## Plan

Type is `fix`, so §1.2's reproduce-first relaxation applies — both directions were measured on `main` before anything was written.

**Docs: n/a — no SSOT contract change.** The window guard is a smoke-arm implementation detail with no SPEC clause; the arm's own comments are its documentation. Test-only surface, so `skip-changelog` per §18.7.

The planner gate did not fire: single file, well under the 3+ threshold.

**Deviation, disclosed:** this PR was opened **ready, not draft-first**. Both phase commits were complete before it was created, so the backbone's `draft PR → checklist commits → ready PR` cadence was skipped. Named here because the Plan discloses two other deviations and silently omitting a third makes the list read as complete when it is not.

## Key context

One unbalanced fence does not make the toggle *stick* — it **inverts the parity** from that point on, so headings sitting in real prose stop terminating the window while `#`-lines inside genuine fences start doing so:

| fixture | non-blank lines | floor-only verdict |
|---|---|---|
| healthy SPEC | 22 | passes |
| **one unclosed fence** in §1.3.1 | **368** | **passes — silent over-extension** |
| §1.3.1 heading renamed | 0 | fails loud |

Measured on the over-extension fixture (SPEC.md plus one injected marker, 2895 lines; SPEC.md itself is 2894), the window spans 269–739 and exits at **740** on a shell comment inside a ` ```bash ` fence — stable at 368 across six injection offsets. Nothing bounds that over-extension from above.

## Checklist

- [x] **Test** (`e8aa0db`): `§156o` (bounds named) + `§156p` (over-extension) as witnesses; `§156q` (truncation) and `§156r` (healthy) as bounds. Red before Code.
- [x] **Code** (`3a6297a`): two-sided bounds, the re-measured provenance count, and `§156m`'s two weak patterns pinned.
- [x] **Review fixes** (`1ada0a0`, `f52ded4`, `fb12283`): round-1, round-2 and round-3 judged lists.
- [~] **Doc**: N/A — no SSOT contract change; see Plan.

## Out of scope

Making the extractor handle nested or four-backtick fences by tracking fence length — per #643's own Out of scope, the ceiling covers those by **bounding the consequence rather than parsing the cause**, and parsing markdown fences correctly in awk is a larger job than this guard warrants.

## Risks

- **A numeric ceiling is a drift-prone bound**, and this very PR fixes a stale count of the same kind (AC5). Mitigated by margin rather than precision: `ceiling=60` leaves §1.3.1 room to **nearly triple** from 22 while sitting **six-fold below** the ~368 a desync produces. It is a consequence bound, not a size assertion, and the comment says so.
- **The bound spellings are load-bearing, but they fail *closed*.** `§156o`/`§156p` parse `floor=<n>` and `ceiling=<n>` out of `§156a`'s assertion text. *(Corrected across two rounds: round 1 called a rename a **silent** unbind; round 2's replacement explained it with a mechanism that was also backwards. Measured outcome: both arms red **loud**.)* The real, undisclosed vector was different — see below.

## Review rounds (`1ada0a0`, `f52ded4`, `fb12283`)

`code-reviewer` returned **`ship after fix`** with four must-fix findings — **all four were false claims in my own comments**, in a PR whose `Docs: n/a` explicitly elevates those comments to documentation. The judged list is posted above: **5 fix-now, 2 defer, 2 drop, 1 refuted.**

Three rulings are worth surfacing.

**F2's remedy was a scoping deletion, and the judge refused a replacement narrative it had itself verified as accurate.** I wrote that the count "read 21, which was correct at `f5af42c`". Measured, `f5af42c` carried **18**; `21` came from `4c23a93`, where the count was **already 22** — stale on arrival. AC5 requires only that the **count** be re-measured; the narrative carries **zero** enforcement value, because §156j doctrine leaves provenance counts unpinned so nothing can ever catch a story about it drifting. This line has now carried two successive wrong provenance stories, so the comment says *re-measure it, do not re-tell it*.

**One finding was REFUTED, and acting on it would have introduced a fourth false claim — through the review channel itself.** The reviewer said the MISSION citation was wrong because "The mechanism" is only about context narrowing. That section spans lines **10–22**, and **line 18** is an entire paragraph on enforcement. The reviewer read 10–16 and stopped immediately before it.

**One reviewer figure was not copied forward.** Its F1 text says "84% of the file is never reached"; measured, **74.5%**. Copying it would have made the repair of a false claim introduce the next one.

**The two pushed commit bodies are unamendable** and still carry the superseded "runs to EOF" mechanism and the wrong provenance history. Corrected forward here rather than by rewriting reviewed history.

## Round 2 (`f52ded4`) — the generator, measured

Round 2 returned `ship after fix` again, and **my round-1 repair had introduced a new false claim**: I wrote that a rename fails closed *"because the accept-check rejects an empty bound"*. The outcome is true; the mechanism is backwards — `s156o_accepts` short-circuits on an empty ceiling and falls through to `return 0`, so it **accepts**. The correct mechanism was already stated correctly **twice** in the same file, 140 lines below.

**The judge resolved the generator into something measurable.** Of the five edit clusters in `1ada0a0`, the **four that deleted or scoped** a claim are verified **true**; the **one that added an explanatory `because`** is verified **false** — 4-for-4 versus 0-for-1. The discriminator carried forward: *keep a claim only if it is verifiable against a cheap, stable oracle.* A fixed-commit fact is one `git show` away and can never go stale — keep it. A mechanism explanation needs a mutated-fixture run and has been wrong twice — delete it. The file already said *"Re-measure it; do not re-tell it"* **four lines above** the clause that violated it.

A second generator was also named: **corrections not reaching every surface** — round 2 reproduced it twice. The adopted counter is an **enumerated surface sweep**, and it worked: it found a **third** stale tense claim the review had not cited.

It also surfaced a **pre-existing** false claim of the same class in the §157 block (`157v–157x` described as "LOAD-BEARING RED at this commit"; all three are green today). It is from another PR and untouched here — deliberately **not** fixed, because that is the while-I'm-here move that produced both prior rounds. Recorded rather than repaired.

## Round 3 (`fb12283`) — the criterion fires, the swing is refused

Round 3's `code-reviewer` found **zero code defects for the third round running** and re-measured every fixed-commit claim round 2 installed as **true**. It found two more false/stale prose claims, both in text the two prior sweeps had passed over. The judge confirmed 5 of 5 findings, **upgraded** one the reviewer had marked no-edit, and **dropped** one the reviewer had also declined — after measuring all three rename variants rather than agreeing on sight.

**Round 2's stopping criterion is TRIGGERED**, and the reviewer missed it: it checked only the two findings in older text, never its own `A2`. The sentence *"the mechanism is stated once"* is **new in `f52ded4`**, is **false** (`grep` finds two sites), and contradicts the judged list that authorized the edit — round 2's own ruling said "stated correctly **twice**" while quoting both. So the generator survived a targeted counter, and the cheap-stable-oracle discriminator did not prevent it. The lesson the judge draws: *the discriminator selects which claims are keepable, but nothing forces the check to actually run.*

**The licensed consequence — "strip the remaining prose to assertions only" — was refused** as `unjustified — needs measurement`. Its only ground is the direction of the previous failure, which is not a position; it is an opposite-end move from round 2's deliberate `interior`; and a mass strip is itself the large-prose-edit class carrying the measured ~1-defect-per-round rate. It would delete text three rounds measured true and load-bearing, including the F4b **self-disclosure** at `:2497-2504`. Deleting honest self-disclosure to punish dishonest prose is a strictly worse artifact.

**The bounded rule adopted instead, decidable for round 4:** the prose is not stripped, but **no clause here may be corrected a fourth time — a clause measured false a third time is deleted, never rewritten.** All three round-3 fixes discharge under it already: two deletions and one token anchored onto the convention this PR had already adopted.

## Test plan

`§156o` and `§156p` are the **witnesses** — red at `1295/2` before Code, green after. `§156p` reads the guard's **behaviour** (does it reject an over-extended window?); `§156o` reads its **text** (does a failure name which side tripped?), which is AC1 made machine-readable.

`§156q` and `§156r` are **bounds, not witnesses**, labelled as such in-file under a `WITNESS HONESTY` block. `§156q` passes today only because the floor already rejects 0 — its job is to red **later** if a ceiling implementation blinds the floor. Its fixture is validated by its **marker** (renamed heading present, original absent) rather than by its count, because reading `0` as proof the fixture built would be circular when `0` is the very thing the arm asserts. `§156r` additionally pins that the fixture path still reproduces the live guard, by requiring its count to equal the live one.

The arms drive the live guard's **extractor** verbatim — but its **decision** is re-implemented from the two integers scraped out of the assertion messages, so an executed condition that *diverges* from the declared bounds is **not** caught by these arms. That is a real, measured vacuity vector: delete the ceiling from the executed condition only, leave the messages untouched, and all four arms stay green while the guard carries no effective ceiling. It is **deferred, not fixed here** — the proposed hoist would make the arms an unbound-variable **abort** against the pre-fix guard, degrading the witness reproduction from a clean `§156p` RED to a crash, and that RED is this PR's entire evidence the defect was repaired. **No Issue tracks it yet.**

**AC5 — re-measured, not re-typed.** The comment carried a stale `21`; the re-measured count is **22**. No history is reconstructed, deliberately: the count is **not** pinned by an arm (per `§156j`'s doctrine that provenance counts stay unpinned), so nothing can ever catch a narrative about it drifting — and this line had already carried two successive wrong provenance stories. *(Round 2: this paragraph still asserted the refuted narrative after the code comment was corrected — the second instance of a fix not reaching every surface.)*

**AC6 — phrases, not bare words.** `widened` and `re-anchor` were each individually satisfiable by unrelated prose anywhere in the window, so only the conjunction carried the lock. Both are now pinned to the forms §1.3.1 actually uses, verified against the live window, so each conjunct bites on its own.

**Measured, no live agent worktree:** `pass=1295 fail=2` → **`pass=1297 fail=0`**; `lint OK: 79 files clean`; real `SPEC.md` unmodified after a full run.
