### PR TITLE
fix(#694): bound each 174h leg by its own measurement, not one guess

### DIFF
--- a/changelog_unreleased/fixed/694.md
+++ b/changelog_unreleased/fixed/694.md
@@ -1,0 +1,1 @@
+- Smoke §174h no longer reds on a healthy developer machine: each of its five cost legs now carries a bound derived from that leg's own measured healthy and pre-fix costs, and the 250-span leg — whose two costs are too close for any bound to separate them — is guarded by its cap assertion instead of by the clock (#694).

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -4330,7 +4330,10 @@ if [ -n "$S174G_DIR" ] && [ -d "$S174G_DIR" ]; then rm -rf "$S174G_DIR"; fi
 #   - 4 MB as 60 000 short lines, one span — the file-size axis.
 #   - the SAME 4 MB as ONE line: the per-record normalisation is quadratic in line
 #     length, so a one-line file never entered the trim loop (0.32 s at 256 KB
-#     doubling cleanly to 66.9 s at 4 MB). Reachable with nothing planted — a minified
+#     doubling cleanly to 66.9 s at 4 MB — #677's figure on its own host; this
+#     arm's own measurement of the same axis at the pre-fix blob fca2e4b is
+#     26.7 s, and that is the figure the 5 s bound below derives from).
+#     Reachable with nothing planted — a minified
 #     bundle, a one-line JSON dump, an inlined SVG.
 #   - 30 spans against the same file — the multiplier a one-span arm cannot see.
 #   - a 1.6 MB BODY on one line: the extractor's own scan is quadratic in one BODY
@@ -4343,14 +4346,16 @@ if [ -n "$S174G_DIR" ] && [ -d "$S174G_DIR" ]; then rm -rf "$S174G_DIR"; fi
 # d376190 on arm64 macOS, the pre-fix half against the pre-bounding reader blob
 # (fca2e4b) or with that leg's own cap lifted. many-line 0.56 s / >120 s -> 15;
 # one-line 0.29 s / 26.7 s -> 5; 30-span 5.63 s / >400 s -> 60; body-line
-# 0.20 s / 28.3 s -> 5. A single
-# uniform bound cannot be stated: the figures differ by three orders of magnitude
-# across the legs, so one number is either loose enough to miss a regression or
-# tight enough to red a healthy host.
+# 0.20 s / 28.3 s -> 5. A single uniform bound cannot be stated: the healthy-to-
+# pre-fix figures differ by three orders of magnitude across the legs, so one
+# number is either loose enough to miss a regression or tight enough to red a
+# healthy host.
 # The 250-span leg carries NO clock bound. Its measured pair is 19.9 s / 24.9 s -
-# a 1.25x window, inside $SECONDS' own +/-1 s quantisation - so no bound separates
-# healthy from pre-fix there, and the 20 s bound it used to carry redded healthy
-# hosts (#694). Its guard is `s174h_clsC -eq 200`, which asserts the cap actually
+# a 1.25x window. A bound CAN be placed inside a gap that narrow on one host, but
+# it cannot be placed safely: no value clears the 4x floor both sides, and any
+# value inside a 1.25x window pins machine speed to within 25%. The 20 s bound it
+# used to carry is the proof - this host measures 19.9 s and redded on a healthy
+# tree (#694). Its guard is `s174h_clsC -eq 200`, which asserts the cap actually
 # truncated 250 spans to 200: that is the mechanism bounding the cost, and it is
 # machine-independent. What retiring the clock gives up is the class where per-span
 # work becomes uniformly slower while the cap still truncates - the cap bounds the

--- a/scripts/test/smoke.d/70-gates-contentlocks.sh
+++ b/scripts/test/smoke.d/70-gates-contentlocks.sh
@@ -4338,8 +4338,23 @@ if [ -n "$S174G_DIR" ] && [ -d "$S174G_DIR" ]; then rm -rf "$S174G_DIR"; fi
 #     the cited artifact's lines were capped (measured: 118 s in extraction alone).
 #   - 250 spans against the span-count cap: rungs 1 and 3 fork a git process per span,
 #     so a GitHub-legal 64 KB body of minimal spans ran for two minutes.
-# The bounds are deliberately loose (20 s) — they separate linear from quadratic by
-# more than an order of magnitude without pinning machine speed.
+# Each leg's bound is set from ITS OWN measured pair (#694): at least 4x above that
+# leg's healthy cost and at least 4x below its pre-fix cost, both measured at
+# d376190 on arm64 macOS, the pre-fix half against the pre-bounding reader blob
+# (fca2e4b) or with that leg's own cap lifted. many-line 0.56 s / >120 s -> 15;
+# one-line 0.29 s / 26.7 s -> 5; 30-span 5.63 s / >400 s -> 60; body-line
+# 0.20 s / 28.3 s -> 5. A single
+# uniform bound cannot be stated: the figures differ by three orders of magnitude
+# across the legs, so one number is either loose enough to miss a regression or
+# tight enough to red a healthy host.
+# The 250-span leg carries NO clock bound. Its measured pair is 19.9 s / 24.9 s -
+# a 1.25x window, inside $SECONDS' own +/-1 s quantisation - so no bound separates
+# healthy from pre-fix there, and the 20 s bound it used to carry redded healthy
+# hosts (#694). Its guard is `s174h_clsC -eq 200`, which asserts the cap actually
+# truncated 250 spans to 200: that is the mechanism bounding the cost, and it is
+# machine-independent. What retiring the clock gives up is the class where per-span
+# work becomes uniformly slower while the cap still truncates - the cap bounds the
+# NUMBER of forks, not the cost of each. Stated rather than covered (SPEC 1.11 L3).
 # §174j shares this repo, so it is nested here — but its ng path is duplicated into
 # BOTH guard arms below. Nested inside the success branch alone it emitted neither ok
 # nor ng when the precondition failed, so the suite would report fail=0 with one fewer
@@ -4390,14 +4405,14 @@ else
   s174h_t0=$SECONDS
   s174h_clsC=$(s174_count 'unresolved' "$(bash "$S174_CHECKER" "$S174H_WORK/probeC.md" 2>/dev/null)")
   s174h_elC=$(( SECONDS - s174h_t0 ))
-  if [ "$s174h_el" -lt 20 ] && [ "$s174h_cls" -eq 1 ] \
-     && [ "$s174h_el1" -lt 20 ] && [ "$s174h_cls1" -eq 1 ] \
-     && [ "$s174h_elN" -lt 20 ] && [ "$s174h_clsN" -eq 30 ] \
-     && [ "$s174h_elB" -lt 20 ] \
-     && [ "$s174h_elC" -lt 20 ] && [ "$s174h_clsC" -eq 200 ]; then
-    ok "174h: 4 MB as 60 000 lines (${s174h_el}s), the same 4 MB as ONE line (${s174h_el1}s), 30 spans against it (${s174h_elN}s), a 1.6 MB single-line BODY (${s174h_elB}s) and 250 spans capped to 200 (${s174h_elC}s) all finish inside the bound — every factor of the product is capped (PR #677)"
+  if [ "$s174h_el" -lt 15 ] && [ "$s174h_cls" -eq 1 ] \
+     && [ "$s174h_el1" -lt 5 ] && [ "$s174h_cls1" -eq 1 ] \
+     && [ "$s174h_elN" -lt 60 ] && [ "$s174h_clsN" -eq 30 ] \
+     && [ "$s174h_elB" -lt 5 ] \
+     && [ "$s174h_clsC" -eq 200 ]; then
+    ok "174h: 4 MB as 60 000 lines (${s174h_el}s < 15), the same 4 MB as ONE line (${s174h_el1}s < 5), 30 spans against it (${s174h_elN}s < 60) and a 1.6 MB single-line BODY (${s174h_elB}s < 5) each finish inside ITS OWN measured bound; 250 spans are bounded by the cap, not the clock — classified ${s174h_clsC} of 250 (PR #677, #694)"
   else
-    ng "174h: every factor of the cost must be bounded under 20s — 4 MB many-line (1 unresolved), 4 MB one-line (1 unresolved), 30 spans (30 unresolved), a 1.6 MB one-line body, and 250 spans classified down to the 200 cap — got many=${s174h_el}s/$s174h_cls oneline=${s174h_el1}s/$s174h_cls1 multi=${s174h_elN}s/$s174h_clsN bodyline=${s174h_elB}s spancount=${s174h_elC}s/$s174h_clsC (PR #677)"
+    ng "174h: every factor of the cost must be bounded — many-line <15s (1 unresolved), one-line <5s (1 unresolved), 30 spans <60s (30 unresolved), a 1.6 MB one-line body <5s, and 250 spans truncated by the cap to 200 (no clock bound on that leg, #694) — got many=${s174h_el}s/$s174h_cls oneline=${s174h_el1}s/$s174h_cls1 multi=${s174h_elN}s/$s174h_clsN bodyline=${s174h_elB}s spancount=${s174h_clsC} classified in ${s174h_elC}s (PR #677, #694)"
   fi
 
   # §174j (EVERY BOUND THE READER REACHES, IT STATES, #677) — the anti-silence arm,


### PR DESCRIPTION
Closes #694

## Goal

Smoke `§174h` redded the full local suite on a healthy tree. The cause was not a slow machine: the arm applied **one 20s bound to five legs whose healthy costs span two orders of magnitude**, so a single number could not be both loose enough to pass a healthy host and tight enough to catch the regression each leg exists for. It was too loose for four legs and too tight for one.

## How this serves the mission

`MISSION.md` "The mechanism": an arm that fires on a healthy state is noise the shell then argues around instead of evidence it can lean on. It also broke clean-window claims structurally — a PR wanting to assert "full suite green" had to explain a red first.

## What changed

**Each leg's bound now comes from that leg's own measured pair** — at least 4× above its healthy cost and at least 4× below its pre-fix cost. The pre-fix half is **measured**, against the pre-bounding reader blob or with that leg's own cap lifted; it is not quoted from the arm's prose. The measured pairs and the resulting windows are recorded on the issue.

**The 250-span leg gets no clock bound at all.** Its healthy and pre-fix costs sit 1.25× apart — inside the ±1s quantisation of the `$SECONDS` sampling the arm uses — so the two-sided window is arithmetically empty. No bound separates healthy from broken there, which is why 20s redded healthy hosts. Its real guard was never the clock but `s174h_clsC -eq 200`, the assertion that the cap truncated 250 spans to 200; that is machine-independent and is verified still failing when the cap is lifted.

**What the retirement gives up is stated, not hidden**: the class where per-span work becomes uniformly slower while the cap still truncates — the cap bounds the *number* of forks, not the cost of each. Written at the arm per §1.11 L3 rather than papered over.

**The arm's own false claim is deleted, not reworded.** It asserted its bounds "separate linear from quadratic by more than an order of magnitude"; at the 250-span leg the separation is 1.25×. Deletion is the default repair (§1.11 L5).

## Target base

`main`

## Key context

- `scripts/test/smoke.d/70-gates-contentlocks.sh` — the `§174h` block
- `scripts/lint_citations.sh` — its caps are documented "Overridable for measurement", which is how the pre-fix half was measured without editing the file (out of scope by file)

## Checklist

- [x] **Fix**: per-leg bounds from measured pairs; the 250-span clock guard retired in favour of its cap assertion; the false separation claim deleted; ok/ng messages restated to what the assertions actually check
- [x] **Fix**: `changelog_unreleased/fixed/694.md`
- [~] **Doc**: N/A — the arm's own comment block is the contract home for its bounds and is updated in place; no SPEC or `docs/*.md` surface states them (`grep` for the arm's bound returns only this file).
- [~] **Test**: N/A — the arm *is* the test. AC2's obligation is a mutation survey rather than a new test, and it is recorded on the issue.

