### PR TITLE
fix(#673): decide from the executed condition, not the declared bounds

### DIFF
--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2494,21 +2494,64 @@ fi
 # NO LIVE SPEC MUTATION. All three fixtures are copies under the preamble's $TMP,
 # removed by its EXIT trap; $S156_SPEC is only ever read.
 #
-# The arms drive the live guard's EXTRACTOR verbatim, but its DECISION is
-# re-implemented here from the two integers scraped out of the assertion messages
-# — so an executed condition that diverges from the declared bounds is NOT caught
-# by these arms (#643 round-1 F4b, deferred; tracked at #673). The extractor is lifted
-# verbatim out of the guard's own source line, and the bounds are read out of the
-# `156a:` assertion messages — i.e. the bounds the guard TELLS a failing reader about.
-# This covers the OMISSION direction only — a divergence, where the guard declares
-# a bound it does not execute, is the deferred F4b vector.
-# A bound the guard does not declare cannot bind anything, so an undeclared ceiling
-# reads here exactly as it behaves there: absent.
+# DECISION SOURCE (#673). Every arm here drives the live guard: its EXTRACTOR is lifted
+# verbatim out of the guard's own `s156_win=$(awk …)` source line, and its DECISION is
+# taken by EVALUATING the guard's own condition line, lifted the same way (see the lift
+# below and §156s). Nothing in this block re-implements §156a's comparison, so the two
+# directions are covered together:
+#   OMISSION  — a bound the guard never declares and never executes cannot bind anything,
+#               and reads here exactly as it behaves there: absent (§156p reds).
+#   DIVERGENCE — a bound the guard DECLARES but does not EXECUTE, or executes but does not
+#               declare, is caught by the composition: §156s (the condition can be read at
+#               all) + §156t (the two `156a:` messages agree with each other) + §156u
+#               (what the messages declare equals the numerals the condition executes).
+#               This is #643 round-1's F4b vector; #673 is its repair, not its deferral.
+#
+# UNCOVERED BY CONSTRUCTION, deliberately: a bound changed WRONGLY but CONSISTENTLY — in
+# the condition and in both messages together — stays green here. It has to. #673 AC2 asks
+# for exactly that: the arms must DERIVE the bound rather than restate it, so a ceiling
+# retuned everywhere at once is indistinguishable from a legitimate retuning. Whether the
+# two values are the RIGHT ones is a judgement no arm in this file makes (#643, locked). No
+# bound numeral is repeated in this block, on purpose — a copy here would be one more thing
+# to keep in sync and would silently satisfy AC1 while re-creating #673's own defect.
+#
+# FAIL-CLOSED ON A REFACTOR. The lift anchor is broad (`^elif .*s156_n.*; then$`, and an
+# arithmetic `(( s156_n < … || s156_n > … ))` rewrite is measured to lift and evaluate
+# cleanly), but a rewrite it cannot recognise yields an empty condition, which is
+# UNEVALUABLE, not accepting: §156s reds and §156p/§156q/§156r red as UNTESTED rather than
+# reporting a bound they never applied.
+#
+# RUNNABLE AGAINST e8aa0db (the pre-#643 Test commit, guard floor-only) — #643 round 1's
+# measured deferral reason and #673 AC3's binding constraint. Measured for this design:
+# `✗156o ✗156p ✓156q ✓156r`, clean `ng` assertion failures, no `unbound variable` under
+# `set -u`. The lifted condition names only `s156_n`, which s156o_accepts binds as a
+# function-local before evaluating it, so a floor-only condition evaluates there exactly as
+# it does here.
+#
+# SHARED BLINDSPOT, disclosed rather than mitigated: no arm in this block ever executes
+# §156a itself. All of them SIMULATE it from its source text — the extractor and now the
+# condition are the guard's real bytes, but they are re-run over fixtures, not observed
+# firing. An edit that leaves both source lines intact and breaks §156a some other way
+# (its surrounding `if`/`elif` chain, the variable it feeds) is invisible here.
 S156O_SRC="$SHELL_ROOT/scripts/test/smoke.d/70-gates-contentlocks.sh"
 s156o_msgs=""
 s156o_floor=""
 s156o_ceil=""
 s156o_prog=""
+# s156o_cbound — the guard's own first `156a` assertion-message line number. It is the
+# LIFT BOUND, and the bound is load-bearing rather than tidy: the lift anchor
+# `^elif .*s156_n.*; then$` is deliberately broad enough to survive a rewrite of the
+# condition's shape, and unbounded it also matches §156r's own
+# `elif [ "$s156o_hn" -ne "$s156_n" ]; then` below. Against a guard refactored to a form
+# that no longer names s156_n, an unbounded -m1 lift picks up THAT line instead and — with
+# s156o_hn bound in-suite — every arm in this block greens with no bounds in force at all.
+# Searching only ahead of the first `156a` message cannot reach any arm of this block.
+#
+# s156o_cond — §156a's executed condition, lifted verbatim within that bound and stripped
+# of its `elif`/`; then` wrapper. Empty means the lift failed, which every consumer treats
+# as UNTESTED (never as agreement).
+s156o_cbound=""
+s156o_cond=""
 if [ -f "$S156O_SRC" ]; then
   s156o_msgs=$(grep -E '^[[:space:]]*(ok|ng) "156a:' "$S156O_SRC")
   s156o_floor=$(printf '%s\n' "$s156o_msgs" | grep -oE 'floor=[0-9]+' | head -1 | cut -d= -f2)
@@ -2518,15 +2561,37 @@ if [ -f "$S156O_SRC" ]; then
   case "$s156o_line" in
     *"awk '"*) s156o_prog=${s156o_line#*awk \'}; s156o_prog=${s156o_prog%\'*} ;;
   esac
+  s156o_cbound=$(grep -n -m1 -E '^[[:space:]]*(ok|ng) "156a:' "$S156O_SRC" | cut -d: -f1)
+  if [ -n "$s156o_cbound" ]; then
+    s156o_cline=$(head -n "$s156o_cbound" "$S156O_SRC" | grep -m1 -E '^elif .*s156_n.*; then$')
+    case "$s156o_cline" in
+      elif\ *\;\ then) s156o_cond=${s156o_cline#elif }; s156o_cond=${s156o_cond%; then} ;;
+    esac
+  fi
 fi
 
-# s156o_accepts <non-blank-line-count> — 0 when the guard's DECLARED bounds admit a
-# window of that size. Mirrors §156a's decision; an undeclared bound is inert.
+# s156o_accepts <non-blank-line-count> — THREE-VALUED, and the three values are the point:
+#   0 ACCEPT       — the guard's own condition, evaluated at that count, does NOT trip
+#   1 REJECT       — it trips
+#   2 UNEVALUABLE  — the condition could not be lifted, or evaluating it failed
+# It does not mirror §156a's decision any more; it RUNS it. The lifted text is EVALUATED in
+# a SUBSHELL with `s156_n` bound function-locally, so a condition naming a variable that is
+# unbound at this point in the suite kills the subshell under `set -u` and comes back as
+# UNEVALUABLE instead of killing the run. The two sentinel exits (10/11) are what separate a
+# genuine verdict from any failure mode of eval itself — a shell that died on the condition
+# exits 1/2/127, all of which land in UNEVALUABLE. Callers must branch on all three: folding
+# 2 into "not accepted" would green §156p/§156q on a condition they never managed to run.
 s156o_accepts() {
-  local n="$1"
-  [ -n "$s156o_floor" ] && [ "$n" -lt "$s156o_floor" ] && return 1
-  [ -n "$s156o_ceil" ] && [ "$n" -gt "$s156o_ceil" ] && return 1
-  return 0
+  # shellcheck disable=SC2034  # read by the lifted condition below, via eval
+  local s156_n="$1"
+  local rc=0
+  ( eval "if $s156o_cond; then exit 11; else exit 10; fi" ) >/dev/null 2>&1
+  rc=$?
+  case "$rc" in
+    10) return 0 ;;
+    11) return 1 ;;
+    *)  return 2 ;;
+  esac
 }
 
 # Fixtures. -1 means NOT MEASURED, so no arm can read a zero as agreement.
