### PR TITLE
fix(#679): include CR in the C0 neutralisation range

### DIFF
--- a/changelog_unreleased/fixed/679.md
+++ b/changelog_unreleased/fixed/679.md
@@ -1,0 +1,1 @@
+- The citation reader neutralises CR along with the other C0 controls, so a carriage return in an attribution can no longer redraw its own report line on a terminal — the header's every-C0-except-tab invariant is now true of the code. (#679)

--- a/scripts/lint_citations.sh
+++ b/scripts/lint_citations.sh
@@ -429,7 +429,7 @@ extract() {
     {
       line = $0
       # Every C0 control except tab becomes a space — see NEUTRALISED BYTES above.
-      gsub(/[\001-\010\013\014\016-\037\177]/, " ", line)
+      gsub(/[\001-\010\013-\037\177]/, " ", line)
       # Only an ASCII double-quote pair is extracted. Typographic pairs are counted
       # and stated rather than declined in silence — or widened into: widening the
       # alphabet changes the span set for a case with no measured demand, while the

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -4137,6 +4137,10 @@ else
   # Line 1: an ESC[2K/ESC[1G redraw inside the attribution token and a CR inside
   # the span. Line 2: the ordinary control that must still resolve.
   printf -- '- `tr\033[2K\033[1Gacked.md` states "a redraw carrying span for\r this control byte arm" here.\n' > "$S174L_WORK/probe.md"
+  # CR inside the ATTRIBUTION token: an attribution is echoed into the report
+  # sentence, so a CR surviving neutralisation reaches stdout there — the one
+  # channel the span-only probe above cannot exercise.
+  printf -- '- `ev\rildoc.md` states "a fake quote attributed here four words" x.\n' >> "$S174L_WORK/probe.md"
   printf -- '- `tracked.md` states "a plain control span for the control byte arm" too.\n' >> "$S174L_WORK/probe.md"
   s174l_out="$(bash "$S174_CHECKER" "$S174L_WORK/probe.md" 2>/dev/null)"
   s174l_ctl=$(printf '%s\n' "$s174l_out" | LC_ALL=C grep -c "$(printf '[\033\r]')" || true)


### PR DESCRIPTION
Closes #679

## Goal

Make the citation reader's control-byte invariant true: the header states "every C0 control except tab" is neutralised, and the shipped range omitted CR (`\015`) — the one byte whose whole effect is redrawing the line it sits on. Found by exploit in PR #677's §4.11 security tier (Low, vote 3), recorded in that PR's review-record comment for `ff75a36` with this issue as the disposition.

## How this serves the mission

MISSION "The mechanism" — checks the agent cannot drift past without leaving evidence. A reader whose stated invariant its code lacks is the defect class SPEC §1.10 polices, inside the tool that ships §1.10.

## Plan

Two lines, reproduce-first (`fix` relaxation of Doc → Test → Code; the reproduction is the recorded exploit and the hardened arm below — no doc change is needed because the header sentence already states the intended invariant):

- `scripts/lint_citations.sh`: neutralisation range `[\001-\010\013\014\016-\037\177]` → `[\001-\010\013-\037\177]` (adds `\015`; tab and LF stay untouched; one-byte-for-one-byte, so no column offset shifts).
- `scripts/test/smoke.d/70-gates-contentlocks.sh` §174l: the probe body gains a CR inside an **attribution token** — the channel that reaches stdout (an attribution is echoed into the report sentence), which the existing span-only CR probe cannot exercise (a no-attribution span's text is never echoed).

## Measurements

- §174l red against the pre-fix reader with the hardened probe: `stdout-control-lines=1`.
- §174l green with the fix; full smoke green at head; `bash -n` clean on both files.

## Checklist

- [x] Fix + hardened arm (`0935f93`), red/green measured as above.

## Out of scope

- Any other decline/neutralisation behavior of the reader; the §174l probe carries the only change on the test side.
