### PR TITLE
fix(#642): exclude .claude/worktrees/ from smoke grep -r scans

### DIFF
--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -938,6 +938,53 @@ else
   ng "148i-cli: ghjig_state_dir_cli must be a single hookrt.sh definition the wrapper calls, never re-defines (count=$s148i_defcount hookrt=$s148i_in_hookrt redef=$s148i_wrap_redef calls=$s148i_wrap_calls) (#602, #633)"
 fi
 
+# §148i-decoy (LOAD-BEARING RED until Code, #642): §148i-cli's tree-wide def-form scan greps the
+# WHOLE $SHELL_ROOT/.claude tree, which includes .claude/worktrees/agent-*/ — full repo COPIES a
+# worktree-isolated subagent makes (SPEC §1.5, §4.5). A copy of hookrt.sh there carries a genuine
+# `ghjig_state_dir_cli()` def-form line, so while any such subagent is live the naive `grep -r`
+# double-counts and §148i-cli reds — count=2 though the source tree is fine. This arm plants
+# exactly that decoy at the real worktrees path, re-runs §148i-cli's OWN detection expression
+# verbatim, and asserts it STILL counts exactly 1: the worktree copy must be EXCLUDED. Pre-fix
+# (no exclusion) it counts 2 and reds; Phase C's shared worktrees-exclusion greens it. Anti-
+# vacuity: the decoy must actually exist (made=1) and a real non-worktree hookrt.sh def must still
+# be found (realfound=1), so a broken fixture reds as untested rather than passing on count=1.
+S148I_DECOY_WT="$SHELL_ROOT/.claude/worktrees/agent-decoy"
+S148I_DECOY_F="$S148I_DECOY_WT/.claude/hooks/hookrt.sh"
+mkdir -p "$S148I_DECOY_WT/.claude/hooks"
+printf '%s\n' 'ghjig_state_dir_cli() { :; }' > "$S148I_DECOY_F" 2>/dev/null
+s148i_decoy_made=0; [ -f "$S148I_DECOY_F" ] && s148i_decoy_made=1
+s148i_decoy_defs=$(grep -rlE '^[[:space:]]*ghjig_state_dir_cli[[:space:]]*\(\)' "$SHELL_ROOT/.claude" "$SHELL_ROOT/scripts" 2>/dev/null | sort -u)
+s148i_decoy_count=$(printf '%s\n' "$s148i_decoy_defs" | grep -c . )
+s148i_decoy_realfound=0
+printf '%s\n' "$s148i_decoy_defs" | grep 'hookrt\.sh$' | grep -qv '/worktrees/' && s148i_decoy_realfound=1
+rm -rf "$S148I_DECOY_WT"
+if [ "$s148i_decoy_made" = 1 ] && [ "$s148i_decoy_realfound" = 1 ] && [ "$s148i_decoy_count" = 1 ]; then
+  ok "148i-decoy: §148i-cli's def-form scan excludes .claude/worktrees/agent-*/ copies — a live worktree-isolated subagent can no longer false-red the single-def lock (count=$s148i_decoy_count) (#642)"
+else
+  ng "148i-decoy: §148i-cli's def-form scan must exclude .claude/worktrees/ — a worktree copy of hookrt.sh double-counts ghjig_state_dir_cli (made=$s148i_decoy_made realfound=$s148i_decoy_realfound count=$s148i_decoy_count want 1) (#642)"
+fi
+
+# §148i-neg (paired negative — must stay GREEN both before and after the fix, #642): the
+# worktrees-exclusion must not BLIND the original single-def check. A genuine SECOND
+# ghjig_state_dir_cli() definition placed OUTSIDE .claude/worktrees/ must still push the count
+# past 1. Constructed over a controlled $TMP fixture (never the live tree): two def-form files at
+# ordinary, non-worktree paths. §148i-cli's OWN detection expression, run over the fixture, must
+# count BOTH (==2). Anti-vacuity: both fixture files must exist and the count is pinned to exactly
+# 2 — a fix that over-broadly prunes real source (or a grep that breaks) drops below 2 and reds.
+S148I_NEG_DIR="$TMP/s148i-neg"
+mkdir -p "$S148I_NEG_DIR/.claude/hooks" "$S148I_NEG_DIR/scripts/helpers"
+printf '%s\n' 'ghjig_state_dir_cli() { :; }' > "$S148I_NEG_DIR/.claude/hooks/hookrt.sh"
+printf '%s\n' 'ghjig_state_dir_cli() { :; }' > "$S148I_NEG_DIR/scripts/helpers/rogue.sh"
+s148i_neg_made=0
+[ -f "$S148I_NEG_DIR/.claude/hooks/hookrt.sh" ] && [ -f "$S148I_NEG_DIR/scripts/helpers/rogue.sh" ] && s148i_neg_made=1
+s148i_neg_defs=$(grep -rlE '^[[:space:]]*ghjig_state_dir_cli[[:space:]]*\(\)' "$S148I_NEG_DIR/.claude" "$S148I_NEG_DIR/scripts" 2>/dev/null | sort -u)
+s148i_neg_count=$(printf '%s\n' "$s148i_neg_defs" | grep -c . )
+if [ "$s148i_neg_made" = 1 ] && [ "$s148i_neg_count" = 2 ]; then
+  ok "148i-neg: a genuine second ghjig_state_dir_cli() def OUTSIDE worktrees still counts>1 — the exclusion never blinds the original single-def check (count=$s148i_neg_count) (#642)"
+else
+  ng "148i-neg: two real def-forms outside .claude/worktrees/ must both be counted (made=$s148i_neg_made count=$s148i_neg_count want 2) (#642)"
+fi
+
 # §148i-clibranch (LOAD-BEARING RED — writer/reader path agreement is CHECKABLE): the agent
 # writes the project-dir-relative literal `.claude/ghjig-state/file-review/staging` while the
 # wrapper resolves its own path via ghjig_state_dir_cli. `hookrt.sh:95-97` records that a

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -923,7 +923,7 @@ fi
 # DEFINED EXACTLY ONCE in the tree (anchored def-form grep, so the file-review.md prose mention
 # does not count), that one definition lives in hookrt.sh, and the wrapper — now its ONLY
 # caller, the writer having been deleted — calls it without re-defining it.
-s148i_defs=$(grep -rlE '^[[:space:]]*ghjig_state_dir_cli[[:space:]]*\(\)' "$SHELL_ROOT/.claude" "$SHELL_ROOT/scripts" 2>/dev/null | sort -u)
+s148i_defs=$(ghjig_grep_claude_defs '^[[:space:]]*ghjig_state_dir_cli[[:space:]]*\(\)' "$SHELL_ROOT/.claude" "$SHELL_ROOT/scripts")
 s148i_defcount=$(printf '%s\n' "$s148i_defs" | grep -c . )
 s148i_in_hookrt=0
 printf '%s\n' "$s148i_defs" | grep -q 'hookrt\.sh$' && s148i_in_hookrt=1
@@ -953,7 +953,7 @@ S148I_DECOY_F="$S148I_DECOY_WT/.claude/hooks/hookrt.sh"
 mkdir -p "$S148I_DECOY_WT/.claude/hooks"
 printf '%s\n' 'ghjig_state_dir_cli() { :; }' > "$S148I_DECOY_F" 2>/dev/null
 s148i_decoy_made=0; [ -f "$S148I_DECOY_F" ] && s148i_decoy_made=1
-s148i_decoy_defs=$(grep -rlE '^[[:space:]]*ghjig_state_dir_cli[[:space:]]*\(\)' "$SHELL_ROOT/.claude" "$SHELL_ROOT/scripts" 2>/dev/null | sort -u)
+s148i_decoy_defs=$(ghjig_grep_claude_defs '^[[:space:]]*ghjig_state_dir_cli[[:space:]]*\(\)' "$SHELL_ROOT/.claude" "$SHELL_ROOT/scripts")
 s148i_decoy_count=$(printf '%s\n' "$s148i_decoy_defs" | grep -c . )
 s148i_decoy_realfound=0
 printf '%s\n' "$s148i_decoy_defs" | grep 'hookrt\.sh$' | grep -qv '/worktrees/' && s148i_decoy_realfound=1
@@ -977,7 +977,7 @@ printf '%s\n' 'ghjig_state_dir_cli() { :; }' > "$S148I_NEG_DIR/.claude/hooks/hoo
 printf '%s\n' 'ghjig_state_dir_cli() { :; }' > "$S148I_NEG_DIR/scripts/helpers/rogue.sh"
 s148i_neg_made=0
 [ -f "$S148I_NEG_DIR/.claude/hooks/hookrt.sh" ] && [ -f "$S148I_NEG_DIR/scripts/helpers/rogue.sh" ] && s148i_neg_made=1
-s148i_neg_defs=$(grep -rlE '^[[:space:]]*ghjig_state_dir_cli[[:space:]]*\(\)' "$S148I_NEG_DIR/.claude" "$S148I_NEG_DIR/scripts" 2>/dev/null | sort -u)
+s148i_neg_defs=$(ghjig_grep_claude_defs '^[[:space:]]*ghjig_state_dir_cli[[:space:]]*\(\)' "$S148I_NEG_DIR/.claude" "$S148I_NEG_DIR/scripts")
 s148i_neg_count=$(printf '%s\n' "$s148i_neg_defs" | grep -c . )
 if [ "$s148i_neg_made" = 1 ] && [ "$s148i_neg_count" = 2 ]; then
   ok "148i-neg: a genuine second ghjig_state_dir_cli() def OUTSIDE worktrees still counts>1 — the exclusion never blinds the original single-def check (count=$s148i_neg_count) (#642)"

--- a/scripts/test/smoke.d/_preamble.sh
+++ b/scripts/test/smoke.d/_preamble.sh
@@ -72,3 +72,22 @@ trap 'rm -rf "$TMP" "$SMOKE_STATE"' EXIT
 HOOK="$SHELL_ROOT/.claude/hooks/pre_tool_use.sh"
 POST_HOOK="$SHELL_ROOT/.claude/hooks/post_tool_use.sh"
 ESC_HOOK="$SHELL_ROOT/.claude/hooks/pre_tool_use.sh"
+
+# ghjig_grep_claude_defs <regex> <path…> — SINGLE SHARED POINT (#642) for a
+# whole-.claude def-form scan that must EXCLUDE .claude/worktrees/. A worktree-
+# isolated subagent (SPEC §1.5/§4.5) makes a full repo COPY under
+# .claude/worktrees/agent-*/, so a naive `grep -r` over $SHELL_ROOT/.claude
+# double-counts every def while such a subagent is live. Emits the sorted-
+# unique list of matching file paths with any path under a .claude/worktrees/
+# component dropped, and nothing else pruned (the §148i-neg smoke arm proves
+# the exclusion never blinds legitimate source elsewhere).
+#
+# Portability: `grep --exclude-dir=worktrees` is NOT reliable across the two CI
+# greps — BSD grep on macos-latest vs GNU grep on ubuntu-latest differ in
+# support/semantics — so we post-filter the recursive match through a portable
+# `grep -v '/\.claude/worktrees/'`, which both CIs honour identically and which
+# targets ONLY the worktrees path component.
+ghjig_grep_claude_defs() {
+  local regex="$1"; shift
+  grep -rlE "$regex" "$@" 2>/dev/null | grep -v '/\.claude/worktrees/' | sort -u
+}


### PR DESCRIPTION
Closes #642

## Goal

A smoke gate must not flip on whether an unrelated worktree-isolated subagent is alive. §148i-cli (and the same-shaped `grep -r` siblings) recurse over the whole `$SHELL_ROOT/.claude` tree, which now includes `.claude/worktrees/agent-*/` full repo copies — so a file-counting assertion double-counts while a subagent runs, reddening a clean suite (observed on PR #641's own /ship review step).

## Plan

`fix`, reproduce-first: the failing arm IS the reproduction (Test commit lands before Code). No planner contest — the change is smoke-internal, under 3 files, no schema/API/contract surface (norm: planner required at 3+ files or schema/API/migration). No Doc phase — no SSOT clause governs smoke internals (the issue confirms this); `Docs: n/a — smoke-internal test-harness scoping`.

- **Test** (`8040824`) — §148i-decoy: a decoy `ghjig_state_dir_cli()` def-form under the real `.claude/worktrees/agent-decoy/...` must be excluded (count stays 1); reds pre-fix at count=2. §148i-neg: a genuine second def OUTSIDE worktrees still counts>1, so the exclusion cannot blind the original check.
- **Code** (`d8b0088`) — a single shared `ghjig_grep_claude_defs` helper in `_preamble.sh` (portable post-filter dropping `/.claude/worktrees/` paths — `--exclude-dir` diverges BSD/GNU), routed through by §148i-cli's detection (AC1). §148i-neg also routes through it so it genuinely guards against an over-broad exclusion pruning real source.

## Out of scope

Changing worktree isolation or relocating `.claude/worktrees/`; auditing every `grep -r` beyond the four named call sites.

## Checklist

- [x] **Test** (`8040824`) — §148i-decoy (red pre-fix) + §148i-neg (paired negative)
- [x] **Code** (`d8b0088`) — shared `ghjig_grep_claude_defs` in `_preamble.sh` (portable `-v '/.claude/worktrees/'` post-filter, not `--exclude-dir`); §148i-cli/decoy/neg routed through it. Suite pass=1325 fail=0.

## Ship gate

- [x] `code-reviewer` clean at head — ship at d8b0088 (head blind-compare matched)
- [x] full smoke green in a worktree-free window — pass=1325 fail=0 at d8b0088
- [~] CI green — N/A at ready; verified at merge gate
- [x] AC closeout posted on #642