@@ -2555,6 +2620,15 @@ if [ -f "$S156_SPEC" ] && [ -n "$s156o_prog" ] && mkdir -p "$S156O_DIR" 2>/dev/n
   fi
 fi
 
+# Verdicts, taken ONCE and stored, because s156o_accepts is three-valued and
+# `if s156o_accepts "$n"; then` would silently fold UNEVALUABLE into REJECT — greening
+# §156p/§156q on a condition the arms never managed to run. 2 (UNEVALUABLE) is also the
+# initial value, so an unbuilt fixture is never mistaken for a verdict.
+s156o_hv=2; s156o_ov=2; s156o_tv=2
+if [ "$s156o_hn" -ge 0 ]; then s156o_accepts "$s156o_hn"; s156o_hv=$?; fi
+if [ "$s156o_on" -ge 0 ]; then s156o_accepts "$s156o_on"; s156o_ov=$?; fi
+if [ "$s156o_tn" -ge 0 ]; then s156o_accepts "$s156o_tn"; s156o_tv=$?; fi
+
 # §156o — AC1: the guard names BOTH bounds in its own assertion message, so a failure
 # says WHICH SIDE tripped. Reads the guard's text; §156p reads its behaviour.
 if [ -z "$s156o_msgs" ]; then
@@ -2573,10 +2647,12 @@ elif [ "$s156o_ofence" -ne $((s156o_hfence + 1)) ]; then
   ng "156p: over-extension fixture did not take (fence markers healthy=$s156o_hfence over=$s156o_ofence, expected +1) — arm would be vacuous (#643)"
 elif [ "$s156o_on" -le "$s156o_hn" ]; then
   ng "156p: over-extension fixture did not over-extend (over n=$s156o_on vs healthy n=$s156o_hn) — arm would be vacuous (#643)"
-elif s156o_accepts "$s156o_on"; then
-  ng "156p: an unclosed fence in §1.3.1 runs the window to $s156o_on non-blank lines (healthy=$s156o_hn) and the declared bounds ACCEPT it (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) — the content locks would be called load-bearing over §1.4–§3 (#643)"
+elif [ "$s156o_ov" -ge 2 ]; then
+  ng "156p: §156a's executed condition could not be evaluated at n=$s156o_on (lifted='${s156o_cond:-<none>}') — the ceiling is UNTESTED, not satisfied (#673)"
+elif [ "$s156o_ov" -eq 0 ]; then
+  ng "156p: an unclosed fence in §1.3.1 runs the window to $s156o_on non-blank lines (healthy=$s156o_hn) and the guard's EXECUTED condition ACCEPTS it (declared floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) — the content locks would be called load-bearing over §1.4–§3 (#643, #673)"
 else
-  ok "156p: an unclosed fence in §1.3.1 over-extends the window to $s156o_on non-blank lines and the declared bounds REJECT it (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) (#643)"
+  ok "156p: an unclosed fence in §1.3.1 over-extends the window to $s156o_on non-blank lines and the guard's EXECUTED condition REJECTS it (declared floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) (#643, #673)"
 fi
 
 # §156q — AC3, a BOUND (not a witness; passes before and after). The ceiling must not
@@ -2585,10 +2661,12 @@ if [ "$s156o_tn" -lt 0 ]; then
   ng "156q: renamed-heading fixture not built or rename did not land — the floor is UNTESTED, not satisfied (#643)"
 elif [ "$s156o_tn" -ne 0 ]; then
   ng "156q: renamed-heading fixture left a non-empty window (n=$s156o_tn, expected 0) — arm would be vacuous (#643)"