## Test plan

- [x] Full suite `pass=1407 fail=0` locally — the first clean local run since this arm regressed.
- [x] **Per-leg mutation survey, all five red**, each mutation on the leg's guard or measured code path and never on its fixture. Recorded on #694 with the applied mutation and the observed result per leg. The 250-span row is the one that matters: retiring its clock left its cap assertion still failing when the cap is lifted.

## Notes for the reviewer

- The `66.9 s` figure near the top of the arm's comment is **left in place deliberately**. It is #677's record of the doubling curve that motivated the one-line leg, not a figure any bound here rests on. My own measurement of that leg's pre-fix cost is 26.7s and is what its bound is derived from.
- A first draft of this change took that leg's pre-fix cost from the prose instead of measuring it, and the bound that produced (15s) sits outside the window the measured figure gives. It is 5s. Recorded because the acceptance criterion requiring measurement is what caught it.
## Review round 1 — `ship after fix`, applied

Every measured figure in this change was reproduced independently by the reviewer on its own host and matched. Four fixes, three of which were typed claims that were wrong.

1. **The retirement's stated reason was false.** The comment attributed the empty window to `$SECONDS`' ±1 s quantisation; the gap is four to five seconds — four to five times the quantisation — and a ratio is not comparable to a second. The absolute that followed ("no bound separates healthy from pre-fix") is false too: a bound of 22 separates them on this host. Replaced with the argument that holds — a bound can be placed inside a 1.25× window but not *safely*, since no value clears the 4× floor on both sides and any value inside it pins machine speed to within 25%. **The retirement itself was upheld**: lifting the cap makes the classified count read 250 instead of 200, so the remaining guard is live.
2. **Two pre-fix figures for the same fixture collided.** `66.9 s` and `26.7 s` sat twelve lines apart on the same axis with nothing reconciling them. `66.9 s` is now marked as #677's figure on its own host, with this change's own measurement named as what the 5 s bound derives from. Left in place rather than deleted, since it is that PR's record and no bound rests on it.
3. **"Three orders of magnitude" was wrong** for the healthy costs (0.20–19.91 s ≈ two orders). True only of the healthy-to-pre-fix figures, and the comment now says which.
4. **AC1 and AC6 were undischarged** — the green `ok` line and the §6.0 negative-face statement are now recorded on #694.

The reviewer also confirmed the four surviving bounds are safe on CI by a stronger argument than headroom: CI is green today at the old `-lt 20` while this host measures 20 s on that leg, so CI is not slower than this host on the fork-heavy path.

**Worth stating plainly, because it is this PR's own subject.** The defect being repaired here is a false claim in a test's comment. The first repair deleted it and wrote a different false claim in its place. That is the same defect one turn later, and it is why the fix list above is mostly about figures rather than about code.