-elif s156o_accepts "$s156o_tn"; then
-  ng "156q: a renamed §1.3.1 heading collapses the window to 0 non-blank lines and the declared bounds ACCEPT it (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) (#643)"
+elif [ "$s156o_tv" -ge 2 ]; then
+  ng "156q: §156a's executed condition could not be evaluated at n=$s156o_tn (lifted='${s156o_cond:-<none>}') — the floor is UNTESTED, not satisfied (#673)"
+elif [ "$s156o_tv" -eq 0 ]; then
+  ng "156q: a renamed §1.3.1 heading collapses the window to 0 non-blank lines and the guard's EXECUTED condition ACCEPTS it (declared floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) (#643, #673)"
 else
-  ok "156q: a renamed §1.3.1 heading collapses the window to 0 non-blank lines and the declared bounds REJECT it — the ceiling does not blind the floor (#643)"
+  ok "156q: a renamed §1.3.1 heading collapses the window to 0 non-blank lines and the guard's EXECUTED condition REJECTS it — the ceiling does not blind the floor (#643, #673)"
 fi
 
 # §156r — AC4, a BOUND (not a witness; passes before and after). The two rejections
@@ -2601,35 +2679,27 @@ elif [ "$s156o_hn" -lt 0 ]; then
   ng "156r: healthy fixture not built or the guard's extractor could not be lifted from its source — bound UNTESTED (#643)"
 elif [ "$s156o_hn" -ne "$s156_n" ]; then
   ng "156r: healthy fixture window ($s156o_hn) disagrees with the live §156a window ($s156_n) — the fixture path no longer reproduces the guard (#643)"
-elif s156o_accepts "$s156o_hn"; then
-  ok "156r: the unmodified SPEC §1.3.1 window ($s156o_hn non-blank lines) is ACCEPTED by both declared bounds (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) (#643)"
+elif [ "$s156o_hv" -ge 2 ]; then
+  ng "156r: §156a's executed condition could not be evaluated at n=$s156o_hn (lifted='${s156o_cond:-<none>}') — the healthy-window bound is UNTESTED, not satisfied (#673)"
+elif [ "$s156o_hv" -eq 0 ]; then
+  ok "156r: the unmodified SPEC §1.3.1 window ($s156o_hn non-blank lines) is ACCEPTED by the guard's EXECUTED condition (declared floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) (#643, #673)"
 else
-  ng "156r: the unmodified SPEC §1.3.1 window ($s156o_hn non-blank lines) is REJECTED by the declared bounds (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) — the bounds are always-failing (#643)"
+  ng "156r: the unmodified SPEC §1.3.1 window ($s156o_hn non-blank lines) is REJECTED by the guard's EXECUTED condition (declared floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) — the bounds are always-failing (#643, #673)"
 fi
 
-# ---------- §156s/§156u: DECLARED bounds vs the EXECUTED condition (#673) -----------
-# The four arms above decide from the bounds §156a DECLARES in its assertion messages;
-# the property they claim is about the bound §156a EXECUTES. Measured at 469d9fb:
-# deleting only the executed ceiling clause and leaving both messages intact leaves the
-# whole suite green, §156o included. The two arms below close that gap in the order the
+# ---------- §156s/§156t/§156u: DECLARED bounds vs the EXECUTED condition (#673) -----------
+# §156p/§156q/§156r above now DECIDE by evaluating the guard's own lifted condition, so a
+# bound the guard executes is measured directly. What they no longer check is the guard's
+# TEXT: §156a also tells a failing reader a floor and a ceiling, and those messages can
+# drift away from the condition without any arm above noticing. Measured at 469d9fb:
+# deleting only the executed ceiling clause and leaving both messages intact left the whole
+# suite green, §156o included. The three arms below close that gap in the order the
 # composition needs — first that the executed condition can be READ at all (§156s), then
-# that it AGREES with what the messages declare (§156u).
+# that the two messages agree with EACH OTHER (§156t), then that they agree with the
+# numerals the condition EXECUTES (§156u).
 #
-# s156o_cbound — the guard's own first `156a` assertion-message line number. It is the
-# LIFT BOUND, and the bound is load-bearing rather than tidy: the lift anchor
-# `^elif .*s156_n.*; then$` is deliberately broad enough to survive a rewrite of the
-# condition's shape, and unbounded it also matches §156r's own
-# `elif [ "$s156o_hn" -ne "$s156_n" ]; then` above. Against a guard refactored to a form
-# that no longer names s156_n, an unbounded -m1 lift picks up THAT line instead and — with
-# s156o_hn bound in-suite — every arm in this block greens with no bounds in force at all.
-# Searching only ahead of the first `156a` message cannot reach any arm of this block.
-s156o_cbound=$(grep -n -m1 -E '^[[:space:]]*(ok|ng) "156a:' "$S156O_SRC" 2>/dev/null | cut -d: -f1)
-# s156o_cond — §156a's executed condition, lifted verbatim out of this suite's own source
-# within that bound and stripped of its `elif`/`; then` wrapper. Empty here: the lift is
-# the Code phase of #673. Both arms below therefore fail CLOSED, which is the direction
-# an unreadable condition must fail in anyway — an arm that cannot see the executed bound
-# must say so, never report the composition as satisfied.
-s156o_cond=""
+# The lift itself (s156o_cbound / s156o_cond) is above, next to the extractor lift, because
+# s156o_accepts consumes it before §156p runs; its bound rationale is documented there.
 
 # §156s — the composition's PRECONDITION. Reading the executed condition is what lets an
 # arm stop re-implementing §156a's decision from its messages; if the lift comes back
@@ -2640,6 +2710,26 @@ elif [ -z "$s156o_cond" ]; then
   ng "156s: §156a's executed condition could not be lifted from this suite's own source (anchor '^elif .*s156_n.*; then\$', bounded to lines 1-$s156o_cbound) — the executed bound is UNTESTED, not satisfied (#673)"
 else
   ok "156s: §156a's executed condition lifts from this suite's own source, bounded to lines 1-$s156o_cbound (#673)"
+fi
+
+# §156t — MESSAGE CONSISTENCY, and specifically the `head -1` blind spot. §156a states its
+# bounds TWICE, once in each branch, and s156o_floor/s156o_ceil keep only the FIRST spelling
+# of each. So changing the ceiling in exactly one of the two messages is invisible to §156o
+# (a ceiling is still named) and can be invisible to §156u too (it compares the first one,
+# which may be the untouched copy). Both messages describe the SAME condition, so more than
+# one distinct value for either bound is a defect on its face: one of them is telling a
+# failing reader a bound the guard does not apply. Counted as DISTINCT values, not
+# occurrences — two branches legitimately repeat the same pair.
+s156t_floors=$(printf '%s\n' "$s156o_msgs" | grep -oE 'floor=[0-9]+' | sort -u | tr '\n' ' ')
+s156t_ceils=$(printf '%s\n' "$s156o_msgs" | grep -oE 'ceiling=[0-9]+' | sort -u | tr '\n' ' ')
+s156t_nf=$(printf '%s\n' "$s156o_msgs" | grep -oE 'floor=[0-9]+' | sort -u | grep -c .)
+s156t_nc=$(printf '%s\n' "$s156o_msgs" | grep -oE 'ceiling=[0-9]+' | sort -u | grep -c .)
+if [ -z "$s156o_msgs" ]; then
+  ng "156t: cannot read this suite's own 156a assertion messages — message consistency is UNTESTED, not satisfied (#673)"
+elif [ "$s156t_nf" -le 1 ] && [ "$s156t_nc" -le 1 ]; then
+  ok "156t: §156a's two assertion messages declare one bound pair between them (floor={ ${s156t_floors:-<none> }} ceiling={ ${s156t_ceils:-<none> }}) (#673)"
+else
+  ng "156t: §156a's two assertion messages disagree with each other (floor={ ${s156t_floors:-<none> }} ceiling={ ${s156t_ceils:-<none> }}) — one branch tells a failing reader a bound the other does not, and only the first is read below (#673)"
 fi
 
 # §156u — AC1: what the guard TELLS a failing reader must be what it APPLIES. §156o

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2352,9 +2352,11 @@ elif [ "$s156_n" -lt 18 ] || [ "$s156_n" -gt 60 ]; then
   # and this line has already carried two successive wrong provenance stories.
   # Re-measure it; do not re-tell it.
   #
-  # floor=18 tolerates ordinary prose tightening and catches a collapsed or
-  # renamed heading; ceiling=60 leaves §1.3.1 room to nearly triple while sitting
-  # six-fold below the ~368 a desync produces today. The bounds are NAMED in both
+  # The floor tolerates ordinary prose tightening and catches a collapsed or
+  # renamed heading; the ceiling leaves §1.3.1 room to nearly triple while sitting
+  # six-fold below the ~368 a desync produces today. Both values are deliberately
+  # NOT repeated here — they are on the two lines directly below, and a fourth
+  # hand-synced copy is a fourth thing to keep in sync (#673). The bounds are NAMED in both
   # messages so a failure says which side tripped, and §156o/§156p parse those two
   # spellings — renaming them fails CLOSED (measured: both arms red), so it is not
   # a silent hazard.
@@ -2495,7 +2497,7 @@ fi
 # The arms drive the live guard's EXTRACTOR verbatim, but its DECISION is
 # re-implemented here from the two integers scraped out of the assertion messages
 # — so an executed condition that diverges from the declared bounds is NOT caught
-# by these arms (#643 round-1 F4b, deferred). The extractor is lifted
+# by these arms (#643 round-1 F4b, deferred; tracked at #673). The extractor is lifted
 # verbatim out of the guard's own source line, and the bounds are read out of the
 # `156a:` assertion messages — i.e. the bounds the guard TELLS a failing reader about.
 # This covers the OMISSION direction only — a divergence, where the guard declares
@@ -2657,8 +2659,11 @@ fi
 #   already satisfies them. They exist so a later edit cannot rename a record field, drop
 #   one of the three anti-swing rules, weaken a closed menu into a free-text hatch, or
 #   dilute one of the load-bearing negative results.
-#   ROUTING arms (157v–157x) are LOAD-BEARING RED at this commit: `/review` step 3.5 and
-#   `/ship` step 1.5 are the Code phase.
+#   ROUTING arms (157v–157x) were LOAD-BEARING RED at 58b43ee: `/review` step 3.5 and
+#   `/ship` step 1.5 were the Code phase. They are GREEN from 9aa6e85 on (measured:
+#   `finding-judge` refs in review.md/ship.md go 0 -> 2 across that commit) — anchored
+#   rather than left present-tense, because "at this commit" goes stale the moment the
+#   Code phase lands and cannot be re-checked afterwards (#673).
 #
 # ANTI-VACUITY. 157a count-guards the contract file — a lock over an absent or gutted file
 # passes vacuously, anti-pattern #2 in the smoke.sh header. Every anti-swing arm reads a

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2543,8 +2543,10 @@ s156o_prog=""
 # `^elif .*s156_n.*; then$` is deliberately broad enough to survive a rewrite of the
 # condition's shape, and unbounded it also matches §156r's own
 # `elif [ "$s156o_hn" -ne "$s156_n" ]; then` below. Against a guard refactored to a form
-# that no longer names s156_n, an unbounded -m1 lift picks up THAT line instead and — with
-# s156o_hn bound in-suite — every arm in this block greens with no bounds in force at all.
+# that no longer names s156_n, an unbounded -m1 lift picks up THAT line instead — so the
+# arms would decide from a condition that is not §156a's, and their verdicts would say
+# nothing about the guard. Measured, and this is the whole rationale: bounded, the lift
+# returns empty; unbounded, it returns §156r's line.
 # Searching only ahead of the first `156a` message cannot reach any arm of this block.
 #
 # s156o_cond — §156a's executed condition, lifted verbatim within that bound and stripped
@@ -2720,8 +2722,8 @@ fi
 # one distinct value for either bound is a defect on its face: one of them is telling a
 # failing reader a bound the guard does not apply. Counted as DISTINCT values, not
 # occurrences — two branches legitimately repeat the same pair.
-s156t_floors=$(printf '%s\n' "$s156o_msgs" | grep -oE 'floor=[0-9]+' | sort -u | tr '\n' ' ')
-s156t_ceils=$(printf '%s\n' "$s156o_msgs" | grep -oE 'ceiling=[0-9]+' | sort -u | tr '\n' ' ')
+s156t_floors=$(printf '%s\n' "$s156o_msgs" | grep -oE 'floor=[0-9]+' | cut -d= -f2 | sort -u | tr '\n' ' ')
+s156t_ceils=$(printf '%s\n' "$s156o_msgs" | grep -oE 'ceiling=[0-9]+' | cut -d= -f2 | sort -u | tr '\n' ' ')
 s156t_nf=$(printf '%s\n' "$s156o_msgs" | grep -oE 'floor=[0-9]+' | sort -u | grep -c .)
 s156t_nc=$(printf '%s\n' "$s156o_msgs" | grep -oE 'ceiling=[0-9]+' | sort -u | grep -c .)
 if [ -z "$s156o_msgs" ]; then

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2734,8 +2734,12 @@ fi
 
 # §156u — AC1: what the guard TELLS a failing reader must be what it APPLIES. §156o
 # asserts both bounds are named and §156s asserts the condition can be read; neither
-# compares them, so a guard whose messages both say ceiling=40 while its condition
-# executes 60 satisfies both arms. Compared as SETS of numerals: the two surfaces order
+# compares them, so a guard whose two messages CONSISTENTLY declare a ceiling its
+# condition does not execute satisfies both arms. (Numerals are deliberately not used
+# to illustrate that here: this block went from four hand-synced copies of the bound
+# to two, and an example numeral is one more thing a reader can mistake for the real
+# value once the real value moves — #673.)
+# Compared as SETS of numerals: the two surfaces order
 # and spell their bounds differently, and neither ordering is a property worth locking.
 #
 # SYMMETRIC PIPELINE, deliberately. Both sides end in the same sort/tr tail, so a bound

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -2607,6 +2607,72 @@ else
   ng "156r: the unmodified SPEC §1.3.1 window ($s156o_hn non-blank lines) is REJECTED by the declared bounds (floor=${s156o_floor:-<none>} ceiling=${s156o_ceil:-<none>}) — the bounds are always-failing (#643)"
 fi
 
+# ---------- §156s/§156u: DECLARED bounds vs the EXECUTED condition (#673) -----------
+# The four arms above decide from the bounds §156a DECLARES in its assertion messages;
+# the property they claim is about the bound §156a EXECUTES. Measured at 469d9fb:
+# deleting only the executed ceiling clause and leaving both messages intact leaves the
+# whole suite green, §156o included. The two arms below close that gap in the order the
+# composition needs — first that the executed condition can be READ at all (§156s), then
+# that it AGREES with what the messages declare (§156u).
+#
+# s156o_cbound — the guard's own first `156a` assertion-message line number. It is the
+# LIFT BOUND, and the bound is load-bearing rather than tidy: the lift anchor
+# `^elif .*s156_n.*; then$` is deliberately broad enough to survive a rewrite of the
+# condition's shape, and unbounded it also matches §156r's own
+# `elif [ "$s156o_hn" -ne "$s156_n" ]; then` above. Against a guard refactored to a form
+# that no longer names s156_n, an unbounded -m1 lift picks up THAT line instead and — with
+# s156o_hn bound in-suite — every arm in this block greens with no bounds in force at all.
+# Searching only ahead of the first `156a` message cannot reach any arm of this block.
+s156o_cbound=$(grep -n -m1 -E '^[[:space:]]*(ok|ng) "156a:' "$S156O_SRC" 2>/dev/null | cut -d: -f1)
+# s156o_cond — §156a's executed condition, lifted verbatim out of this suite's own source
+# within that bound and stripped of its `elif`/`; then` wrapper. Empty here: the lift is
+# the Code phase of #673. Both arms below therefore fail CLOSED, which is the direction
+# an unreadable condition must fail in anyway — an arm that cannot see the executed bound
+# must say so, never report the composition as satisfied.
+s156o_cond=""
+
+# §156s — the composition's PRECONDITION. Reading the executed condition is what lets an
+# arm stop re-implementing §156a's decision from its messages; if the lift comes back
+# empty there is nothing to compose and the block is back to reading the messages only.
+if [ -z "$s156o_cbound" ]; then
+  ng "156s: cannot locate this suite's own 156a assertion message — the condition lift has no search bound, so the executed condition is UNTESTED, not satisfied (#673)"
+elif [ -z "$s156o_cond" ]; then
+  ng "156s: §156a's executed condition could not be lifted from this suite's own source (anchor '^elif .*s156_n.*; then\$', bounded to lines 1-$s156o_cbound) — the executed bound is UNTESTED, not satisfied (#673)"
+else
+  ok "156s: §156a's executed condition lifts from this suite's own source, bounded to lines 1-$s156o_cbound (#673)"
+fi
+
+# §156u — AC1: what the guard TELLS a failing reader must be what it APPLIES. §156o
+# asserts both bounds are named and §156s asserts the condition can be read; neither
+# compares them, so a guard whose messages both say ceiling=40 while its condition
+# executes 60 satisfies both arms. Compared as SETS of numerals: the two surfaces order
+# and spell their bounds differently, and neither ordering is a property worth locking.
+#
+# SYMMETRIC PIPELINE, deliberately. Both sides end in the same sort/tr tail, so a bound
+# absent from BOTH surfaces contributes to neither set and the two compare EQUAL. That is
+# the e8aa0db case — floor only, no ceiling in the condition and none in the messages —
+# and it must read as AGREEMENT: an asymmetric pipeline reds there on "" vs " " and costs
+# this block its runnability against the pre-#643 tree, which is #643 round 1's measured
+# deferral reason. Only the DECLARED side is count-guarded, because a guard that declares
+# no numeral at all gives the comparison nothing to bite on — UNTESTED, not agreement.
+#
+# The executed side matches the OPERAND, never a bare integer: the condition names
+# `s156_n`, whose own digits would otherwise enter the set and make parity unsatisfiable.
+s156u_set() { grep -oE '[0-9]+' | sort -un | tr '\n' ' '; }
+s156u_dec=$(printf '%s\n' "$s156o_msgs" | grep -oE '(floor|ceiling)=[0-9]+' | s156u_set)
+s156u_exe=$(printf '%s\n' "$s156o_cond" | grep -oE '([-](lt|gt|le|ge)|[<>]=?)[[:space:]]*[0-9]+' | s156u_set)
+if [ -z "$s156o_cbound" ]; then
+  ng "156u: cannot locate this suite's own 156a assertion message — declared-vs-executed parity is UNTESTED, not satisfied (#673)"
+elif [ -z "$s156o_cond" ]; then
+  ng "156u: §156a's executed condition could not be lifted — declared-vs-executed parity is UNTESTED, not satisfied (#673)"
+elif [ -z "$s156u_dec" ]; then
+  ng "156u: the guard's 156a messages declare no numeric bound — parity has nothing to compare, UNTESTED, not satisfied (#673)"
+elif [ "$s156u_dec" = "$s156u_exe" ]; then
+  ok "156u: the bounds §156a DECLARES agree with the numerals its condition EXECUTES (declared={ $s156u_dec} executed={ $s156u_exe}) (#673)"
+else
+  ng "156u: the bounds §156a DECLARES diverge from the numerals its condition EXECUTES (declared={ $s156u_dec} executed={ $s156u_exe}) — a failing reader is told a bound the guard does not apply, or a bound it applies is invisible here (#673)"
+fi
+
 # §156j — POSITIVE parity assertion: the §1.8 lever row and the §1.9 posture row
 # added for the SSOT change sweep are shaped so §116's OWN derivations count them, and
 # §116's parity therefore still balances. The awk/grep expressions below are


### PR DESCRIPTION
Closes #673

## Plan

`§156a`'s window guard is the only thing standing between §1.3.1's eleven content locks and the state #643 fixed, where the locks were asserted over §1.4–§3. Its dedicated arm, `§156o`, lifts the guard's **extractor** verbatim out of the guard's own source — but then **re-implements the guard's decision** from two integers scraped out of the `156a:` assertion *messages*. So every arm in the block measures what the guard **says**, and nothing measures what it **does**.

Measured on `main` at `469d9fb`: deleting only `|| [ "$s156_n" -gt 60 ]` from the executed condition, leaving both messages intact, leaves the suite at **`pass=1297 fail=0`** with `✓156o ✓156p ✓156q ✓156r`. The guard silently loses its ceiling and the suite reports success.

**The fix: stop re-implementing the decision and run it.** `s156o_accepts` lifts `§156a`'s condition line from the guard's own source — the technique `§156o` already uses for the awk extractor, proven backward-portable — strips the `elif`/`; then` wrapper, sets a function-local `s156_n`, and evaluates it in a **subshell with a three-valued result** (accept / reject / unevaluable), so a condition referencing a later-defined variable cannot crash the parent under `set -u`.

**`fix` relaxation not taken.** Doc → Test → Code is kept in full. The reproduce-first relaxation was available, but the reproduction already exists — recorded in the Issue and re-run on `main` before filing.

## The contest — two challengers, both wrong in instructive ways

The plan went through `planner` + two mutually-blind `plan-challenger`s (axes `correctness` and `simplicity/maintainability`) + `plan-reviewer`. **Both challengers returned `dominates-A`. Only one survived measurement.**

| mutant | Plan A | B1 (correctness) | B2 (maintainability) | **winner (B1 + grafts)** |
|---|---|---|---|---|
| unmutated | green | green | green | **all green** |
| `\|\|` → `&&` @ the condition | **GREEN (miss)** | `✗156p ✗156q` | **GREEN (miss)** | **`✗156p ✗156q`** |
| M6 messages→40, condition 60 | red | **GREEN (miss)** | `✗156s` | **`✗156u`** |
| M3 `ok` message only→40 | red | `✗156t` | `✗156s` | **`✗156t ✗156u`** |
| M2 →40 everywhere | green (**needs prose deleted**) | green, prose intact | green | **green, prose intact** |
| M1 delete `-gt 60` | red | `✗156p` | `✗156p ✗156s` | **`✗156p`** |
| `(( ))` refactor | red (fail-open cost) | green + still discriminating | `✗` 3 arms | **green + still discriminating** |
| `e8aa0db` splice | n/a | clean | clean | **`✗156o ✗156p ✓156q ✓156r`, no crash** |

**`||` → `&&` is one token, and it makes *both* bounds inert.** Every numeric operand and every message numeral stays byte-identical, so Plan A's parity scanner is **provably** green on it — which refutes A's central claim that *"declared ≡ executed ⟹ deciding on declared is faithful."*

**B2 claimed to dominate A and does not.** B2 extracts the operands and re-applies its own comparison, so a connective flip is invisible to it too. B2 never ran that mutant; the reviewer built B2's design verbatim and did: `pass=1294 fail=4`, all arms green, byte-identical to B2 unmutated. B2 dominates on diff size and fixture reuse only — a fake-diff on the decisive axis.

**B1 is not a clean winner either.** It misses M6 — both messages *consistently* declaring `ceiling=40` while the condition executes `60` — which is AC1's own wording. Hence the graft: B1's decision source **plus** A/B2's declared-vs-executed parity arm.

## Invariant preserved by measurement, not by argument

AC3 requires `§156p`'s clean RED at `e8aa0db` to survive — this is round 1 of PR #672's *measured* deferral reason, which rejected the shared-symbol hoist precisely because it turned that clean RED into a `set -u` crash. Splicing the winner's block into a `git archive e8aa0db` tree: `✗156o ✗156p ✓156q ✓156r`, clean `ng` assertion failures, **zero** `unbound variable` or `command not found`.

**Scope ruling.** Touching `s156o_accepts` is admissible — the Issue's out-of-scope bars only `§156p`/`q`/`r`'s *fixture construction*, and says verbatim *"This issue changes where the decision comes from"*. Plan A's scope-out was self-imposed, and touching it was measured **not** to cost the invariant.

## Two corrections applied to the plan before implementation

1. **The reviewer refuted one of my own plan's claims.** Round 1 recorded that `empty-on-both = agreement` was the invariant-1 rescue. Round 2 re-measured: with a symmetric pipeline both ceiling sets come out empty at `e8aa0db` and naive equality already agrees. The rule is **defensive, not load-bearing** — still carried, but the plan no longer claims it saves the invariant.
2. **The broadened lift anchor needed bounding.** `^elif .*s156_n.*; then$` also matches `§156r`'s own `elif [ "$s156o_hn" -ne "$s156_n" ]` — against a guard refactored to a form not naming `s156_n`, `-m1` would lift *that* line and green `p`/`q`/`r`/`s` **with no bounds at all**. The Code phase bounds the lift to the region before the first `156a:` message.

## Disclosed, not hidden

**None of the three candidate designs ever executes `§156a` itself** — all remain source-derived simulations, B1 closest since it evaluates the real condition text. The gap is real and is stated in the in-file note rather than papered over.

## Measured kill matrix — every mutant on an isolated `git archive` copy, live tree never mutated

Isolated-copy floor is 4 (`status-cache` ×2, `133a`, `135e-2`) — artifacts of the copy lacking `.git`/the self-symlink, unrelated to §156. So `1296/4` **is** fully green there.

| mutant | measured | verdict |
|---|---|---|
| unmutated (archive) | `1296/4`, all §156 green | ✓ |
| **M-AND** `\|\|` → `&&` in the condition | `1294/6` — **`✗156p ✗156q`** | ✓ **the mutant that decided the contest** |
| **M1** delete `\|\| [ "$s156_n" -gt 60 ]`, messages intact | `1294/6` — **`✗156p ✗156u`** | ✓ *stronger than planned* |
| **M6** both messages → `ceiling=40`, condition executes `60` | `1295/5` — **`✗156u`** | ✓ |
| **M3** `ok` message only → `40` | `1294/6` — **`✗156t ✗156u`** | ✓ |
| **M2** ceiling → `40` in condition **and** both messages | **`1296/4` fully green**, block prose byte-untouched | ✓ AC2 |
| **M4** `(( s156_n < … \|\| s156_n > … ))` refactor | **`1296/4` green** | ✓ refactor-tolerant |
| **M4d** same form minus the ceiling | `1294/6` — **`✗156p ✗156u`** | ✓ still discriminating |
| **M-OMIT** ceiling gone from condition **and** both messages | `1294/6` — **`✗156o ✗156p`**, `✓156q ✓156r ✓156s ✓156t ✓156u` | ✓ AC3 — absent, not crashed |
| **`e8aa0db` true splice** | `1294/6` — **`✗156o ✗156p ✓156q ✓156r`**, clean `ng`s, **0** noise lines mentioning `156` | ✓ **invariant 1** |
| **M-ANCHOR** condition rewritten to a shape not naming `s156_n` | `1291/9` — **five arms red, all `UNTESTED`** | ✓ fail-closed, loud, no crash |

**AC6, live tree, no agent worktree live:** `lint OK: 79 files clean`; `smoke: pass=1300 fail=0`; the `^[[:space:]]*(ok|ng) "156a:` scrape still matches exactly **2** lines, so the additions do not perturb `§156o`; real `SPEC.md` unmutated.

## Four things the implementation found that the plan and the Issue had wrong

1. **The plan's kill matrix understated M1.** It recorded `✗156p` only. Measured, M1 also reds `§156u` (`declared={18 60} executed={18}`) — deleting the executed clause while leaving the messages intact *is* a declared-vs-executed divergence, so the parity arm necessarily fires. Same for M4d. The composition is strictly stronger than the plan claimed.
2. **The bound on the lift is load-bearing, and now measured directly rather than argued.** Counterfactual built: same M-ANCHOR mutant, lift *unbounded*. `§156p` greens **spuriously** — the unbounded `-m1` lifts `§156r`'s own `elif [ "$s156o_hn" -ne "$s156_n" ]` and, with `s156o_hn=22` / `s156_n=368`, that "condition" happens to reject. Only `§156u` reds, and only because the lifted line carries no numerals — exactly the *"do not rely on that"* the plan review warned of. With the bound in place, all five arms red `UNTESTED`.
3. **`§156t` is *not* subsumed by `§156u`** in the direction the plan assumed. Under M3 both red, but `§156u` reports `declared={18 40 60}` with no indication the *messages* disagree with *each other* rather than with the condition. The subsumption holds on the pass/fail bit only; `§156t` is the arm that localises the defect.
4. **`§156o` was never the arm AC1's reproduction needed.** Under M1 and M-AND it stays green; it reds only for the text reason it always did. The repair lands entirely in `§156p`/`§156q` (behaviour) and `§156s`/`§156t`/`§156u` (text-vs-behaviour). `§156o`'s WITNESS-HONESTY note, which already calls it a bounds-not-witness arm reading the guard's *text*, remains accurate and was left alone.

## Two implementation deviations from the approved plan

1. **Three-valued dispatch is via stored verdicts, not at the `elif` sites.** `if s156o_accepts "$n"; then` cannot distinguish `rc=1` from `rc=2`, so it would have folded UNEVALUABLE into REJECT and **greened `§156p`/`§156q`** — a direct invariant-3 violation. The three verdicts are taken once, initialised to `2`, and each arm branches on all three. This adds an `UNTESTED` arm to `§156p`/`q`/`r`: a branch change, not a fixture-construction change, so the Issue's out-of-scope is untouched.
2. **The lift moved up next to the extractor lift.** `s156o_accepts` is consumed by `§156p` ~90 lines before the `§156s` block where the plan placed the lift, so leaving it there would have made every arm UNEVALUABLE. Bound and anchor are exactly as planned.

## Round 1 review (`be5d256`) — one real finding, one refuted

`code-reviewer` re-ran every load-bearing row of the matrix above and reproduced them all, then returned `ship after fix` on **one** finding — and it was, again, *prose about correct code*: an in-file comment claimed an unbounded lift makes **every** arm green, where six green and `§156u` reds. The PR body stated it correctly; only the comment overstated.

**The judge refused the reviewer's remedy.** The proposed rewrite repaired one false clause by pinning five arm identities plus a contingent reason, and its own added clause — that `§156u`'s red is *"incidental and not a property to rely on"* — is self-undermining: it labels the property unreliable while depending on it. So the clause was **severed**, not re-specified. What replaces it is a statement about what gets *lifted* rather than what the arms then do — an analytic consequence with no staleness path — keeping the judge's floor (the anchor's breadth and the `§156r` dependency, which #673 AC5 binds) and its ceiling (no arm-outcome enumeration, no numeral-contingent clause, no bound literal).

**One finding was refuted outright.** The reviewer flagged `s156o_cline` as the lone un-initialised sibling. Measured: `s156o_line` is *also* assigned inside the guard block with no up-front declaration and is untouched by this PR. The real convention is not *declared vs forgotten* but **read outside the block vs not** — and `s156o_cline` follows it. Initialising it would make the file *less* consistent with its own rule.

**One cosmetic fix landed** (`§156t` rendered `floor={ floor=18 }` on the pass path, so every green run printed it), bounded to the two display assignments; the verdict variables are computed independently and untouched.

**The judge also caught an error neither the reviewer nor I did:** this body's M-ANCHOR row read `1290/10` where the measurement is `1291/9` — the same defect class as the finding, on a durable surface. Corrected above.

**No further adversarial round for behaviour.** The lift bound is line `2363`; both edits sit after it, outside the lift's search range, and the `§156t` edit touches only message interpolation. The kill matrix is inert with respect to them.

## Checklist

- [x] **Doc** (`9dd8529`) — delete the **fourth** bound copy; anchor §157's stale tense claim; point the deferral note at #673.
- [x] **Test** (`ffb3ff0`) — `§156s` (lift precondition) and `§156u` (parity) added while `s156o_accepts` still reads the messages → clean RED at `pass=1297 fail=2`, with three same-input positive controls.
- [x] **Code** (`b52a9ea`) — condition lift (bounded anchor) + subshell three-valued eval; `§156t`; `§156p`/`q`/`r` branch on all three verdicts; deferral note replaced wholesale (AC5).
- [x] **Code** (`be5d256`) — de-numeralise the last illustrative bound. **Measured across the entire PR diff: zero added lines contain a bound numeral.** The block went from **four** hand-synced declaration sites to **two** — both of them the `156a:` messages `§156o` must grep by contract.
- [x] **Review fixes** (`6413a98`) — sever the false lift-bound clause (F1); strip `§156t`'s doubled label (F3). F2 refuted, no change.

## Docs touched

- [~] `SPEC.md` — N/A. No SPEC clause governs a smoke arm; this block's in-file comment is its contract SSOT (`3a6297a` precedent).
- [~] Changelog fragment — N/A. Smoke-internal, no adopter-observable surface (§18.7); `skip-changelog` to be applied.

## Ship gate

- [x] `code-reviewer` round 1 at `be5d256` → `ship after fix`; judged, fixed in `6413a98`
- [x] **AC6** — full suite green in a worktree-free window (#642): `pass=1300 fail=0`, `lint OK: 79 files clean`. The judge ruled this **structurally undischargeable by any worktree-isolated agent**, so it was run by the main session at the final head.
- [x] AC closeout posted on #673
- [x] head-pinned review at the final head (`6413a98`)

## Review cost, recorded

Four review rounds; **zero code defects in all four.** Round 1 found one false clause in a code comment (real, fixed). Rounds 2, 3 and 4 found, in order: a wrong numeral in this body, a wrong numeral in a PR comment, and nothing. `s156o_cbound` is computed at runtime — so `2363` vs `2364` was only ever a claim *about* a measurement, and no code path could carry a stale value.

Recorded because it is evidence for the review-round-inflation work being raised in priority, not as a complaint about the reviewers: round 1's finding was genuine, and the `finding-judge` refuted a bad nit, refused a reviewer remedy that would have added six new claims, and caught a slip in this body that neither the reviewer nor the author saw.
